### PR TITLE
Editorial: minor fixes for HTTP spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MISSPELL = $(TOOLS_DIR)/$(MISSPELL_BINARY)
 
 # see https://github.com/open-telemetry/build-tools/releases for semconvgen updates
 # Keep links in semantic_conventions/README.md and .vscode/settings.json in sync!
-SEMCONVGEN_VERSION=0.17.0
+SEMCONVGEN_VERSION=0.18.0
 
 # TODO: add `yamllint` step to `all` after making sure it works on Mac.
 .PHONY: all

--- a/internal/tools/schema_check.sh
+++ b/internal/tools/schema_check.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-BUILD_TOOL_SCHEMAS_VERSION=0.17.0
+BUILD_TOOL_SCHEMAS_VERSION=0.18.0
 
 # List of versions that do not require or have a schema.
 declare -a skip_versions=("1.0.0" "1.0.1" "1.1.0" "1.2.0" "1.3.0" "1.6.0")

--- a/semantic_conventions/README.md
+++ b/semantic_conventions/README.md
@@ -19,12 +19,12 @@ Semantic conventions for the spec MUST adhere to the
 [attribute requirement level](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/attribute-requirement-level.md),
 and [metric requirement level](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/metric-requirement-level.md) conventions.
 
-Refer to the [syntax](https://github.com/open-telemetry/build-tools/tree/v0.17.0/semantic-conventions/syntax.md)
+Refer to the [syntax](https://github.com/open-telemetry/build-tools/tree/v0.18.0/semantic-conventions/syntax.md)
 for how to write the YAML files for semantic conventions and what the YAML properties mean.
 
 A schema file for VS code is configured in the `/.vscode/settings.json` of this
 repository, enabling auto-completion and additional checks. Refer to
-[the generator README](https://github.com/open-telemetry/build-tools/tree/v0.17.0/semantic-conventions/README.md) for what extension you need.
+[the generator README](https://github.com/open-telemetry/build-tools/tree/v0.18.0/semantic-conventions/README.md) for what extension you need.
 
 ## Generating markdown
 
@@ -35,7 +35,7 @@ formatted Markdown tables for all semantic conventions in the specification. Run
 make table-generation
 ```
 
-For more information, see the [semantic convention generator](https://github.com/open-telemetry/build-tools/tree/v0.17.0/semantic-conventions)
+For more information, see the [semantic convention generator](https://github.com/open-telemetry/build-tools/tree/v0.18.0/semantic-conventions)
 in the OpenTelemetry build tools repository.
 Using this build tool, it is also possible to generate code for use in OpenTelemetry
 language projects.

--- a/semantic_conventions/http-common.yaml
+++ b/semantic_conventions/http-common.yaml
@@ -25,7 +25,7 @@ groups:
   - id: attributes.http.client
     prefix: http
     type: attribute_group
-    brief: 'HTTP Client spans attributes'
+    brief: 'HTTP client attributes'
     attributes:
       - ref: server.address
         requirement_level: required
@@ -51,7 +51,7 @@ groups:
   - id: attributes.http.server
     prefix: http
     type: attribute_group
-    brief: 'HTTP Server spans attributes'
+    brief: 'HTTP server attributes'
     attributes:
       - id: route
         type: string

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -56,11 +56,11 @@ and various HTTP versions like 1.1, 2 and SPDY.
 HTTP spans MUST follow the overall [guidelines for span names](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span).
 HTTP server span names SHOULD be `{http.request.method} {http.route}` if there is a
 (low-cardinality) `http.route` available.
-HTTP server span names SHOULD be `{http.method}` if there is no (low-cardinality)
+HTTP server span names SHOULD be `{http.request.method}` if there is no (low-cardinality)
 `http.route` available.
 HTTP client spans have no `http.route` attribute since client-side instrumentation
 is not generally aware of the "route", and therefore HTTP client spans SHOULD use
-`{http.method}`.
+`{http.request.method}`.
 Instrumentation MUST NOT default to using URI
 path as span name, but MAY provide hooks to allow custom logic to override the
 default span name.

--- a/specification/trace/semantic_conventions/instrumentation/aws-lambda.md
+++ b/specification/trace/semantic_conventions/instrumentation/aws-lambda.md
@@ -168,7 +168,7 @@ Function F:    | Span Function |
 | `cloud.account.id` | | `12345678912` |
 | `server.address` | `foo.execute-api.us-east-1.amazonaws.com` |  |
 | `server.port` | `413` |  |
-| `http.method` | `GET` | `GET` |
+| `http.request.method` | `GET` | `GET` |
 | `user_agent.original` | `okhttp 3.0` | `okhttp 3.0` |
 | `url.scheme` | | `https` |
 | `url.path` | | `/pets/10` |


### PR DESCRIPTION
Updating a few overlooked usages of `http.method` to `http.request.method` and a few other small fixes