### PR TITLE
Rename `process.runtime.jvm.cpu.utilization` to `process.runtime.jvm.cpu.recent_utilization`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,5 @@ release.
   ([#3458](https://github.com/open-telemetry/opentelemetry-specification/pull/3458))
 - Specify the value range for JVM CPU metrics.
   ([#13](https://github.com/open-telemetry/semantic-conventions/pull/13))
+- Rename `process.runtime.jvm.cpu.utilization` to `process.runtime.jvm.cpu.recent_utilization`.
+  ([#53](https://github.com/open-telemetry/semantic-conventions/pull/53))

--- a/schemas/1.21.0
+++ b/schemas/1.21.0
@@ -44,7 +44,12 @@ versions:
               http.scheme: url.scheme
               http.url: url.full
               http.request_content_length: http.request.body.size
-              http.response_content_length: http.response.body.size  
+              http.response_content_length: http.response.body.size
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/53
+        - rename_metrics:
+            process.runtime.jvm.cpu.utilization: process.runtime.jvm.cpu.recent_utilization
   1.20.0:
     spans:
       changes:

--- a/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
+++ b/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
@@ -122,9 +122,9 @@ groups:
     instrument: updowncounter
     unit: "{class}"
 
-  - id: metric.process.runtime.jvm.cpu.utilization
+  - id: metric.process.runtime.jvm.cpu.recent_utilization
     type: metric
-    metric_name: process.runtime.jvm.cpu.utilization
+    metric_name: process.runtime.jvm.cpu.recent_utilization
     brief: "Recent CPU utilization for the process."
     note: >
       The value range is [0.0,1.0].

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -30,7 +30,7 @@ semantic conventions when instrumenting runtime environments.
   * [Metric: `process.runtime.jvm.classes.loaded`](#metric-processruntimejvmclassesloaded)
   * [Metric: `process.runtime.jvm.classes.unloaded`](#metric-processruntimejvmclassesunloaded)
   * [Metric: `process.runtime.jvm.classes.current_loaded`](#metric-processruntimejvmclassescurrent_loaded)
-  * [Metric: `process.runtime.jvm.cpu.utilization`](#metric-processruntimejvmcpuutilization)
+  * [Metric: `process.runtime.jvm.cpu.recent_utilization`](#metric-processruntimejvmcpurecent_utilization)
   * [Metric: `process.runtime.jvm.system.cpu.utilization`](#metric-processruntimejvmsystemcpuutilization)
   * [Metric: `process.runtime.jvm.system.cpu.load_1m`](#metric-processruntimejvmsystemcpuload_1m)
   * [Metric: `process.runtime.jvm.buffer.usage`](#metric-processruntimejvmbufferusage)
@@ -297,19 +297,20 @@ This metric is obtained from [`ClassLoadingMXBean#getLoadedClassCount()`](https:
 <!-- semconv metric.process.runtime.jvm.classes.current_loaded(full) -->
 <!-- endsemconv -->
 
-### Metric: `process.runtime.jvm.cpu.utilization`
+### Metric: `process.runtime.jvm.cpu.recent_utilization`
 
 This metric is [recommended][MetricRecommended].
 This metric is obtained from [`com.sun.management.OperatingSystemMXBean#getProcessCpuLoad()`](https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getProcessCpuLoad()) on HotSpot
 and [`com.ibm.lang.management.OperatingSystemMXBean#getProcessCpuLoad()`](https://www.ibm.com/docs/api/v1/content/SSYKE2_8.0.0/com.ibm.java.api.80.doc/com.ibm.lang.management/com/ibm/lang/management/OperatingSystemMXBean.html#getProcessCpuLoad--) on J9.
+Note that the JVM does not provide a definition of what "recent" means.
 
-<!-- semconv metric.process.runtime.jvm.cpu.utilization(metric_table) -->
+<!-- semconv metric.process.runtime.jvm.cpu.recent_utilization(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `process.runtime.jvm.cpu.utilization` | Gauge | `1` | Recent CPU utilization for the process. |
+| `process.runtime.jvm.cpu.recent_utilization` | Gauge | `1` | Recent CPU utilization for the process. |
 <!-- endsemconv -->
 
-<!-- semconv metric.process.runtime.jvm.cpu.utilization(full) -->
+<!-- semconv metric.process.runtime.jvm.cpu.recent_utilization(full) -->
 <!-- endsemconv -->
 
 ### Metric: `process.runtime.jvm.system.cpu.utilization`


### PR DESCRIPTION
Fixes #42

Renames `process.runtime.jvm.cpu.utilization` to `process.runtime.jvm.cpu.recent_utilization` to make it clear that this is not "utilization since last measurement" (or "utilization since start").