### PR TITLE
Fix the unit of metric.process.runtime.jvm.system.cpu.load_1m to be {run_queue_item}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ release.
 
 ## Unreleased
 
+- Fix the unit of metric.process.runtime.jvm.system.cpu.load_1m to be {run_queue_item}
+  ([#95](https://github.com/open-telemetry/semantic-conventions/pull/95))
+
 ## v1.21.0 (2023-07-13)
 
 Note: This is the first release of Semantic Conventions separate from the Specification.
 
 - Add GCP Bare Metal Solution as a cloud platform
- ([#64](https://github.com/open-telemetry/semantic-conventions/pull/64))
+  ([#64](https://github.com/open-telemetry/semantic-conventions/pull/64))
 - Clarify the scope of the HTTP client span.
- ([#3290](https://github.com/open-telemetry/opentelemetry-specification/pull/3290))
+  ([#3290](https://github.com/open-telemetry/opentelemetry-specification/pull/3290))
 - Add moratorium on relying on schema transformations for telemetry stability
   ([#3380](https://github.com/open-telemetry/opentelemetry-specification/pull/3380))
 - Mark "Instrumentation Units" and "Instrumentation Types" sections of the general

--- a/docs/system/runtime-environment-metrics.md
+++ b/docs/system/runtime-environment-metrics.md
@@ -363,7 +363,7 @@ This metric is obtained from [`OperatingSystemMXBean#getSystemLoadAverage()`](ht
 <!-- semconv metric.process.runtime.jvm.system.cpu.load_1m(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `process.runtime.jvm.system.cpu.load_1m` | Gauge | `1` | Average CPU load of the whole system for the last minute as reported by the JVM. [1] |
+| `process.runtime.jvm.system.cpu.load_1m` | Gauge | `{run_queue_item}` | Average CPU load of the whole system for the last minute as reported by the JVM. [1] |
 
 **[1]:** The value range is [0,n], where n is the number of CPU cores - or a negative number if the value is not available. This utilization is not defined as being for the specific interval since last measurement (unlike `system.cpu.utilization`). [Reference](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/OperatingSystemMXBean.html#getSystemLoadAverage()).
 <!-- endsemconv -->

--- a/model/metrics/process-runtime-jvm-metrics-experimental.yaml
+++ b/model/metrics/process-runtime-jvm-metrics-experimental.yaml
@@ -29,7 +29,7 @@ groups:
       (unlike `system.cpu.utilization`).
       [Reference](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/OperatingSystemMXBean.html#getSystemLoadAverage()).
     instrument: gauge
-    unit: "1"
+    unit: "{run_queue_item}"
 
   - id: attributes.process.runtime.jvm.buffer
     type: attribute_group


### PR DESCRIPTION
Fix the unit of metric.process.runtime.jvm.system.cpu.load_1m to be "{core}"

This is particularly obvious when you see that the the metric name is converted to `process_runtime_jvm_system_cpu_load_1m_ratio{}` in prometheus.
