### PR TITLE
Limit HTTP request method cardinality: use one attribute (option C/E)

### DIFF
--- a/semantic_conventions/http-common.yaml
+++ b/semantic_conventions/http-common.yaml
@@ -13,10 +13,13 @@ groups:
           The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
           or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-          Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
-          For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+          Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
+          [Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+          to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
+          
+          For general-purpose HTTP instrumentations the list SHOULD include common request methods:
           `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-          Applications MAY use TODO View API to override instrumentation defaults.
+          Applications MAY override instrumentation defaults using [view](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view) TODO property.
 
           Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
       - id: response.status_code

--- a/semantic_conventions/http-common.yaml
+++ b/semantic_conventions/http-common.yaml
@@ -14,7 +14,7 @@ groups:
           or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
           Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-          and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+          and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
           `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
           Applications MAY use TODO advice API to override instrumentation defaults.
 

--- a/semantic_conventions/http-common.yaml
+++ b/semantic_conventions/http-common.yaml
@@ -14,9 +14,9 @@ groups:
           or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
           Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
-          [Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+          [Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available)
           to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
-          
+
           For general-purpose HTTP instrumentations the list SHOULD include common request methods:
           `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
           Applications MAY override instrumentation defaults using [view](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view) TODO property.

--- a/semantic_conventions/http-common.yaml
+++ b/semantic_conventions/http-common.yaml
@@ -5,9 +5,48 @@ groups:
     prefix: http
     attributes:
       - id: request.method
-        type: string
+        type:
+          allow_custom_values: true
+          members:
+            - id: connect
+              value: "CONNECT"
+              brief: 'CONNECT method.'
+            - id: delete
+              value: "DELETE"
+              brief: 'DELETE method.'
+            - id: get
+              value: "GET"
+              brief: 'GET method.'
+            - id: head
+              value: "HEAD"
+              brief: 'HEAD method.'
+            - id: options
+              value: "OPTIONS"
+              brief: 'OPTIONS method.'
+            - id: patch
+              value: "PATCH"
+              brief: 'PATCH method.'
+            - id: post
+              value: "POST"
+              brief: 'POST method.'
+            - id: put
+              value: "PUT"
+              brief: 'PUT method.'
+            - id: trace
+              value: "TRACE"
+              brief: 'TRACE method.'
+            - id: other
+              value: "other"
+              brief: 'Any custom HTTP method that the instrumentation has no prior knowledge of.'
         requirement_level: required
         brief: 'HTTP request method.'
+        note: |
+          HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+          or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+          Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
+          [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+          
+          If the HTTP request method is not known to the instrumentation, metrics instrumentations MAY set `other` as the attribute value.
         examples: ["GET", "POST", "HEAD"]
       - id: response.status_code
         type: int

--- a/semantic_conventions/http-common.yaml
+++ b/semantic_conventions/http-common.yaml
@@ -5,48 +5,9 @@ groups:
     prefix: http
     attributes:
       - id: request.method
-        type:
-          allow_custom_values: true
-          members:
-            - id: connect
-              value: "CONNECT"
-              brief: 'CONNECT method.'
-            - id: delete
-              value: "DELETE"
-              brief: 'DELETE method.'
-            - id: get
-              value: "GET"
-              brief: 'GET method.'
-            - id: head
-              value: "HEAD"
-              brief: 'HEAD method.'
-            - id: options
-              value: "OPTIONS"
-              brief: 'OPTIONS method.'
-            - id: patch
-              value: "PATCH"
-              brief: 'PATCH method.'
-            - id: post
-              value: "POST"
-              brief: 'POST method.'
-            - id: put
-              value: "PUT"
-              brief: 'PUT method.'
-            - id: trace
-              value: "TRACE"
-              brief: 'TRACE method.'
-            - id: other
-              value: "other"
-              brief: 'Any custom HTTP method that the instrumentation has no prior knowledge of.'
+        type: string
         requirement_level: required
         brief: 'HTTP request method.'
-        note: |
-          HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-          or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-          Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
-          [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
-          
-          If the HTTP request method is not known to the instrumentation, metrics instrumentations MAY set `other` as the attribute value.
         examples: ["GET", "POST", "HEAD"]
       - id: response.status_code
         type: int

--- a/semantic_conventions/http-common.yaml
+++ b/semantic_conventions/http-common.yaml
@@ -9,6 +9,16 @@ groups:
         requirement_level: required
         brief: 'HTTP request method.'
         examples: ["GET", "POST", "HEAD"]
+        note: |
+          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+
+          Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
+          and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+          `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
+          Applications MAY use TODO advice API to override instrumentation defaults.
+
+          Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
       - id: response.status_code
         type: int
         requirement_level:

--- a/semantic_conventions/http-common.yaml
+++ b/semantic_conventions/http-common.yaml
@@ -13,12 +13,12 @@ groups:
           The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
           or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-          Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-          and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+          Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
+          For general-purpose HTTP instrumentations this list SHOULD include common request methods:
           `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-          Applications MAY use TODO advice API to override instrumentation defaults.
+          Applications MAY use TODO View API to override instrumentation defaults.
 
-          Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
+          Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
       - id: response.status_code
         type: int
         requirement_level:

--- a/semantic_conventions/metrics/http.yaml
+++ b/semantic_conventions/metrics/http.yaml
@@ -7,8 +7,14 @@ groups:
     unit: "s"
     extends: attributes.http.server
     attributes:
-      # todo (lmolkova) build tools don't populate grandparent attributes
       - ref: http.request.method
+        note: |
+          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+
+          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+      # todo (lmolkova) build tools don't populate grandparent attributes
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -21,6 +27,12 @@ groups:
     unit: "{request}"
     attributes:
       - ref: http.request.method
+        note: |
+          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+
+          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
       - ref: url.scheme
         requirement_level: required
         examples: ["http", "https"]
@@ -61,8 +73,14 @@ groups:
     extends: attributes.http.server
     # TODO (trask) below attributes are identical to above in metric.http.server.duration
     attributes:
-      # todo (lmolkova) build tools don't populate grandparent attributes
       - ref: http.request.method
+        note: |
+          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+
+          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+      # todo (lmolkova) build tools don't populate grandparent attributes      
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -77,6 +95,12 @@ groups:
     # TODO (trask) below attributes are identical to above in metric.http.server.duration
     attributes:
       - ref: http.request.method
+        note: |
+          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+
+          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -90,6 +114,12 @@ groups:
     extends: attributes.http.client
     attributes:
       - ref: http.request.method
+        note: |
+          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+
+          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -104,6 +134,12 @@ groups:
     # TODO (trask) below attributes are identical to above in metric.http.client.duration
     attributes:
       - ref: http.request.method
+        note: |
+          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+
+          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -119,6 +155,12 @@ groups:
     # TODO (trask) below attributes are identical to above in metric.http.client.duration
     attributes:
       - ref: http.request.method
+        note: |
+          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+
+          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version

--- a/semantic_conventions/metrics/http.yaml
+++ b/semantic_conventions/metrics/http.yaml
@@ -7,15 +7,8 @@ groups:
     unit: "s"
     extends: attributes.http.server
     attributes:
-      - ref: http.request.method
-        note: |
-          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
-
-          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       # todo (lmolkova) build tools don't populate grandparent attributes
+      - ref: http.request.method      
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -28,13 +21,6 @@ groups:
     unit: "{request}"
     attributes:
       - ref: http.request.method
-        note: |
-          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
-
-          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       - ref: url.scheme
         requirement_level: required
         examples: ["http", "https"]
@@ -75,15 +61,8 @@ groups:
     extends: attributes.http.server
     # TODO (trask) below attributes are identical to above in metric.http.server.duration
     attributes:
-      - ref: http.request.method
-        note: |
-          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
-
-          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       # todo (lmolkova) build tools don't populate grandparent attributes      
+      - ref: http.request.method
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -98,13 +77,6 @@ groups:
     # TODO (trask) below attributes are identical to above in metric.http.server.duration
     attributes:
       - ref: http.request.method
-        note: |
-          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
-
-          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -118,13 +90,6 @@ groups:
     extends: attributes.http.client
     attributes:
       - ref: http.request.method
-        note: |
-          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
-
-          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -139,13 +104,6 @@ groups:
     # TODO (trask) below attributes are identical to above in metric.http.client.duration
     attributes:
       - ref: http.request.method
-        note: |
-          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
-
-          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -161,13 +119,6 @@ groups:
     # TODO (trask) below attributes are identical to above in metric.http.client.duration
     attributes:
       - ref: http.request.method
-        note: |
-          The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-          or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-          However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
-
-          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version

--- a/semantic_conventions/metrics/http.yaml
+++ b/semantic_conventions/metrics/http.yaml
@@ -13,7 +13,8 @@ groups:
           or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
           However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       # todo (lmolkova) build tools don't populate grandparent attributes
       - ref: http.response.status_code
       - ref: network.protocol.name
@@ -32,7 +33,8 @@ groups:
           or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
           However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       - ref: url.scheme
         requirement_level: required
         examples: ["http", "https"]
@@ -79,7 +81,8 @@ groups:
           or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
           However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       # todo (lmolkova) build tools don't populate grandparent attributes      
       - ref: http.response.status_code
       - ref: network.protocol.name
@@ -100,7 +103,8 @@ groups:
           or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
           However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -119,7 +123,8 @@ groups:
           or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
           However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -139,7 +144,8 @@ groups:
           or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
           However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -160,7 +166,8 @@ groups:
           or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
           However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-          Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+          Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version

--- a/semantic_conventions/metrics/http.yaml
+++ b/semantic_conventions/metrics/http.yaml
@@ -8,7 +8,7 @@ groups:
     extends: attributes.http.server
     attributes:
       # todo (lmolkova) build tools don't populate grandparent attributes
-      - ref: http.request.method      
+      - ref: http.request.method
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
@@ -61,7 +61,7 @@ groups:
     extends: attributes.http.server
     # TODO (trask) below attributes are identical to above in metric.http.server.duration
     attributes:
-      # todo (lmolkova) build tools don't populate grandparent attributes      
+      # todo (lmolkova) build tools don't populate grandparent attributes
       - ref: http.request.method
       - ref: http.response.status_code
       - ref: network.protocol.name

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -83,12 +83,11 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/specification/trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
-**[2]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
-[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+**[2]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-If the HTTP request method is not known to the instrumentation, metrics instrumentations MAY set `other` as the attribute value.
+Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -110,21 +109,6 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 - Port identifier of the `Host` header
 
 **[6]:** If not default (`80` for `http` scheme, `443` for `https`).
-
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 ### Metric: `http.server.active_requests`
@@ -145,12 +129,11 @@ This metric is optional.
 | [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
 | `url.scheme` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
-**[1]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
-[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+**[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-If the HTTP request method is not known to the instrumentation, metrics instrumentations MAY set `other` as the attribute value.
+Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
 
 **[2]:** Determined by using the first of the following that applies
 
@@ -170,21 +153,6 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 - Port identifier of the `Host` header
 
 **[4]:** If not default (`80` for `http` scheme, `443` for `https`).
-
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 ### Metric: `http.server.request.size`
@@ -212,12 +180,11 @@ This metric is optional.
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/specification/trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
-**[2]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
-[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+**[2]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-If the HTTP request method is not known to the instrumentation, metrics instrumentations MAY set `other` as the attribute value.
+Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -239,21 +206,6 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 - Port identifier of the `Host` header
 
 **[6]:** If not default (`80` for `http` scheme, `443` for `https`).
-
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 ### Metric: `http.server.response.size`
@@ -281,12 +233,11 @@ This metric is optional.
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/specification/trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
-**[2]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
-[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+**[2]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-If the HTTP request method is not known to the instrumentation, metrics instrumentations MAY set `other` as the attribute value.
+Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -308,21 +259,6 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 - Port identifier of the `Host` header
 
 **[6]:** If not default (`80` for `http` scheme, `443` for `https`).
-
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 ## HTTP Client
@@ -354,12 +290,11 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
 | [`server.socket.address`](../../trace/semantic_conventions/span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
 
-**[1]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
-[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+**[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-If the HTTP request method is not known to the instrumentation, metrics instrumentations MAY set `other` as the attribute value.
+Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -374,21 +309,6 @@ SHOULD NOT be set if capturing it would require an extra DNS lookup.
 **[4]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
 **[5]:** If not default (`80` for `http` scheme, `443` for `https`).
-
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 ### Metric: `http.client.request.size`
@@ -412,12 +332,11 @@ This metric is optional.
 | [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
 | [`server.socket.address`](../../trace/semantic_conventions/span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
 
-**[1]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
-[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+**[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-If the HTTP request method is not known to the instrumentation, metrics instrumentations MAY set `other` as the attribute value.
+Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -432,21 +351,6 @@ SHOULD NOT be set if capturing it would require an extra DNS lookup.
 **[4]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
 **[5]:** If not default (`80` for `http` scheme, `443` for `https`).
-
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 ### Metric: `http.client.response.size`
@@ -470,12 +374,11 @@ This metric is optional.
 | [`server.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
 | [`server.socket.address`](../../trace/semantic_conventions/span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
 
-**[1]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
-[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+**[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-If the HTTP request method is not known to the instrumentation, metrics instrumentations MAY set `other` as the attribute value.
+Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -490,21 +393,6 @@ SHOULD NOT be set if capturing it would require an extra DNS lookup.
 **[4]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
 **[5]:** If not default (`80` for `http` scheme, `443` for `https`).
-
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/document-status.md

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -87,7 +87,8 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
 However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -133,7 +134,8 @@ This metric is optional.
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
 However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
 
 **[2]:** Determined by using the first of the following that applies
 
@@ -184,7 +186,8 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
 However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -237,7 +240,8 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
 However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -294,7 +298,8 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
 However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -336,7 +341,8 @@ This metric is optional.
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
 However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -378,7 +384,8 @@ This metric is optional.
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
 However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
 
-Applications MAY use Hint API (once available) to specify a list of known HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
+Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -87,7 +87,7 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
 Applications MAY use TODO advice API to override instrumentation defaults.
 
@@ -137,7 +137,7 @@ This metric is optional.
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
 Applications MAY use TODO advice API to override instrumentation defaults.
 
@@ -192,7 +192,7 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
 Applications MAY use TODO advice API to override instrumentation defaults.
 
@@ -249,7 +249,7 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
 Applications MAY use TODO advice API to override instrumentation defaults.
 
@@ -310,7 +310,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
 Applications MAY use TODO advice API to override instrumentation defaults.
 
@@ -356,7 +356,7 @@ This metric is optional.
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
 Applications MAY use TODO advice API to override instrumentation defaults.
 
@@ -402,7 +402,7 @@ This metric is optional.
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
 Applications MAY use TODO advice API to override instrumentation defaults.
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -86,10 +86,13 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 **[2]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
-For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
+
+For general-purpose HTTP instrumentations the list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO View API to override instrumentation defaults.
+Applications MAY override instrumentation defaults using [view](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view) TODO property.
 
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
@@ -136,10 +139,13 @@ This metric is optional.
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
-For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
+
+For general-purpose HTTP instrumentations the list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO View API to override instrumentation defaults.
+Applications MAY override instrumentation defaults using [view](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view) TODO property.
 
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
@@ -191,10 +197,13 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 **[2]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
-For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
+
+For general-purpose HTTP instrumentations the list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO View API to override instrumentation defaults.
+Applications MAY override instrumentation defaults using [view](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view) TODO property.
 
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
@@ -248,10 +257,13 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 **[2]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
-For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
+
+For general-purpose HTTP instrumentations the list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO View API to override instrumentation defaults.
+Applications MAY override instrumentation defaults using [view](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view) TODO property.
 
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
@@ -309,10 +321,13 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
-For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
+
+For general-purpose HTTP instrumentations the list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO View API to override instrumentation defaults.
+Applications MAY override instrumentation defaults using [view](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view) TODO property.
 
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
@@ -355,10 +370,13 @@ This metric is optional.
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
-For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
+
+For general-purpose HTTP instrumentations the list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO View API to override instrumentation defaults.
+Applications MAY override instrumentation defaults using [view](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view) TODO property.
 
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
@@ -401,10 +419,13 @@ This metric is optional.
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
-For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
+
+For general-purpose HTTP instrumentations the list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO View API to override instrumentation defaults.
+Applications MAY override instrumentation defaults using [view](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view) TODO property.
 
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -84,11 +84,14 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 SHOULD include the [application root](/specification/trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
 **[2]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
+Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
+Applications MAY use TODO advice API to override instrumentation defaults.
+
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -131,11 +134,14 @@ This metric is optional.
 | `url.scheme` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
+Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
+Applications MAY use TODO advice API to override instrumentation defaults.
+
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
 
 **[2]:** Determined by using the first of the following that applies
 
@@ -183,11 +189,14 @@ This metric is optional.
 SHOULD include the [application root](/specification/trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
 **[2]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
+Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
+Applications MAY use TODO advice API to override instrumentation defaults.
+
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -237,11 +246,14 @@ This metric is optional.
 SHOULD include the [application root](/specification/trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
 **[2]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
+Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
+Applications MAY use TODO advice API to override instrumentation defaults.
+
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -295,11 +307,14 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | [`server.socket.address`](../../trace/semantic_conventions/span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
 
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
+Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
+Applications MAY use TODO advice API to override instrumentation defaults.
+
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -338,11 +353,14 @@ This metric is optional.
 | [`server.socket.address`](../../trace/semantic_conventions/span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
 
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
+Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
+Applications MAY use TODO advice API to override instrumentation defaults.
+
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -381,11 +399,14 @@ This metric is optional.
 | [`server.socket.address`](../../trace/semantic_conventions/span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
 
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html), or a custom one, which could be registered with [HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml).
-However, HTTP clients may send arbitrary method string resulting in a high cardinality of this attribute.
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentation libraries SHOULD use TODO Hint API (once available) and specify a default list of standard HTTP request methods to be prioritized when capping dimensions if cardinality limit is reached.
-Applications MAY use TODO Hint API (once available) to override instrumentation defaults.
+Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
+Applications MAY use TODO advice API to override instrumentation defaults.
+
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -87,7 +87,7 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
-[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available)
 to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
 
 For general-purpose HTTP instrumentations the list SHOULD include common request methods:
@@ -140,7 +140,7 @@ This metric is optional.
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
-[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available)
 to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
 
 For general-purpose HTTP instrumentations the list SHOULD include common request methods:
@@ -198,7 +198,7 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
-[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available)
 to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
 
 For general-purpose HTTP instrumentations the list SHOULD include common request methods:
@@ -258,7 +258,7 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
-[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available)
 to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
 
 For general-purpose HTTP instrumentations the list SHOULD include common request methods:
@@ -322,7 +322,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
-[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available)
 to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
 
 For general-purpose HTTP instrumentations the list SHOULD include common request methods:
@@ -371,7 +371,7 @@ This metric is optional.
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
-[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available)
 to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
 
 For general-purpose HTTP instrumentations the list SHOULD include common request methods:
@@ -420,7 +420,7 @@ This metric is optional.
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
-[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available)
 to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
 
 For general-purpose HTTP instrumentations the list SHOULD include common request methods:

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -86,12 +86,12 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 **[2]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
+For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO advice API to override instrumentation defaults.
+Applications MAY use TODO View API to override instrumentation defaults.
 
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -136,12 +136,12 @@ This metric is optional.
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
+For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO advice API to override instrumentation defaults.
+Applications MAY use TODO View API to override instrumentation defaults.
 
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
 **[2]:** Determined by using the first of the following that applies
 
@@ -191,12 +191,12 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 **[2]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
+For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO advice API to override instrumentation defaults.
+Applications MAY use TODO View API to override instrumentation defaults.
 
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -248,12 +248,12 @@ SHOULD include the [application root](/specification/trace/semantic_conventions/
 **[2]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
+For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO advice API to override instrumentation defaults.
+Applications MAY use TODO View API to override instrumentation defaults.
 
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -309,12 +309,12 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
+For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO advice API to override instrumentation defaults.
+Applications MAY use TODO View API to override instrumentation defaults.
 
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -355,12 +355,12 @@ This metric is optional.
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
+For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO advice API to override instrumentation defaults.
+Applications MAY use TODO View API to override instrumentation defaults.
 
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -401,12 +401,12 @@ This metric is optional.
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
+For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO advice API to override instrumentation defaults.
+Applications MAY use TODO View API to override instrumentation defaults.
 
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -103,7 +103,7 @@ sections below.
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
 Applications MAY use TODO advice API to override instrumentation defaults.
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -92,16 +92,26 @@ sections below.
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
 | `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
-| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| `http.request.method` | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
 | [`network.protocol.name`](span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `http`; `spdy` | Recommended: if not default (`http`). |
-| [`network.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [1] | `1.0`; `1.1`; `2.0` | Recommended |
-| [`network.transport`](span-general.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Conditionally Required: [2] |
+| [`network.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [2] | `1.0`; `1.1`; `2.0` | Recommended |
+| [`network.transport`](span-general.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Conditionally Required: [3] |
 | [`network.type`](span-general.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
 | `user_agent.original` | string | Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | Recommended |
 
-**[1]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-**[2]:** If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
+Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
+and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list MUST include common request methods:
+`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
+Applications MAY use TODO advice API to override instrumentation defaults.
+
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
+
+**[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[3]:** If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
 
 Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -103,7 +103,7 @@ sections below.
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
 Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
-[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available)
 to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
 
 For general-purpose HTTP instrumentations the list SHOULD include common request methods:

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -102,10 +102,13 @@ sections below.
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
-For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations are RECOMMENDED to provide a list of known HTTP request methods via
+[Instrument advice](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-advice) (when available) 
+to avoid the [cardinality explosion](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/supplementary-guidelines.md#aggregation-temporality)
+
+For general-purpose HTTP instrumentations the list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO View API to override instrumentation defaults.
+Applications MAY override instrumentation defaults using [view](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view) TODO property.
 
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -61,9 +61,6 @@ HTTP server span names SHOULD be `{http.request.method}` if there is no (low-car
 HTTP client spans have no `http.route` attribute since client-side instrumentation
 is not generally aware of the "route", and therefore HTTP client spans SHOULD use
 `{http.request.method}`.
-
-If HTTP method used is not known to the instrumentation, it MAY use `other` instead of an unknown method captured in `http.request.method` attribute.
-
 Instrumentation MUST NOT default to using URI
 path as span name, but MAY provide hooks to allow custom logic to override the
 default span name.
@@ -95,42 +92,20 @@ sections below.
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
 | `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
-| `http.request.method` | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
 | [`network.protocol.name`](span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `http`; `spdy` | Recommended: if not default (`http`). |
-| [`network.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [2] | `1.0`; `1.1`; `2.0` | Recommended |
-| [`network.transport`](span-general.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Conditionally Required: [3] |
+| [`network.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [1] | `1.0`; `1.1`; `2.0` | Recommended |
+| [`network.transport`](span-general.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Conditionally Required: [2] |
 | [`network.type`](span-general.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
 | `user_agent.original` | string | Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | Recommended |
 
-**[1]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
-[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
+**[1]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
-If the HTTP request method is not known to the instrumentation, metrics instrumentations MAY set `other` as the attribute value.
-
-**[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
-
-**[3]:** If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
+**[2]:** If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
 
 Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
 
 * `http.request.method`
-
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 
 `network.transport` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -102,12 +102,12 @@ sections below.
 **[1]:** The HTTP request method usually contains one of a standard methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 or [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-Instrumentations SHOULD call into TODO advice API (when available) before recording any telemetry
-and specify a list of known HTTP request methods. For general-purpose HTTP instrumentations this list SHOULD include common request methods:
+Instrumentations SHOULD call into TODO advice API (when available) and specify a list of known HTTP request methods.
+For general-purpose HTTP instrumentations this list SHOULD include common request methods:
 `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`.
-Applications MAY use TODO advice API to override instrumentation defaults.
+Applications MAY use TODO View API to override instrumentation defaults.
 
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate the canonical name.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, MAY uppercase HTTP method and populate canonical names.
 
 **[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -61,6 +61,9 @@ HTTP server span names SHOULD be `{http.request.method}` if there is no (low-car
 HTTP client spans have no `http.route` attribute since client-side instrumentation
 is not generally aware of the "route", and therefore HTTP client spans SHOULD use
 `{http.request.method}`.
+
+If HTTP method used is not known to the instrumentation, it MAY use `other` instead of an unknown method captured in `http.request.method` attribute.
+
 Instrumentation MUST NOT default to using URI
 path as span name, but MAY provide hooks to allow custom logic to override the
 default span name.
@@ -92,20 +95,42 @@ sections below.
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
 | `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
-| `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| `http.request.method` | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
 | [`network.protocol.name`](span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `http`; `spdy` | Recommended: if not default (`http`). |
-| [`network.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [1] | `1.0`; `1.1`; `2.0` | Recommended |
-| [`network.transport`](span-general.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Conditionally Required: [2] |
+| [`network.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [2] | `1.0`; `1.1`; `2.0` | Recommended |
+| [`network.transport`](span-general.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Conditionally Required: [3] |
 | [`network.type`](span-general.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
 | `user_agent.original` | string | Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | Recommended |
 
-**[1]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[1]:** HTTP request method SHOULD be one of the methods defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+or the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+Instrumentation MAY additionally support the closed set of custom HTTP methods defined in
+[HTTP method registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) or a private registry.
 
-**[2]:** If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
+If the HTTP request method is not known to the instrumentation, metrics instrumentations MAY set `other` as the attribute value.
+
+**[2]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[3]:** If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
 
 Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
 
 * `http.request.method`
+
+`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `CONNECT` | CONNECT method. |
+| `DELETE` | DELETE method. |
+| `GET` | GET method. |
+| `HEAD` | HEAD method. |
+| `OPTIONS` | OPTIONS method. |
+| `PATCH` | PATCH method. |
+| `POST` | POST method. |
+| `PUT` | PUT method. |
+| `TRACE` | TRACE method. |
+| `other` | Any custom HTTP method that the instrumentation has no prior knowledge of. |
 
 `network.transport` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 


### PR DESCRIPTION
Option C/E from #17 :
- don't try to fix the method on the instrumentation side
- recommend instrumentation to call a metric-only advice API
  - the SHOULD provide a (short/common) method list by default 
  - OTel will let users override it with a custom set
- Give up on span name low cardinality in edge cases, see #3534 for details

Pros:
- generic solution for any attribute
- advice API can use the same value for extra values (e.g. `__DIMENSION_CAP` or another magic string consistent for all attributes value)

Trade-offs:
- querying across signals is still non-trivial. It can still work with backend help translating match to `__DIMENSION_CAP` magic string to a query like `not in(methods_used_on_metrics_set)`. Or there could be another backend solution to the query-by-capped-method-across-signals problem
- HTTP semconv can go stable as is. Instrumentations would probably wait for advice API to materialize before they can go stable to avoid breaking changes.
 