### PR TITLE
Clarify `process.runtime.jvm.threads.count` refers to platform threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,5 @@ release.
   ([#3458](https://github.com/open-telemetry/opentelemetry-specification/pull/3458))
 - Specify the value range for JVM CPU metrics.
   ([#13](https://github.com/open-telemetry/semantic-conventions/pull/13))
+- Clarify `process.runtime.jvm.threads.count` refers to platform threads.
+  ([#54](https://github.com/open-telemetry/semantic-conventions/pull/54))

--- a/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
+++ b/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
@@ -92,7 +92,7 @@ groups:
   - id: metric.process.runtime.jvm.threads.count
     type: metric
     metric_name: process.runtime.jvm.threads.count
-    brief: "Number of executing threads."
+    brief: "Number of executing platform threads."
     instrument: updowncounter
     unit: "{thread}"
     attributes:

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -242,11 +242,12 @@ of `[]` (single bucket histogram capturing count, sum, min, max).
 This metric is [recommended][MetricRecommended].
 This metric is obtained from [`ThreadMXBean#getDaemonThreadCount()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getDaemonThreadCount--) and
 [`ThreadMXBean#getThreadCount()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getThreadCount--).
+Note that this is the number of platform threads (as opposed to virtual threads).
 
 <!-- semconv metric.process.runtime.jvm.threads.count(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `process.runtime.jvm.threads.count` | UpDownCounter | `{thread}` | Number of executing threads. |
+| `process.runtime.jvm.threads.count` | UpDownCounter | `{thread}` | Number of executing platform threads. |
 <!-- endsemconv -->
 
 <!-- semconv metric.process.runtime.jvm.threads.count(full) -->


### PR DESCRIPTION
Fixes #49

Clarifies that `process.runtime.jvm.threads.count` refers to platform threads, as opposed to virtual threads.