### PR TITLE
Add container metrics fields from ECS

### DIFF
--- a/semantic_conventions/metrics/container.yaml
+++ b/semantic_conventions/metrics/container.yaml
@@ -1,0 +1,97 @@
+groups:
+  - id: metric.container.cpu.usage
+    type: metric
+    metric_name: container.cpu.usage
+    brief: "Recent CPU utilization for the container."
+    note: >
+      CPU usage percentage normalized by the number of CPU cores.
+      The value range is [0.0,1.0].
+    instrument: gauge
+    unit: "1"
+    attributes:
+      - ref: container.name
+      - ref: container.id
+      - ref: container.runtime
+      - ref: container.image.name
+      - ref: container.image.tag
+  - id: metric.container.memory.usage
+    type: metric
+    metric_name: container.memory.usage
+    brief: "Recent memory utilization for the container."
+    note: >
+      Memory usage percentage.
+      The value range is [0.0,1.0].
+    instrument: gauge
+    unit: "1"
+    attributes:
+      - ref: container.name
+      - ref: container.id
+      - ref: container.runtime
+      - ref: container.image.name
+      - ref: container.image.tag
+  - id: metric.container.disk.read.bytes
+    type: metric
+    metric_name: container.disk.read.bytes
+    brief: "Disk read bytes for the container."
+    note: >
+      The total number of bytes read
+      successfully (aggregated from all disks)
+      since the last metric collection.
+    instrument: gauge
+    unit: "By"
+    attributes:
+      - ref: container.name
+      - ref: container.id
+      - ref: container.runtime
+      - ref: container.image.name
+      - ref: container.image.tag
+  - id: metric.container.disk.write.bytes
+    type: metric
+    metric_name: container.disk.write.bytes
+    brief: "Disk write bytes for the container."
+    note: >
+      The total number of bytes written 
+      successfully (aggregated from all disks)
+      since the last metric collection
+    instrument: gauge
+    unit: "By"
+    attributes:
+      - ref: container.name
+      - ref: container.id
+      - ref: container.runtime
+      - ref: container.image.name
+      - ref: container.image.tag
+  - id: metric.container.network.ingress.bytes
+    type: metric
+    metric_name: container.network.ingress.bytes
+    brief: "Network ingress bytes for the container."
+    note: >
+      The number of bytes received
+      on all network interfaces
+      by the container since
+      the last metric collection.
+    instrument: gauge
+    unit: "By"
+    attributes:
+      - ref: container.name
+      - ref: container.id
+      - ref: container.runtime
+      - ref: container.image.name
+      - ref: container.image.tag
+  - id: metric.container.network.egress.bytes
+    type: metric
+    metric_name: container.network.egress.bytes
+    brief: "Network egress bytes for the container."
+    note: >
+      The number of bytes sent out
+      on all network interfaces
+      by the container since
+      the last metric collection.
+    instrument: gauge
+    unit: "By"
+    attributes:
+      - ref: container.name
+      - ref: container.id
+      - ref: container.runtime
+      - ref: container.image.name
+      - ref: container.image.tag

