### PR TITLE
Update CHANGELOG with missing entry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,5 +59,8 @@ release.
   ([#3355](https://github.com/open-telemetry/opentelemetry-specification/pull/3355))
 - Add `gcp.cloud_run.job.execution` and `gcp.cloud_run.job.task_id` resource
   attributes for GCP Cloud Run Jobs ([#3378](https://github.com/open-telemetry/opentelemetry-specification/pull/3378))
+- Specify second unit (`s`) and advice bucket boundaries of `[]`
+  for `process.runtime.jvm.gc.duration`.
+  ([#3458](https://github.com/open-telemetry/opentelemetry-specification/pull/3458))
 - Specify the value range for JVM CPU metrics.
   ([#13](https://github.com/open-telemetry/semantic-conventions/pull/13))


### PR DESCRIPTION
That would be [#3458](https://github.com/open-telemetry/opentelemetry-specification/pull/3458), which had been included in the metrics section (instead of semantic conventions) of the CHANGELOG.