### PR TITLE
Add semantic conventions for Elasticsearch client instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ Note: This is the first release of Semantic Conventions separate from the Specif
   ([#106](https://github.com/open-telemetry/semantic-conventions/pull/106))
 - Mark initial set of HTTP semantic conventions as frozen
   ([#105](https://github.com/open-telemetry/semantic-conventions/pull/105))
+- Add Elasticsearch client semantic conventions.
+  ([#23](https://github.com/open-telemetry/semantic-conventions/pull/23))
 
 ## v1.20.0 (2023-04-07)
 

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -414,6 +414,10 @@ groups:
         brief: The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string.
         note: The value may be sanitized to exclude sensitive information.
         examples: [ '"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"' ]
+      - ref: db.operation
+        requirement_level: required
+        brief: The endpoint identifier for the request.
+        examples: [ 'search', 'ml.close_job', 'cat.aliases' ]
       - ref: server.address
       - ref: server.port
       - ref: http.request.method

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -400,9 +400,10 @@ groups:
         examples: [ 'https://localhost:9200/index/_search?q=user.id:kimchy' ]
       - ref: db.statement
         requirement_level:
-          recommended: Should be collected when a search-type query is executed
+          recommended: >
+            Should be collected by default for search-type queries and only if there is sanitization that excludes
+            sensitive information.
         brief: The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string.
-        note: The value may be sanitized to exclude sensitive information.
         examples: [ '"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"' ]
       - ref: server.address
       - ref: server.port

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -398,22 +398,6 @@ groups:
       - ref: url.full
         requirement_level: required
         examples: [ 'https://localhost:9200/index/_search?q=user.id:kimchy' ]
-      - id: doc_id
-        type: string
-        requirement_level:
-          conditionally_required: when the request targets a specific document by id
-        tag: call-level-tech-specific-elasticsearch
-        brief: >
-          The document that the request targets.
-        examples: [ '123', '456' ]
-      - id: target
-        type: string
-        requirement_level:
-          conditionally_required: when a specific index or data stream is targeted by the request
-        tag: call-level-tech-specific
-        brief: >
-          The name of the data stream or index that is targeted.
-        examples: [ 'users' ]
       - ref: db.statement
         requirement_level:
           recommended: Should be collected when a search-type query is executed

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -405,23 +405,19 @@ groups:
         brief: >
           The name of the data stream or index that is targeted.
         examples: [ 'users' ]
-      - ref: url.query
-        requirement_level:
-          conditionally_required: when query params are provided as part of the request
-        brief: >
-          The query params of the request, as a json string.
-        examples: [ '"{\"q\":\"test\"}", "{\"refresh\":true}"' ]
-      - ref: url.path
+      - ref: url.full
         requirement_level: required
-        brief: >
-          The path of the request, including the target and exact document id.
-        examples: [ '/test-index/_search', '/test-index/_doc/123' ]
+        examples: [ 'https://localhost:9200/index/_search?q=user.id:kimchy' ]
       - ref: db.statement
         requirement_level:
-          conditionally_required: when there is a request body
-        brief: The request body, as a json string.
+          conditionally_required: when a search-type query is executed
+        brief: The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string.
         note: The value may be sanitized to exclude sensitive information.
         examples: [ '"{\"name\":\"TestUser\",\"password\":\"top_secret\"}"' ]
+      - ref: server.address
+        requirement_level: recommended
+      - ref: server.port
+        requirement_level: recommended
       - ref: http.request.method
         requirement_level: required
 

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -410,14 +410,12 @@ groups:
         examples: [ 'https://localhost:9200/index/_search?q=user.id:kimchy' ]
       - ref: db.statement
         requirement_level:
-          conditionally_required: when a search-type query is executed
+          recommended: Should be collected when a search-type query is executed
         brief: The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string.
         note: The value may be sanitized to exclude sensitive information.
         examples: [ '"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"' ]
       - ref: server.address
-        requirement_level: recommended
       - ref: server.port
-        requirement_level: recommended
       - ref: http.request.method
         requirement_level: required
 

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -389,6 +389,15 @@ groups:
     brief: >
       Call-level attributes for Elasticsearch
     attributes:
+      - ref: http.request.method
+        requirement_level: required
+      - ref: db.operation
+        requirement_level: required
+        brief: The endpoint identifier for the request.
+        examples: [ 'search', 'ml.close_job', 'cat.aliases' ]
+      - ref: url.full
+        requirement_level: required
+        examples: [ 'https://localhost:9200/index/_search?q=user.id:kimchy' ]
       - id: doc_id
         type: string
         requirement_level:
@@ -405,23 +414,14 @@ groups:
         brief: >
           The name of the data stream or index that is targeted.
         examples: [ 'users' ]
-      - ref: url.full
-        requirement_level: required
-        examples: [ 'https://localhost:9200/index/_search?q=user.id:kimchy' ]
       - ref: db.statement
         requirement_level:
           recommended: Should be collected when a search-type query is executed
         brief: The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string.
         note: The value may be sanitized to exclude sensitive information.
         examples: [ '"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"' ]
-      - ref: db.operation
-        requirement_level: required
-        brief: The endpoint identifier for the request.
-        examples: [ 'search', 'ml.close_job', 'cat.aliases' ]
       - ref: server.address
       - ref: server.port
-      - ref: http.request.method
-        requirement_level: required
 
   - id: db.sql
     prefix: 'db.sql'

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -404,7 +404,7 @@ groups:
             Should be collected by default for search-type queries and only if there is sanitization that excludes
             sensitive information.
         brief: The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string.
-        examples: [ '"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"' ]
+        examples: [ '"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"' ]
       - ref: server.address
       - ref: server.port
 

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -413,7 +413,7 @@ groups:
           conditionally_required: when a search-type query is executed
         brief: The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string.
         note: The value may be sanitized to exclude sensitive information.
-        examples: [ '"{\"name\":\"TestUser\",\"password\":\"top_secret\"}"' ]
+        examples: [ '"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"' ]
       - ref: server.address
         requirement_level: recommended
       - ref: server.port

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -422,7 +422,7 @@ groups:
         brief: The request body, as a json string.
         note: The value may be sanitized to exclude sensitive information.
         examples: [ '"{\"name\":\"TestUser\",\"password\":\"top_secret\"}"' ]
-      - ref: http.method
+      - ref: http.request.method
         requirement_level: required
 
   - id: db.sql

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -382,6 +382,49 @@ groups:
           The collection being accessed within the database stated in `db.name`.
         examples: [ 'customers', 'products' ]
 
+  - id: db.elasticsearch
+    prefix: db.elasticsearch
+    type: span
+    extends: db
+    brief: >
+      Call-level attributes for Elasticsearch
+    attributes:
+      - id: doc_id
+        type: string
+        requirement_level:
+          conditionally_required: when the request targets a specific document by id
+        tag: call-level-tech-specific-elasticsearch
+        brief: >
+          The document that the request targets.
+        examples: [ '123', '456' ]
+      - id: target
+        type: string
+        requirement_level:
+          conditionally_required: when a specific index or data stream is targeted by the request
+        tag: call-level-tech-specific
+        brief: >
+          The name of the data stream or index that is targeted.
+        examples: [ 'users' ]
+      - ref: url.query
+        requirement_level:
+          conditionally_required: when query params are provided as part of the request
+        brief: >
+          The query params of the request, as a json string.
+        examples: [ '"{\"q\":\"test\"}", "{\"refresh\":true}"' ]
+      - ref: url.path
+        requirement_level: required
+        brief: >
+          The path of the request, including the target and exact document id.
+        examples: [ '/test-index/_search', '/test-index/_doc/123' ]
+      - ref: db.statement
+        requirement_level:
+          conditionally_required: when there is a request body
+        brief: The request body, as a json string.
+        note: The value may be sanitized to exclude sensitive information.
+        examples: [ '"{\"name\":\"TestUser\",\"password\":\"top_secret\"}"' ]
+      - ref: http.method
+        requirement_level: required
+
   - id: db.sql
     prefix: 'db.sql'
     type: span

--- a/specification/trace/semantic_conventions/README.md
+++ b/specification/trace/semantic_conventions/README.md
@@ -29,6 +29,7 @@ The following library-specific semantic conventions are defined:
 
 * [AWS Lambda](instrumentation/aws-lambda.md): For AWS Lambda spans.
 * [AWS SDK](instrumentation/aws-sdk.md): For AWS SDK spans.
+* [Elasticsearch](instrumentation/elasticsearch.md): For Elasticsearch spans.
 * [GraphQL](instrumentation/graphql.md): For GraphQL spans.
 
 Apart from semantic conventions for traces and [metrics](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.21.0/specification/metrics/semantic_conventions/README.md),

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -18,6 +18,7 @@
   * [Redis](#redis)
   * [MongoDB](#mongodb)
   * [Microsoft Azure Cosmos DB](#microsoft-azure-cosmos-db)
+  * [Elasticsearch](#elasticsearch)
 
 <!-- tocstop -->
 

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -18,7 +18,6 @@
   * [Redis](#redis)
   * [MongoDB](#mongodb)
   * [Microsoft Azure Cosmos DB](#microsoft-azure-cosmos-db)
-  * [Elasticsearch](#elasticsearch)
 
 <!-- tocstop -->
 
@@ -364,19 +363,5 @@ Furthermore, `db.name` is not specified as there is no database name in Redis an
 | `db.cosmosdb.status_code`            | `201` |
 | `db.cosmosdb.sub_status_code`        | `0` |
 | `db.cosmosdb.request_charge`         | `7.43` |
-
-### Elasticsearch
-
-| Key                                 | Value                                                                                                                               |
-|:------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------|
-| Span name                           | `"search"`                                                                                                                          |
-| `db.system`                         | `"elasticsearch"`                                                                                                                   |
-| `server.address`                    | `"elasticsearch.mydomain.com"`                                                                                                      |
-| `server.port`                       | `9200`                                                                                                                              |
-| `http.request.method`               | `"GET"`                                                                                                                             |
-| `db.statement`                      | `"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"`                                                                                  |
-| `db.operation`                      | `"search"`                                                                                                                          |
-| `url.full`                          | `"https://elasticsearch.mydomain.com:9200/my-index-000001/_search?from=40&size=20"`                                                 |
-| `db.elasticsearch.path_parts.index` | `"my-index-000001"`                                                                                                                 |
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/document-status.md

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -364,4 +364,18 @@ Furthermore, `db.name` is not specified as there is no database name in Redis an
 | `db.cosmosdb.sub_status_code`        | `0` |
 | `db.cosmosdb.request_charge`         | `7.43` |
 
+### Elasticsearch
+
+| Key                                 | Value                                                                                                                               |
+|:------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------|
+| Span name                           | `"search"`                                                                                                                          |
+| `db.system`                         | `"elasticsearch"`                                                                                                                   |
+| `server.address`                    | `"elasticsearch.mydomain.com"`                                                                                                      |
+| `server.port`                       | `9200`                                                                                                                              |
+| `http.request.method`               | `"GET"`                                                                                                                             |
+| `db.statement`                      | `"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"`                                                                                  |
+| `db.operation`                      | `"search"`                                                                                                                          |
+| `url.full`                          | `"https://elasticsearch.mydomain.com:9200/my-index-000001/_search?from=40&size=20"`                                                 |
+| `db.elasticsearch.path_parts.index` | `"my-index-000001"`                                                                                                                 |
+
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/document-status.md

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -23,11 +23,11 @@ When there is no target or document id, the span name contains the exact path, a
 |---|---|---|---|---|
 | `db.elasticsearch.doc_id` | string | The document that the request targets. | `123`; `456` | Conditionally Required: [1] |
 | `db.elasticsearch.target` | string | The name of the data stream or index that is targeted. | `users` | Conditionally Required: [2] |
-| [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. [3] | `"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"` | Conditionally Required: when a search-type query is executed |
+| [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. [3] | `"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"` | Recommended: [4] |
 | `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
 | [`server.address`](../span-general.md) | string | Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is not known. | `example.com` | See below |
 | [`server.port`](../span-general.md) | int | Logical server port number | `80`; `8080`; `443` | Recommended |
-| `url.full` | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [4] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |
+| `url.full` | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [5] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |
 
 **[1]:** when the request targets a specific document by id
 
@@ -35,7 +35,9 @@ When there is no target or document id, the span name contains the exact path, a
 
 **[3]:** The value may be sanitized to exclude sensitive information.
 
-**[4]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
+**[4]:** Should be collected when a search-type query is executed
+
+**[5]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
 `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password should be redacted and attribute's value should be `https://REDACTED:REDACTED@www.example.com/`.
 `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -42,7 +42,7 @@ in order to map the path part values to their names.
 
 **[2]:** The value may be sanitized to exclude sensitive information.
 
-**[3]:** Should be collected when a search-type query is executed
+**[3]:** Should be collected by default for search-type queries and only if there is sanitization that excludes sensitive information.
 
 **[4]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
 `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password should be redacted and attribute's value should be `https://REDACTED:REDACTED@www.example.com/`.

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -2,9 +2,7 @@
 
 **Status**: [Experimental](../../../document-status.md)
 
-This document defines semantic conventions to apply when instrumenting requests to Elasticsearch. They map Elasticsearch
-requests to attributes on a Span. Note that there may also be an http span created in addition to the Elasticsearch
-span.
+This document defines semantic conventions to apply when creating a span to capture requests to Elasticsearch.
 
 ## Span Name
 

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -1,6 +1,6 @@
 # Semantic conventions for Elasticsearch
 
-**Status**: [Experimental](../../../document-status.md)
+**Status**: [Experimental][DocumentStatus]
 
 This document defines semantic conventions to apply when creating a span for requests to Elasticsearch.
 
@@ -8,7 +8,7 @@ This document defines semantic conventions to apply when creating a span for req
 
 The **span name** SHOULD be of the format `<endpoint id>`.
 
-The elasticsearch endpoint identifier is used instead of the url path in order to reduce the cardinality of the span 
+The elasticsearch endpoint identifier is used instead of the url path in order to reduce the cardinality of the span
 name, as the path could contain dynamic values. The endpoint id is the `name` field in the
 [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json).
 If the endpoint id is not available, the span name SHOULD be `http.request.method`.

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -2,7 +2,7 @@
 
 **Status**: [Experimental](../../../document-status.md)
 
-This document defines semantic conventions to apply when creating a span to capture requests to Elasticsearch.
+This document defines semantic conventions to apply when creating a span for requests to Elasticsearch.
 
 ## Span Name
 

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -1,0 +1,21 @@
+# Semantic conventions for Elasticsearch
+
+**Status**: [Experimental](../../../document-status.md)
+
+This document defines semantic conventions to apply when instrumenting requests to Elasticsearch. They map Elasticsearch
+requests to attributes on a Span.
+
+## Span Name
+
+The **span name** SHOULD be of the format `<http.method> <db.elasticsearch.url *with placeholders*>`.
+
+The elasticsearch url is modified with placeholders in order to reduce the cardinality of the span name. When the url
+contains a document id, it SHOULD be replaced by the identifier `{id}`. When the url contains a target data stream or
+index, it SHOULD be replaced by `{target}`.
+For example, a request to `/test-index/_doc/123` should have the span name `GET /{target}/_doc/{id}`.
+When there is no target or document id, the span name will contain the exact url, as in `POST /_search`.
+
+### Span attributes
+
+<!-- semconv db.elasticsearch -->
+<!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -6,39 +6,45 @@ This document defines semantic conventions to apply when creating a span for req
 
 ## Span Name
 
-The **span name** SHOULD be of the format `<http.request.method> <url.path *with placeholders*>`.
+The **span name** SHOULD be of the format `<http.request.method> <endpoint id>`.
 
-The elasticsearch url path is used with placeholders in order to reduce the cardinality of the span name. When the
-path contains a document id, it SHOULD be represented as the identifier `{id}`. When the path contains a target data stream
-or index, it SHOULD be represented as `{target}`.
-For example, a request to `/test-index/_doc/123` should have the span name `GET /{target}/_doc/{id}`.
-When there is no target or document id, the span name contains the exact path, as in `POST /_search`.
+The elasticsearch endpoint identifier is used instead of the url path in order to reduce the cardinality of the span 
+name, as the path could contain dynamic values. The endpoint id is the `name` field in the
+[elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json).
+If the endpoint id is not available, the span name SHOULD be `http.request.method`.
+
+## URL path parts
+
+Many Elasticsearch url paths allow dynamic values. These SHOULD be recorded in span attributes in the format
+`db.elasticsearch.path_parts.<key>`, where `<key>` is the url path part name. The implementation SHOULD
+reference the [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json)
+in order to map the path part values to their names.
+
+| Attribute                           | Type | Description                           | Examples            | Requirement Level |
+|-------------------------------------|---|---------------------------------------|---------------------|---|
+| `db.elasticsearch.path_parts.<key>` | string | A dynamic value in the url path.      | `test-index`; `456` | Conditionally Required: [1] |
+
+**[1]:** when the url has dynamic values
 
 ## Span attributes
 
 <!-- semconv db.elasticsearch -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `db.elasticsearch.doc_id` | string | The document that the request targets. | `123`; `456` | Conditionally Required: [1] |
-| `db.elasticsearch.target` | string | The name of the data stream or index that is targeted. | `users` | Conditionally Required: [2] |
-| [`db.operation`](../database.md) | string | The endpoint identifier for the request. [3] | `search`; `ml.close_job`; `cat.aliases` | Required |
-| [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. [4] | `"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"` | Recommended: [5] |
+| [`db.operation`](../database.md) | string | The endpoint identifier for the request. [1] | `search`; `ml.close_job`; `cat.aliases` | Required |
+| [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. [2] | `"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"` | Recommended: [3] |
 | `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
 | [`server.address`](../span-general.md) | string | Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is not known. | `example.com` | See below |
 | [`server.port`](../span-general.md) | int | Logical server port number | `80`; `8080`; `443` | Recommended |
-| `url.full` | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [6] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |
+| `url.full` | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [4] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |
 
-**[1]:** when the request targets a specific document by id
+**[1]:** When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
 
-**[2]:** when a specific index or data stream is targeted by the request
+**[2]:** The value may be sanitized to exclude sensitive information.
 
-**[3]:** When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
+**[3]:** Should be collected when a search-type query is executed
 
-**[4]:** The value may be sanitized to exclude sensitive information.
-
-**[5]:** Should be collected when a search-type query is executed
-
-**[6]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
+**[4]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
 `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password should be redacted and attribute's value should be `https://REDACTED:REDACTED@www.example.com/`.
 `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -7,13 +7,13 @@ requests to attributes on a Span.
 
 ## Span Name
 
-The **span name** SHOULD be of the format `<http.method> <db.elasticsearch.url *with placeholders*>`.
+The **span name** SHOULD be of the format `<http.request.method> <url.path *with placeholders*>`.
 
-The elasticsearch url is modified with placeholders in order to reduce the cardinality of the span name. When the url
-contains a document id, it SHOULD be replaced by the identifier `{id}`. When the url contains a target data stream or
-index, it SHOULD be replaced by `{target}`.
+The elasticsearch url path is modified with placeholders in order to reduce the cardinality of the span name. When the
+path contains a document id, it SHOULD be replaced by the identifier `{id}`. When the path contains a target data stream
+or index, it SHOULD be replaced by `{target}`.
 For example, a request to `/test-index/_doc/123` should have the span name `GET /{target}/_doc/{id}`.
-When there is no target or document id, the span name will contain the exact url, as in `POST /_search`.
+When there is no target or document id, the span name will contain the exact path, as in `POST /_search`.
 
 ### Span attributes
 

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -18,4 +18,24 @@ When there is no target or document id, the span name will contain the exact url
 ### Span attributes
 
 <!-- semconv db.elasticsearch -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `db.elasticsearch.doc_id` | string | The document that the request targets. | `123`; `456` | Conditionally Required: [1] |
+| `db.elasticsearch.target` | string | The name of the data stream or index that is targeted. | `users` | Conditionally Required: [2] |
+| [`db.statement`](../database.md) | string | The request body, as a json string. [3] | `"{\"name\":\"TestUser\",\"password\":\"top_secret\"}"` | Conditionally Required: when there is a request body |
+| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| `url.path` | string | The path of the request, including the target and exact document id. [4] | `/test-index/_search`; `/test-index/_doc/123` | Required |
+| `url.query` | string | The query params of the request, as a json string. [5] | `"{\"q\":\"test\"}", "{\"refresh\":true}"` | Conditionally Required: [6] |
+
+**[1]:** when the request targets a specific document by id
+
+**[2]:** when a specific index or data stream is targeted by the request
+
+**[3]:** The value may be sanitized to exclude sensitive information.
+
+**[4]:** When missing, the value is assumed to be `/`
+
+**[5]:** Sensitive content provided in query string SHOULD be scrubbed when instrumentations can identify it.
+
+**[6]:** when query params are provided as part of the request
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -62,3 +62,17 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password should be redacted and attribute's value should be `https://REDACTED:REDACTED@www.example.com/`.
 `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
 <!-- endsemconv -->
+
+## Example
+
+| Key                                 | Value                                                                                                                               |
+|:------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------|
+| Span name                           | `"search"`                                                                                                                          |
+| `db.system`                         | `"elasticsearch"`                                                                                                                   |
+| `server.address`                    | `"elasticsearch.mydomain.com"`                                                                                                      |
+| `server.port`                       | `9200`                                                                                                                              |
+| `http.request.method`               | `"GET"`                                                                                                                             |
+| `db.statement`                      | `"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"`                                                                                  |
+| `db.operation`                      | `"search"`                                                                                                                          |
+| `url.full`                          | `"https://elasticsearch.mydomain.com:9200/my-index-000001/_search?from=40&size=20"`                                                 |
+| `db.elasticsearch.path_parts.index` | `"my-index-000001"`                                                                                                                 |

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -14,28 +14,31 @@ or index, it SHOULD be represented as `{target}`.
 For example, a request to `/test-index/_doc/123` should have the span name `GET /{target}/_doc/{id}`.
 When there is no target or document id, the span name contains the exact path, as in `POST /_search`.
 
-### Span attributes
+## Span attributes
 
 <!-- semconv db.elasticsearch -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `db.elasticsearch.doc_id` | string | The document that the request targets. | `123`; `456` | Conditionally Required: [1] |
 | `db.elasticsearch.target` | string | The name of the data stream or index that is targeted. | `users` | Conditionally Required: [2] |
-| [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. [3] | `"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"` | Recommended: [4] |
+| [`db.operation`](../database.md) | string | The endpoint identifier for the request. [3] | `search`; `ml.close_job`; `cat.aliases` | Required |
+| [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. [4] | `"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"` | Recommended: [5] |
 | `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
 | [`server.address`](../span-general.md) | string | Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is not known. | `example.com` | See below |
 | [`server.port`](../span-general.md) | int | Logical server port number | `80`; `8080`; `443` | Recommended |
-| `url.full` | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [5] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |
+| `url.full` | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [6] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |
 
 **[1]:** when the request targets a specific document by id
 
 **[2]:** when a specific index or data stream is targeted by the request
 
-**[3]:** The value may be sanitized to exclude sensitive information.
+**[3]:** When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
 
-**[4]:** Should be collected when a search-type query is executed
+**[4]:** The value may be sanitized to exclude sensitive information.
 
-**[5]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
+**[5]:** Should be collected when a search-type query is executed
+
+**[6]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
 `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password should be redacted and attribute's value should be `https://REDACTED:REDACTED@www.example.com/`.
 `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -33,18 +33,34 @@ in order to map the path part values to their names.
 |---|---|---|---|---|
 | [`db.operation`](../database.md) | string | The endpoint identifier for the request. [1] | `search`; `ml.close_job`; `cat.aliases` | Required |
 | [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. [2] | `"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"` | Recommended: [3] |
-| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| `http.request.method` | string | HTTP request method. [4] | `GET`; `POST`; `HEAD` | Required |
 | [`server.address`](../span-general.md) | string | Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is not known. | `example.com` | See below |
 | [`server.port`](../span-general.md) | int | Logical server port number | `80`; `8080`; `443` | Recommended |
-| `url.full` | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [4] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |
+| `url.full` | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [5] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |
 
 **[1]:** When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
 
-**[2]:** The value may be sanitized to exclude sensitive information.
+**[2]:** Should be collected by default only if there is sanitization that excludes sensitive information.
 
-**[3]:** Should be collected by default for search-type queries and only if there is sanitization that excludes sensitive information.
+**[3]:** Should be collected when a search-type query is executed
 
-**[4]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
+**[4]:** HTTP request method value SHOULD be "known" to the instrumentation.
+By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+
+If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER` and, except if reporting a metric, MUST
+set the exact method received in the request line as value of the `http.request.method_original` attribute.
+
+If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+
+HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+
+**[5]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
 `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password should be redacted and attribute's value should be `https://REDACTED:REDACTED@www.example.com/`.
 `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -11,7 +11,7 @@ The **span name** SHOULD be of the format `<endpoint id>`.
 The elasticsearch endpoint identifier is used instead of the url path in order to reduce the cardinality of the span
 name, as the path could contain dynamic values. The endpoint id is the `name` field in the
 [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json).
-If the endpoint id is not available, the span name SHOULD be `http.request.method`.
+If the endpoint id is not available, the span name SHOULD be the `http.request.method`.
 
 ## URL path parts
 
@@ -32,19 +32,17 @@ in order to map the path part values to their names.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.operation`](../database.md) | string | The endpoint identifier for the request. [1] | `search`; `ml.close_job`; `cat.aliases` | Required |
-| [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. [2] | `"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"` | Recommended: [3] |
-| `http.request.method` | string | HTTP request method. [4] | `GET`; `POST`; `HEAD` | Required |
+| [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. | `"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"` | Recommended: [2] |
+| `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | [`server.address`](../span-general.md) | string | Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is not known. | `example.com` | See below |
 | [`server.port`](../span-general.md) | int | Logical server port number | `80`; `8080`; `443` | Recommended |
-| `url.full` | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [5] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |
+| `url.full` | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [4] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |
 
 **[1]:** When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
 
-**[2]:** Should be collected by default only if there is sanitization that excludes sensitive information.
+**[2]:** Should be collected by default for search-type queries and only if there is sanitization that excludes sensitive information.
 
-**[3]:** Should be collected when a search-type query is executed
-
-**[4]:** HTTP request method value SHOULD be "known" to the instrumentation.
+**[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
@@ -60,7 +58,7 @@ HTTP method names are case-sensitive and `http.request.method` attribute value M
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
 Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
 
-**[5]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
+**[4]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
 `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password should be redacted and attribute's value should be `https://REDACTED:REDACTED@www.example.com/`.
 `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -6,7 +6,7 @@ This document defines semantic conventions to apply when creating a span for req
 
 ## Span Name
 
-The **span name** SHOULD be of the format `<http.request.method> <endpoint id>`.
+The **span name** SHOULD be of the format `<endpoint id>`.
 
 The elasticsearch endpoint identifier is used instead of the url path in order to reduce the cardinality of the span 
 name, as the path could contain dynamic values. The endpoint id is the `name` field in the

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -20,9 +20,9 @@ Many Elasticsearch url paths allow dynamic values. These SHOULD be recorded in s
 reference the [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json)
 in order to map the path part values to their names.
 
-| Attribute                           | Type | Description                           | Examples            | Requirement Level |
-|-------------------------------------|---|---------------------------------------|---------------------|---|
-| `db.elasticsearch.path_parts.<key>` | string | A dynamic value in the url path.      | `test-index`; `456` | Conditionally Required: [1] |
+| Attribute                           | Type | Description                           | Examples                                                                                 | Requirement Level |
+|-------------------------------------|---|---------------------------------------|------------------------------------------------------------------------------------------|---|
+| `db.elasticsearch.path_parts.<key>` | string | A dynamic value in the url path.      | `db.elasticsearch.path_parts.index=test-index`; `db.elasticsearch.path_parts.doc_id=123` | Conditionally Required: [1] |
 
 **[1]:** when the url has dynamic values
 

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -32,7 +32,7 @@ in order to map the path part values to their names.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.operation`](../database.md) | string | The endpoint identifier for the request. [1] | `search`; `ml.close_job`; `cat.aliases` | Required |
-| [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. | `"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"` | Recommended: [2] |
+| [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. | `"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"` | Recommended: [2] |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | [`server.address`](../span-general.md) | string | Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is not known. | `example.com` | See below |
 | [`server.port`](../span-general.md) | int | Logical server port number | `80`; `8080`; `443` | Recommended |

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -23,7 +23,7 @@ When there is no target or document id, the span name contains the exact path, a
 |---|---|---|---|---|
 | `db.elasticsearch.doc_id` | string | The document that the request targets. | `123`; `456` | Conditionally Required: [1] |
 | `db.elasticsearch.target` | string | The name of the data stream or index that is targeted. | `users` | Conditionally Required: [2] |
-| [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. [3] | `"{\"name\":\"TestUser\",\"password\":\"top_secret\"}"` | Conditionally Required: when a search-type query is executed |
+| [`db.statement`](../database.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. [3] | `"{\"name\":\"TestUser\",\"password\":\"REDACTED\"}"` | Conditionally Required: when a search-type query is executed |
 | `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
 | [`server.address`](../span-general.md) | string | Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is not known. | `example.com` | See below |
 | [`server.port`](../span-general.md) | int | Logical server port number | `80`; `8080`; `443` | Recommended |

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -72,7 +72,7 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 | `server.address`                    | `"elasticsearch.mydomain.com"`                                                                                                      |
 | `server.port`                       | `9200`                                                                                                                              |
 | `http.request.method`               | `"GET"`                                                                                                                             |
-| `db.statement`                      | `"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"`                                                                                  |
+| `db.statement`                      | `"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"`                                                                                 |
 | `db.operation`                      | `"search"`                                                                                                                          |
 | `url.full`                          | `"https://elasticsearch.mydomain.com:9200/my-index-000001/_search?from=40&size=20"`                                                 |
 | `db.elasticsearch.path_parts.index` | `"my-index-000001"`                                                                                                                 |


### PR DESCRIPTION
This PR originated as a [PR in the opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification/pull/3358) repo.
The outstanding discussion point from that PR was regarding the path forward for the existing Elasticsearch client instrumentations:

- .NET: No concerns about updating their instrumentation to adopt these semantic conventions
- Python: No concerns about updating their instrumentation to adopt these semantic conventions
- Java: request to understand the complexity of updating the instrumentation by opening a PR with the changes

We are in the process of figuring out the path forward for the Java instrumentation and I'll update here when we have a plan.


Two instrumentations in progress that will use these semantic conventions:
- PHP
- [Ruby](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/357)
