### PR TITLE
Limit HTTP request method cardinality: canonical method (Option B/D)

### DIFF
--- a/semantic_conventions/deprecated/http.yaml
+++ b/semantic_conventions/deprecated/http.yaml
@@ -6,7 +6,7 @@ groups:
     attributes:
       - id: method
         type: string
-        brief: 'Deprecated, use `http.request.method` instead.'
+        brief: 'Deprecated, use `http.request.canonical_method` and `http.request.method` instead.'
         stability: deprecated
         examples: ["GET", "POST", "HEAD"]
       - id: status_code

--- a/semantic_conventions/http-common.yaml
+++ b/semantic_conventions/http-common.yaml
@@ -38,14 +38,14 @@ groups:
             - id: other
               value: "other"
               brief: 'Any custom HTTP method that the instrumentation has no prior knowledge of.'
-        brief: 'HTTP request method.'
+        brief: 'Canonical HTTP request method.'
         examples: ["GET", "POST", "HEAD"]
         note: |
           HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
           or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
           Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
           [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
-          If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.method` attribute to `other` and SHOULD
+          If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
           populate the exact method passed by client on `http.request.original_method` attribute.
 
           HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
@@ -65,7 +65,7 @@ groups:
   - id: attributes.http.client
     prefix: http
     type: attribute_group
-    brief: 'HTTP Client attributes'
+    brief: 'HTTP client attributes'
     attributes:
       - ref: server.address
         requirement_level: required
@@ -91,7 +91,7 @@ groups:
   - id: attributes.http.server
     prefix: http
     type: attribute_group
-    brief: 'HTTP Server attributes'
+    brief: 'HTTP server attributes'
     attributes:
       - id: route
         type: string

--- a/semantic_conventions/http-common.yaml
+++ b/semantic_conventions/http-common.yaml
@@ -4,11 +4,51 @@ groups:
     brief: "Describes HTTP attributes."
     prefix: http
     attributes:
-      - id: request.method
-        type: string
-        requirement_level: required
+      - id: request.canonical_method
+        type:
+          allow_custom_values: true
+          members:
+            - id: connect
+              value: "CONNECT"
+              brief: 'CONNECT method.'
+            - id: delete
+              value: "DELETE"
+              brief: 'DELETE method.'
+            - id: get
+              value: "GET"
+              brief: 'GET method.'
+            - id: head
+              value: "HEAD"
+              brief: 'HEAD method.'
+            - id: options
+              value: "OPTIONS"
+              brief: 'OPTIONS method.'
+            - id: patch
+              value: "PATCH"
+              brief: 'PATCH method.'
+            - id: post
+              value: "POST"
+              brief: 'POST method.'
+            - id: put
+              value: "PUT"
+              brief: 'PUT method.'
+            - id: trace
+              value: "TRACE"
+              brief: 'TRACE method.'
+            - id: other
+              value: "other"
+              brief: 'Any custom HTTP method that the instrumentation has no prior knowledge of.'
         brief: 'HTTP request method.'
         examples: ["GET", "POST", "HEAD"]
+        note: |
+          HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+          or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+          Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
+          [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+          If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.method` attribute to `other` and SHOULD
+          populate the exact method passed by client on `http.request.original_method` attribute.
+
+          HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
       - id: response.status_code
         type: int
         requirement_level:
@@ -25,7 +65,7 @@ groups:
   - id: attributes.http.client
     prefix: http
     type: attribute_group
-    brief: 'HTTP client attributes'
+    brief: 'HTTP Client attributes'
     attributes:
       - ref: server.address
         requirement_level: required
@@ -51,7 +91,7 @@ groups:
   - id: attributes.http.server
     prefix: http
     type: attribute_group
-    brief: 'HTTP server attributes'
+    brief: 'HTTP Server attributes'
     attributes:
       - id: route
         type: string

--- a/semantic_conventions/http-common.yaml
+++ b/semantic_conventions/http-common.yaml
@@ -46,7 +46,7 @@ groups:
           Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
           [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
           If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
-          populate the exact method passed by client on `http.request.original_method` attribute.
+          populate the exact method passed by client on `http.request.method` attribute.
 
           HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
       - id: response.status_code

--- a/semantic_conventions/metrics/http.yaml
+++ b/semantic_conventions/metrics/http.yaml
@@ -8,7 +8,8 @@ groups:
     extends: attributes.http.server
     attributes:
       # todo (lmolkova) build tools don't populate grandparent attributes
-      - ref: http.request.method
+      - ref: http.request.canonical_method
+        requirement_level: required
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -20,7 +21,8 @@ groups:
     instrument: updowncounter
     unit: "{request}"
     attributes:
-      - ref: http.request.method
+      - ref: http.request.canonical_method
+        requirement_level: required
       - ref: url.scheme
         requirement_level: required
         examples: ["http", "https"]
@@ -62,7 +64,8 @@ groups:
     # TODO (trask) below attributes are identical to above in metric.http.server.duration
     attributes:
       # todo (lmolkova) build tools don't populate grandparent attributes
-      - ref: http.request.method
+      - ref: http.request.canonical_method
+        requirement_level: required
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -76,7 +79,8 @@ groups:
     extends: attributes.http.server
     # TODO (trask) below attributes are identical to above in metric.http.server.duration
     attributes:
-      - ref: http.request.method
+      - ref: http.request.canonical_method
+        requirement_level: required
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -89,7 +93,8 @@ groups:
     unit: "s"
     extends: attributes.http.client
     attributes:
-      - ref: http.request.method
+      - ref: http.request.canonical_method
+        requirement_level: required
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -103,7 +108,8 @@ groups:
     extends: attributes.http.client
     # TODO (trask) below attributes are identical to above in metric.http.client.duration
     attributes:
-      - ref: http.request.method
+      - ref: http.request.canonical_method
+        requirement_level: required
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -118,7 +124,8 @@ groups:
     extends: attributes.http.client
     # TODO (trask) below attributes are identical to above in metric.http.client.duration
     attributes:
-      - ref: http.request.method
+      - ref: http.request.canonical_method
+        requirement_level: required
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -8,6 +8,12 @@ groups:
         These conventions can be used for http and https schemes
         and various HTTP versions like 1.1, 2 and SPDY.
     attributes:
+      - id: request.method
+        type: string
+        requirement_level:
+          recommended: If different than `http.request.canonical_method`.
+        brief: Original HTTP method sent by the client in the request line.
+        examples: ["GET", "ACL", "Patch"]
       - id: request.body.size
         type: int
         brief: >
@@ -22,7 +28,8 @@ groups:
           is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)
           header. For requests using transport encoding, this should be the compressed size.
         examples: 3495
-      - ref: http.request.method
+      - ref: http.request.canonical_method
+        requirement_level: required
         sampling_relevant: true
       - ref: network.transport
         requirement_level:

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -11,7 +11,7 @@ groups:
       - id: request.method
         type: string
         requirement_level:
-          recommended: If different than `http.request.canonical_method`.
+          conditionally_required: If different than `http.request.canonical_method`, recommended otherwise.
         brief: Original HTTP method sent by the client in the request line.
         examples: ["GET", "ACL", "Patch"]
       - id: request.body.size

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -86,7 +86,7 @@ or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.
 Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
 [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
 If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
-populate the exact method passed by client on `http.request.original_method` attribute.
+populate the exact method passed by client on `http.request.method` attribute.
 
 HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
@@ -150,7 +150,7 @@ or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.
 Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
 [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
 If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
-populate the exact method passed by client on `http.request.original_method` attribute.
+populate the exact method passed by client on `http.request.method` attribute.
 
 HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
@@ -219,7 +219,7 @@ or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.
 Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
 [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
 If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
-populate the exact method passed by client on `http.request.original_method` attribute.
+populate the exact method passed by client on `http.request.method` attribute.
 
 HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
@@ -290,7 +290,7 @@ or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.
 Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
 [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
 If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
-populate the exact method passed by client on `http.request.original_method` attribute.
+populate the exact method passed by client on `http.request.method` attribute.
 
 HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
@@ -363,7 +363,7 @@ or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.
 Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
 [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
 If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
-populate the exact method passed by client on `http.request.original_method` attribute.
+populate the exact method passed by client on `http.request.method` attribute.
 
 HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
@@ -423,7 +423,7 @@ or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.
 Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
 [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
 If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
-populate the exact method passed by client on `http.request.original_method` attribute.
+populate the exact method passed by client on `http.request.method` attribute.
 
 HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
@@ -483,7 +483,7 @@ or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.
 Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
 [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
 If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
-populate the exact method passed by client on `http.request.original_method` attribute.
+populate the exact method passed by client on `http.request.method` attribute.
 
 HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -70,7 +70,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [2] |
+| `http.request.canonical_method` | string | Canonical HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../../trace/semantic_conventions/span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
@@ -81,7 +81,14 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/specification/trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
-**[2]:** If different than `http.request.canonical_method`.
+**[2]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
+[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
+populate the exact method passed by client on `http.request.original_method` attribute.
+
+HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -103,6 +110,21 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 - Port identifier of the `Host` header
 
 **[6]:** If not default (`80` for `http` scheme, `443` for `https`).
+
+`http.request.canonical_method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `CONNECT` | CONNECT method. |
+| `DELETE` | DELETE method. |
+| `GET` | GET method. |
+| `HEAD` | HEAD method. |
+| `OPTIONS` | OPTIONS method. |
+| `PATCH` | PATCH method. |
+| `POST` | POST method. |
+| `PUT` | PUT method. |
+| `TRACE` | TRACE method. |
+| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 ### Metric: `http.server.active_requests`
@@ -118,12 +140,19 @@ This metric is optional.
 <!-- semconv metric.http.server.active_requests(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [1] |
+| `http.request.canonical_method` | string | Canonical HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
 | [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [2] | `example.com` | Required |
 | [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
 | `url.scheme` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
-**[1]:** If different than `http.request.canonical_method`.
+**[1]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
+[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
+populate the exact method passed by client on `http.request.original_method` attribute.
+
+HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
 **[2]:** Determined by using the first of the following that applies
 
@@ -143,6 +172,21 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 - Port identifier of the `Host` header
 
 **[4]:** If not default (`80` for `http` scheme, `443` for `https`).
+
+`http.request.canonical_method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `CONNECT` | CONNECT method. |
+| `DELETE` | DELETE method. |
+| `GET` | GET method. |
+| `HEAD` | HEAD method. |
+| `OPTIONS` | OPTIONS method. |
+| `PATCH` | PATCH method. |
+| `POST` | POST method. |
+| `PUT` | PUT method. |
+| `TRACE` | TRACE method. |
+| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 ### Metric: `http.server.request.size`
@@ -159,7 +203,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [2] |
+| `http.request.canonical_method` | string | Canonical HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../../trace/semantic_conventions/span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
@@ -170,7 +214,14 @@ This metric is optional.
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/specification/trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
-**[2]:** If different than `http.request.canonical_method`.
+**[2]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
+[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
+populate the exact method passed by client on `http.request.original_method` attribute.
+
+HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -192,6 +243,21 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 - Port identifier of the `Host` header
 
 **[6]:** If not default (`80` for `http` scheme, `443` for `https`).
+
+`http.request.canonical_method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `CONNECT` | CONNECT method. |
+| `DELETE` | DELETE method. |
+| `GET` | GET method. |
+| `HEAD` | HEAD method. |
+| `OPTIONS` | OPTIONS method. |
+| `PATCH` | PATCH method. |
+| `POST` | POST method. |
+| `PUT` | PUT method. |
+| `TRACE` | TRACE method. |
+| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 ### Metric: `http.server.response.size`
@@ -208,7 +274,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [2] |
+| `http.request.canonical_method` | string | Canonical HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../../trace/semantic_conventions/span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
@@ -219,7 +285,14 @@ This metric is optional.
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/specification/trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
-**[2]:** If different than `http.request.canonical_method`.
+**[2]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
+[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
+populate the exact method passed by client on `http.request.original_method` attribute.
+
+HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -241,6 +314,21 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 - Port identifier of the `Host` header
 
 **[6]:** If not default (`80` for `http` scheme, `443` for `https`).
+
+`http.request.canonical_method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `CONNECT` | CONNECT method. |
+| `DELETE` | DELETE method. |
+| `GET` | GET method. |
+| `HEAD` | HEAD method. |
+| `OPTIONS` | OPTIONS method. |
+| `PATCH` | PATCH method. |
+| `POST` | POST method. |
+| `PUT` | PUT method. |
+| `TRACE` | TRACE method. |
+| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 ## HTTP Client
@@ -262,7 +350,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 <!-- semconv metric.http.client.duration(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [1] |
+| `http.request.canonical_method` | string | Canonical HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../../trace/semantic_conventions/span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
@@ -270,7 +358,14 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
 | [`server.socket.address`](../../trace/semantic_conventions/span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
 
-**[1]:** If different than `http.request.canonical_method`.
+**[1]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
+[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
+populate the exact method passed by client on `http.request.original_method` attribute.
+
+HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -285,6 +380,21 @@ SHOULD NOT be set if capturing it would require an extra DNS lookup.
 **[4]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
 **[5]:** If not default (`80` for `http` scheme, `443` for `https`).
+
+`http.request.canonical_method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `CONNECT` | CONNECT method. |
+| `DELETE` | DELETE method. |
+| `GET` | GET method. |
+| `HEAD` | HEAD method. |
+| `OPTIONS` | OPTIONS method. |
+| `PATCH` | PATCH method. |
+| `POST` | POST method. |
+| `PUT` | PUT method. |
+| `TRACE` | TRACE method. |
+| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 ### Metric: `http.client.request.size`
@@ -300,7 +410,7 @@ This metric is optional.
 <!-- semconv metric.http.client.request.size(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [1] |
+| `http.request.canonical_method` | string | Canonical HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../../trace/semantic_conventions/span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
@@ -308,7 +418,14 @@ This metric is optional.
 | [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
 | [`server.socket.address`](../../trace/semantic_conventions/span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
 
-**[1]:** If different than `http.request.canonical_method`.
+**[1]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
+[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
+populate the exact method passed by client on `http.request.original_method` attribute.
+
+HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -323,6 +440,21 @@ SHOULD NOT be set if capturing it would require an extra DNS lookup.
 **[4]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
 **[5]:** If not default (`80` for `http` scheme, `443` for `https`).
+
+`http.request.canonical_method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `CONNECT` | CONNECT method. |
+| `DELETE` | DELETE method. |
+| `GET` | GET method. |
+| `HEAD` | HEAD method. |
+| `OPTIONS` | OPTIONS method. |
+| `PATCH` | PATCH method. |
+| `POST` | POST method. |
+| `PUT` | PUT method. |
+| `TRACE` | TRACE method. |
+| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 ### Metric: `http.client.response.size`
@@ -338,7 +470,7 @@ This metric is optional.
 <!-- semconv metric.http.client.response.size(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [1] |
+| `http.request.canonical_method` | string | Canonical HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../../trace/semantic_conventions/span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
@@ -346,7 +478,14 @@ This metric is optional.
 | [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
 | [`server.socket.address`](../../trace/semantic_conventions/span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
 
-**[1]:** If different than `http.request.canonical_method`.
+**[1]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
+[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
+populate the exact method passed by client on `http.request.original_method` attribute.
+
+HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -361,4 +500,19 @@ SHOULD NOT be set if capturing it would require an extra DNS lookup.
 **[4]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
 **[5]:** If not default (`80` for `http` scheme, `443` for `https`).
+
+`http.request.canonical_method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `CONNECT` | CONNECT method. |
+| `DELETE` | DELETE method. |
+| `GET` | GET method. |
+| `HEAD` | HEAD method. |
+| `OPTIONS` | OPTIONS method. |
+| `PATCH` | PATCH method. |
+| `POST` | POST method. |
+| `PUT` | PUT method. |
+| `TRACE` | TRACE method. |
+| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -70,20 +70,22 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [2] |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../../trace/semantic_conventions/span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
-| [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
-| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [3] | `example.com` | Required |
-| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
+| [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
+| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [4] | `example.com` | Required |
+| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [5] | `80`; `8080`; `443` | Conditionally Required: [6] |
 | `url.scheme` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/specification/trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
-**[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[2]:** If different than `http.request.canonical_method`.
 
-**[3]:** Determined by using the first of the following that applies
+**[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[4]:** Determined by using the first of the following that applies
 
 - The [primary server name](/specification/trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host. MUST only
   include host identifier.
@@ -93,14 +95,14 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
-**[4]:** Determined by using the first of the following that applies
+**[5]:** Determined by using the first of the following that applies
 
 - Port identifier of the [primary server host](/specification/trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
 
-**[5]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[6]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->
 
 ### Metric: `http.server.active_requests`
@@ -116,12 +118,14 @@ This metric is optional.
 <!-- semconv metric.http.server.active_requests(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
-| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [1] | `example.com` | Required |
-| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [2] | `80`; `8080`; `443` | Conditionally Required: [3] |
+| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [1] |
+| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [2] | `example.com` | Required |
+| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
 | `url.scheme` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
-**[1]:** Determined by using the first of the following that applies
+**[1]:** If different than `http.request.canonical_method`.
+
+**[2]:** Determined by using the first of the following that applies
 
 - The [primary server name](/specification/trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host. MUST only
   include host identifier.
@@ -131,14 +135,14 @@ This metric is optional.
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
-**[2]:** Determined by using the first of the following that applies
+**[3]:** Determined by using the first of the following that applies
 
 - Port identifier of the [primary server host](/specification/trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
 
-**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[4]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->
 
 ### Metric: `http.server.request.size`
@@ -155,20 +159,22 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [2] |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../../trace/semantic_conventions/span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
-| [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
-| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [3] | `example.com` | Required |
-| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
+| [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
+| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [4] | `example.com` | Required |
+| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [5] | `80`; `8080`; `443` | Conditionally Required: [6] |
 | `url.scheme` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/specification/trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
-**[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[2]:** If different than `http.request.canonical_method`.
 
-**[3]:** Determined by using the first of the following that applies
+**[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[4]:** Determined by using the first of the following that applies
 
 - The [primary server name](/specification/trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host. MUST only
   include host identifier.
@@ -178,14 +184,14 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
-**[4]:** Determined by using the first of the following that applies
+**[5]:** Determined by using the first of the following that applies
 
 - Port identifier of the [primary server host](/specification/trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
 
-**[5]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[6]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->
 
 ### Metric: `http.server.response.size`
@@ -202,20 +208,22 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [2] |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../../trace/semantic_conventions/span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
-| [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
-| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [3] | `example.com` | Required |
-| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
+| [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
+| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [4] | `example.com` | Required |
+| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [5] | `80`; `8080`; `443` | Conditionally Required: [6] |
 | `url.scheme` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/specification/trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
-**[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[2]:** If different than `http.request.canonical_method`.
 
-**[3]:** Determined by using the first of the following that applies
+**[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[4]:** Determined by using the first of the following that applies
 
 - The [primary server name](/specification/trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host. MUST only
   include host identifier.
@@ -225,14 +233,14 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
-**[4]:** Determined by using the first of the following that applies
+**[5]:** Determined by using the first of the following that applies
 
 - Port identifier of the [primary server host](/specification/trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
 
-**[5]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[6]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->
 
 ## HTTP Client
@@ -254,17 +262,19 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 <!-- semconv metric.http.client.duration(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [1] |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../../trace/semantic_conventions/span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
-| [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [1] | `3.1.1` | Recommended |
-| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `example.com` | Required |
-| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
+| [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
+| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `example.com` | Required |
+| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
 | [`server.socket.address`](../../trace/semantic_conventions/span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
 
-**[1]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[1]:** If different than `http.request.canonical_method`.
 
-**[2]:** Determined by using the first of the following that applies
+**[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[3]:** Determined by using the first of the following that applies
 
 - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form
@@ -272,9 +282,9 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 
 SHOULD NOT be set if capturing it would require an extra DNS lookup.
 
-**[3]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
+**[4]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
-**[4]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[5]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->
 
 ### Metric: `http.client.request.size`
@@ -290,17 +300,19 @@ This metric is optional.
 <!-- semconv metric.http.client.request.size(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [1] |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../../trace/semantic_conventions/span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
-| [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [1] | `3.1.1` | Recommended |
-| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `example.com` | Required |
-| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
+| [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
+| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `example.com` | Required |
+| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
 | [`server.socket.address`](../../trace/semantic_conventions/span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
 
-**[1]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[1]:** If different than `http.request.canonical_method`.
 
-**[2]:** Determined by using the first of the following that applies
+**[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[3]:** Determined by using the first of the following that applies
 
 - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form
@@ -308,9 +320,9 @@ This metric is optional.
 
 SHOULD NOT be set if capturing it would require an extra DNS lookup.
 
-**[3]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
+**[4]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
-**[4]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[5]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->
 
 ### Metric: `http.client.response.size`
@@ -326,17 +338,19 @@ This metric is optional.
 <!-- semconv metric.http.client.response.size(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../../trace/semantic_conventions/http.md) | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [1] |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../../trace/semantic_conventions/span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
-| [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [1] | `3.1.1` | Recommended |
-| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `example.com` | Required |
-| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
+| [`network.protocol.version`](../../trace/semantic_conventions/span-general.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
+| [`server.address`](../../trace/semantic_conventions/span-general.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `example.com` | Required |
+| [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
 | [`server.socket.address`](../../trace/semantic_conventions/span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
 
-**[1]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[1]:** If different than `http.request.canonical_method`.
 
-**[2]:** Determined by using the first of the following that applies
+**[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[3]:** Determined by using the first of the following that applies
 
 - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form
@@ -344,7 +358,7 @@ This metric is optional.
 
 SHOULD NOT be set if capturing it would require an extra DNS lookup.
 
-**[3]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
+**[4]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
-**[4]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[5]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -90,22 +90,49 @@ sections below.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| `http.request.method` | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [1] |
 | `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
 | `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
-| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| `http.request.canonical_method` | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
 | [`network.protocol.name`](span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `http`; `spdy` | Recommended: if not default (`http`). |
-| [`network.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [1] | `1.0`; `1.1`; `2.0` | Recommended |
-| [`network.transport`](span-general.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Conditionally Required: [2] |
+| [`network.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [3] | `1.0`; `1.1`; `2.0` | Recommended |
+| [`network.transport`](span-general.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Conditionally Required: [4] |
 | [`network.type`](span-general.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
 | `user_agent.original` | string | Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | Recommended |
 
-**[1]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[1]:** If different than `http.request.canonical_method`.
 
-**[2]:** If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
+**[2]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
+[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.method` attribute to `other` and SHOULD
+populate the exact method passed by client on `http.request.original_method` attribute.
+
+HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
+
+**[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[4]:** If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
 
 Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
 
-* `http.request.method`
+* `http.request.canonical_method`
+
+`http.request.canonical_method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `CONNECT` | CONNECT method. |
+| `DELETE` | DELETE method. |
+| `GET` | GET method. |
+| `HEAD` | HEAD method. |
+| `OPTIONS` | OPTIONS method. |
+| `PATCH` | PATCH method. |
+| `POST` | POST method. |
+| `PUT` | PUT method. |
+| `TRACE` | TRACE method. |
+| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 
 `network.transport` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -93,7 +93,7 @@ sections below.
 | `http.request.method` | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [1] |
 | `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
 | `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
-| `http.request.canonical_method` | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
+| `http.request.canonical_method` | string | Canonical HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
 | [`network.protocol.name`](span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `http`; `spdy` | Recommended: if not default (`http`). |
 | [`network.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [3] | `1.0`; `1.1`; `2.0` | Recommended |
 | [`network.transport`](span-general.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Conditionally Required: [4] |
@@ -106,7 +106,7 @@ sections below.
 or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
 [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
-If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.method` attribute to `other` and SHOULD
+If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
 populate the exact method passed by client on `http.request.original_method` attribute.
 
 HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -107,7 +107,7 @@ or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.
 Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
 [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
 If the HTTP request method is not known to the instrumentation, it MUST set the `http.request.canonical_method` attribute to `other` and SHOULD
-populate the exact method passed by client on `http.request.original_method` attribute.
+populate the exact method passed by client on `http.request.method` attribute.
 
 HTTP method names are case-sensitive and `http.request.canonical_method` attribute value MUST match a standard (or documented elsewhere) HTTP method name exactly.
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -54,13 +54,13 @@ and various HTTP versions like 1.1, 2 and SPDY.
 ## Name
 
 HTTP spans MUST follow the overall [guidelines for span names](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span).
-HTTP server span names SHOULD be `{http.request.method} {http.route}` if there is a
+HTTP server span names SHOULD be `{http.request.canonical_method} {http.route}` if there is a
 (low-cardinality) `http.route` available.
-HTTP server span names SHOULD be `{http.request.method}` if there is no (low-cardinality)
+HTTP server span names SHOULD be `{http.request.canonical_method}` if there is no (low-cardinality)
 `http.route` available.
 HTTP client spans have no `http.route` attribute since client-side instrumentation
 is not generally aware of the "route", and therefore HTTP client spans SHOULD use
-`{http.request.method}`.
+`{http.request.canonical_method}`.
 Instrumentation MUST NOT default to using URI
 path as span name, but MAY provide hooks to allow custom logic to override the
 default span name.
@@ -90,7 +90,7 @@ sections below.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| `http.request.method` | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Recommended: [1] |
+| `http.request.method` | string | Original HTTP method sent by the client in the request line. | `GET`; `ACL`; `Patch` | Conditionally Required: [1] |
 | `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
 | `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
 | `http.request.canonical_method` | string | Canonical HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
@@ -100,7 +100,7 @@ sections below.
 | [`network.type`](span-general.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
 | `user_agent.original` | string | Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | Recommended |
 
-**[1]:** If different than `http.request.canonical_method`.
+**[1]:** If different than `http.request.canonical_method`, recommended otherwise.
 
 **[2]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
@@ -363,7 +363,7 @@ Span name: `GET`
 
 |   Attribute name     |                                       Value             |
 | :------------------- | :-------------------------------------------------------|
-| `http.request.method`| `"GET"`                                                 |
+| `http.request.canonical_method`| `"GET"`                                                 |
 | `network.protocol.version` | `"1.1"`                                          |
 | `url.full`           | `"https://example.com:8080/webshop/articles/4?s=1"`     |
 | `server.address`     | `example.com`                                           |
@@ -377,7 +377,7 @@ Span name: `GET /webshop/articles/:article_id`.
 
 |   Attribute name     |                      Value                      |
 | :------------------- | :---------------------------------------------- |
-| `http.request.method`| `"GET"`                                         |
+| `http.request.canonical_method`| `"GET"`                                         |
 | `network.protocol.version` | `"1.1"`                                   |
 | `url.path`           | `"/webshop/articles/4"`                         |
 | `url.query`          | `"?s=1"`                                        |

--- a/specification/trace/semantic_conventions/instrumentation/aws-lambda.md
+++ b/specification/trace/semantic_conventions/instrumentation/aws-lambda.md
@@ -168,7 +168,7 @@ Function F:    | Span Function |
 | `cloud.account.id` | | `12345678912` |
 | `server.address` | `foo.execute-api.us-east-1.amazonaws.com` |  |
 | `server.port` | `413` |  |
-| `http.request.method` | `GET` | `GET` |
+| `http.request.canonical_method` | `GET` | `GET` |
 | `user_agent.original` | `okhttp 3.0` | `okhttp 3.0` |
 | `url.scheme` | | `https` |
 | `url.path` | | `/pets/10` |


### PR DESCRIPTION
Implements option b (or d) from #17