--- a/specification/metrics/semantic_conventions/container.md
+++ b/specification/metrics/semantic_conventions/container.md
@@ -1,0 +1,129 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: HTTP
+--->
+
+# Semantic Conventions for Container Metrics
+
+**Status**: [Experimental][DocumentStatus]
+
+## HTTP Server
+
+### Metric: `metric.container.cpu.usage`
+
+This metric is optional.
+
+<!-- semconv metric.container.cpu.usage(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `container.cpu.usage` | Gauge | `1` | Recent CPU utilization for the container. |
+<!-- endsemconv -->
+
+<!-- semconv metric.container.cpu.usage(full) -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`container.id`](../../resource/semantic_conventions/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+| [`container.image.name`](../../resource/semantic_conventions/container.md) | string | Name of the image the container was built on. | `gcr.io/opentelemetry/operator` | Recommended |
+| [`container.image.tag`](../../resource/semantic_conventions/container.md) | string | Container image tag. | `0.1` | Recommended |
+| [`container.name`](../../resource/semantic_conventions/container.md) | string | Container name used by container runtime. | `opentelemetry-autoconf` | Recommended |
+| [`container.runtime`](../../resource/semantic_conventions/container.md) | string | The container runtime managing this container. | `docker`; `containerd`; `rkt` | Recommended |
+<!-- endsemconv -->
+
+### Metric: `metric.container.memory.usage`
+
+This metric is optional.
+
+<!-- semconv metric.container.memory.usage(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `container.memory.usage` | Gauge | `1` | Recent memory utilization for the container. |
+<!-- endsemconv -->
+
+<!-- semconv metric.container.memory.usage(full) -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`container.id`](../../resource/semantic_conventions/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+| [`container.image.name`](../../resource/semantic_conventions/container.md) | string | Name of the image the container was built on. | `gcr.io/opentelemetry/operator` | Recommended |
+| [`container.image.tag`](../../resource/semantic_conventions/container.md) | string | Container image tag. | `0.1` | Recommended |
+| [`container.name`](../../resource/semantic_conventions/container.md) | string | Container name used by container runtime. | `opentelemetry-autoconf` | Recommended |
+| [`container.runtime`](../../resource/semantic_conventions/container.md) | string | The container runtime managing this container. | `docker`; `containerd`; `rkt` | Recommended |
+<!-- endsemconv -->
+
+### Metric: `metric.container.disk.read.bytes`
+
+This metric is optional.
+
+<!-- semconv metric.container.disk.read.bytes(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `container.disk.read.bytes` | Gauge | `By` | Disk read bytes for the container. |
+<!-- endsemconv -->
+
+<!-- semconv metric.container.disk.read.bytes(full) -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`container.id`](../../resource/semantic_conventions/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+| [`container.image.name`](../../resource/semantic_conventions/container.md) | string | Name of the image the container was built on. | `gcr.io/opentelemetry/operator` | Recommended |
+| [`container.image.tag`](../../resource/semantic_conventions/container.md) | string | Container image tag. | `0.1` | Recommended |
+| [`container.name`](../../resource/semantic_conventions/container.md) | string | Container name used by container runtime. | `opentelemetry-autoconf` | Recommended |
+| [`container.runtime`](../../resource/semantic_conventions/container.md) | string | The container runtime managing this container. | `docker`; `containerd`; `rkt` | Recommended |
+<!-- endsemconv -->
+
+### Metric: `metric.container.disk.write.bytes`
+
+This metric is optional.
+
+<!-- semconv metric.container.disk.write.bytes(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `container.disk.write.bytes` | Gauge | `By` | Disk write bytes for the container. |
+<!-- endsemconv -->
+
+<!-- semconv metric.container.disk.write.bytes(full) -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`container.id`](../../resource/semantic_conventions/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+| [`container.image.name`](../../resource/semantic_conventions/container.md) | string | Name of the image the container was built on. | `gcr.io/opentelemetry/operator` | Recommended |
+| [`container.image.tag`](../../resource/semantic_conventions/container.md) | string | Container image tag. | `0.1` | Recommended |
+| [`container.name`](../../resource/semantic_conventions/container.md) | string | Container name used by container runtime. | `opentelemetry-autoconf` | Recommended |
+| [`container.runtime`](../../resource/semantic_conventions/container.md) | string | The container runtime managing this container. | `docker`; `containerd`; `rkt` | Recommended |
+<!-- endsemconv -->
+
+### Metric: `metric.container.network.ingress.bytes`
+
+This metric is optional.
+
+<!-- semconv metric.container.network.ingress.bytes(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `container.network.ingress.bytes` | Gauge | `By` | Network ingress bytes for the container. |
+<!-- endsemconv -->
+
+<!-- semconv metric.container.network.ingress.bytes(full) -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`container.id`](../../resource/semantic_conventions/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+| [`container.image.name`](../../resource/semantic_conventions/container.md) | string | Name of the image the container was built on. | `gcr.io/opentelemetry/operator` | Recommended |
+| [`container.image.tag`](../../resource/semantic_conventions/container.md) | string | Container image tag. | `0.1` | Recommended |
+| [`container.name`](../../resource/semantic_conventions/container.md) | string | Container name used by container runtime. | `opentelemetry-autoconf` | Recommended |
+| [`container.runtime`](../../resource/semantic_conventions/container.md) | string | The container runtime managing this container. | `docker`; `containerd`; `rkt` | Recommended |
+<!-- endsemconv -->
+
+### Metric: `metric.container.network.egress.bytes`
+
+This metric is optional.
+
+<!-- semconv metric.container.network.egress.bytes(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `container.network.egress.bytes` | Gauge | `By` | Network egress bytes for the container. |
+<!-- endsemconv -->
+
+<!-- semconv metric.container.network.egress.bytes(full) -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`container.id`](../../resource/semantic_conventions/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+| [`container.image.name`](../../resource/semantic_conventions/container.md) | string | Name of the image the container was built on. | `gcr.io/opentelemetry/operator` | Recommended |
+| [`container.image.tag`](../../resource/semantic_conventions/container.md) | string | Container image tag. | `0.1` | Recommended |
+| [`container.name`](../../resource/semantic_conventions/container.md) | string | Container name used by container runtime. | `opentelemetry-autoconf` | Recommended |
+| [`container.runtime`](../../resource/semantic_conventions/container.md) | string | The container runtime managing this container. | `docker`; `containerd`; `rkt` | Recommended |
+<!-- endsemconv -->


### PR DESCRIPTION
This PR adds container related metrics fields as part of https://github.com/open-telemetry/semantic-conventions/issues/72.


cc: @AlexanderWert @kaiyan-sheng @mlunadia