### PR TITLE
HTTP duration metrics should match HTTP span duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,5 @@ release.
   ([#13](https://github.com/open-telemetry/semantic-conventions/pull/13))
 - Clarify `process.runtime.jvm.threads.count` refers to platform threads.
   ([#54](https://github.com/open-telemetry/semantic-conventions/pull/54))
+- Add note that HTTP duration metrics should match HTTP span duration.
+  ([#69](https://github.com/open-telemetry/semantic-conventions/pull/69))

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -56,6 +56,8 @@ operations. By adding HTTP attributes to metric events it allows for finely tune
 
 This metric is required.
 
+When this metric is reported alongside an HTTP server span, the metric value SHOULD be the same as the HTTP server span duration.
+
 This metric SHOULD be specified with
 [`ExplicitBucketBoundaries`](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.21.0/specification/metrics/api.md#instrument-advice)
 of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 ]`.
@@ -240,6 +242,8 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 ### Metric: `http.client.duration`
 
 This metric is required.
+
+When this metric is reported alongside an HTTP client span, the metric value SHOULD be the same as the HTTP client span duration.
 
 This metric SHOULD be specified with
 [`ExplicitBucketBoundaries`](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.21.0/specification/metrics/api.md#instrument-advice)


### PR DESCRIPTION
The purpose of this PR is to clarify one of the easier questions that came up as part of https://github.com/open-telemetry/opentelemetry-specification/issues/3520.

I don't think I worded it great, if anyone has suggestions 🙇‍♂️