### PR TITLE
Add `process.runtime.jvm.cpu.time` metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,5 @@ release.
   ([#3458](https://github.com/open-telemetry/opentelemetry-specification/pull/3458))
 - Specify the value range for JVM CPU metrics.
   ([#13](https://github.com/open-telemetry/semantic-conventions/pull/13))
+- Add `process.runtime.jvm.cpu.time` metric.
+  ([#55](https://github.com/open-telemetry/semantic-conventions/pull/55))

--- a/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
+++ b/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
@@ -122,6 +122,13 @@ groups:
     instrument: updowncounter
     unit: "{class}"
 
+  - id: metric.process.runtime.jvm.cpu.time
+    type: metric
+    metric_name: process.runtime.jvm.cpu.time
+    brief: "Number of classes currently loaded."
+    instrument: counter
+    unit: "s"
+
   - id: metric.process.runtime.jvm.cpu.utilization
     type: metric
     metric_name: process.runtime.jvm.cpu.utilization

--- a/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
+++ b/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
@@ -125,7 +125,7 @@ groups:
   - id: metric.process.runtime.jvm.cpu.time
     type: metric
     metric_name: process.runtime.jvm.cpu.time
-    brief: "Number of classes currently loaded."
+    brief: "CPU time used by the process."
     instrument: counter
     unit: "s"
 

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -304,7 +304,7 @@ This metric is obtained from [`ClassLoadingMXBean#getLoadedClassCount()`](https:
 This metric is [recommended][MetricRecommended].
 
 This metric is obtained from [`com.sun.management.OperatingSystemMXBean#getProcessCpuTime()`](https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getProcessCpuTime()) on HotSpot
-and [`com.ibm.lang.management.OperatingSystemMXBean#getProcessCpuTime()`](https://www.ibm.com/docs/api/v1/content/SSYKE2_8.0.0/com.ibm.java.api.80.doc/com.ibm.lang.management/com/ibm/lang/management/OperatingSystemMXBean.html#getProcessCpuTime--) on J9.
+and [`com.ibm.lang.management.OperatingSystemMXBean#getProcessCpuTime()`](https://www.ibm.com/docs/api/v1/content/SSYKE2_8.0.0/openj9/api/jdk8/jre/management/extension/com/ibm/lang/management/OperatingSystemMXBean.html#getProcessCpuTime--) on J9.
 
 <!-- semconv metric.process.runtime.jvm.cpu.time(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -30,6 +30,7 @@ semantic conventions when instrumenting runtime environments.
   * [Metric: `process.runtime.jvm.classes.loaded`](#metric-processruntimejvmclassesloaded)
   * [Metric: `process.runtime.jvm.classes.unloaded`](#metric-processruntimejvmclassesunloaded)
   * [Metric: `process.runtime.jvm.classes.current_loaded`](#metric-processruntimejvmclassescurrent_loaded)
+  * [Metric: `process.runtime.jvm.cpu.time`](#metric-processruntimejvmcputime)
   * [Metric: `process.runtime.jvm.cpu.utilization`](#metric-processruntimejvmcpuutilization)
   * [Metric: `process.runtime.jvm.system.cpu.utilization`](#metric-processruntimejvmsystemcpuutilization)
   * [Metric: `process.runtime.jvm.system.cpu.load_1m`](#metric-processruntimejvmsystemcpuload_1m)
@@ -295,6 +296,22 @@ This metric is obtained from [`ClassLoadingMXBean#getLoadedClassCount()`](https:
 <!-- endsemconv -->
 
 <!-- semconv metric.process.runtime.jvm.classes.current_loaded(full) -->
+<!-- endsemconv -->
+
+### Metric: `process.runtime.jvm.cpu.time`
+
+This metric is [recommended][MetricRecommended].
+
+This metric is obtained from [`com.sun.management.OperatingSystemMXBean#getProcessCpuTime()`](https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getProcessCpuTime()) on HotSpot
+and [`com.ibm.lang.management.OperatingSystemMXBean#getProcessCpuTime()`](https://www.ibm.com/docs/api/v1/content/SSYKE2_8.0.0/com.ibm.java.api.80.doc/com.ibm.lang.management/com/ibm/lang/management/OperatingSystemMXBean.html#getProcessCpuTime--) on J9.
+
+<!-- semconv metric.process.runtime.jvm.cpu.time(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `process.runtime.jvm.cpu.time` | Counter | `s` | Number of classes currently loaded. |
+<!-- endsemconv -->
+
+<!-- semconv metric.process.runtime.jvm.cpu.time(full) -->
 <!-- endsemconv -->
 
 ### Metric: `process.runtime.jvm.cpu.utilization`

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -308,7 +308,7 @@ and [`com.ibm.lang.management.OperatingSystemMXBean#getProcessCpuTime()`](https:
 <!-- semconv metric.process.runtime.jvm.cpu.time(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `process.runtime.jvm.cpu.time` | Counter | `s` | Number of classes currently loaded. |
+| `process.runtime.jvm.cpu.time` | Counter | `s` | CPU time used by the process. |
 <!-- endsemconv -->
 
 <!-- semconv metric.process.runtime.jvm.cpu.time(full) -->


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/3490

Adds `process.runtime.jvm.cpu.time` metric.