### PR TITLE
Messaging: Remove `messaging.source.*` attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,5 @@ release.
   ([#55](https://github.com/open-telemetry/semantic-conventions/pull/55))
 - Split out sections for proposed stable JVM metrics and experimental JVM metrics.
   ([#56](https://github.com/open-telemetry/semantic-conventions/pull/56))
-- BREAKING: Remove `messaging.source.*` attributes and use `messaging.destination.*`
-  attributes on producer and consumer to describe messaging queue or topic.
+- BREAKING: Remove `messaging.source.*` attributes.
   ([#100](https://github.com/open-telemetry/semantic-conventions/pull/100))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,5 +84,6 @@ release.
   ([#55](https://github.com/open-telemetry/semantic-conventions/pull/55))
 - Split out sections for proposed stable JVM metrics and experimental JVM metrics.
   ([#56](https://github.com/open-telemetry/semantic-conventions/pull/56))
-- BREAKING: Remove `messaging.source.*` attributes.
+- BREAKING: Remove `messaging.source.*` attributes and use `messaging.destination.*`
+  attributes on producer and consumer to describe messaging queue or topic.
   ([#100](https://github.com/open-telemetry/semantic-conventions/pull/100))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,3 +74,6 @@ release.
   attributes for GCP Compute Engine VMs. ([#15](https://github.com/open-telemetry/semantic-conventions/pull/15))
 - Add note that HTTP duration metrics should match HTTP span duration.
   ([#69](https://github.com/open-telemetry/semantic-conventions/pull/69))
+- BREAKING: Remove `messaging.source.*` attributes and use `messaging.destination.*`
+  attributes on producer and consumer to describe messaging queue or topic.
+  ([#100](https://github.com/open-telemetry/semantic-conventions/pull/100))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ Note: This is the first release of Semantic Conventions separate from the Specif
 - Mark service.version as stable.
   ([#106](https://github.com/open-telemetry/semantic-conventions/pull/106))
 - Mark initial set of HTTP semantic conventions as frozen
-  ([#105](https://github.com/open-telemetry/semantic-conventions/pull/105))  
+  ([#105](https://github.com/open-telemetry/semantic-conventions/pull/105))
 - BREAKING: Remove `messaging.source.*` attributes and use `messaging.destination.*`
   attributes on producer and consumer to describe messaging queue or topic.
   ([#100](https://github.com/open-telemetry/semantic-conventions/pull/100))

--- a/schemas/1.21.0
+++ b/schemas/1.21.0
@@ -44,7 +44,14 @@ versions:
               http.scheme: url.scheme
               http.url: url.full
               http.request_content_length: http.request.body.size
-              http.response_content_length: http.response.body.size  
+              http.response_content_length: http.response.body.size
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/3450
+        - rename_attributes:
+            attribute_map:
+              messaging.source.name: messaging.destination_original.name
+              messaging.source.template: messaging.destination_original.template
+              messaging.source.temporary: messaging.destination_original.temporary
+              messaging.source.anonymous: messaging.destination_original.anonymous
   1.20.0:
     spans:
       changes:

--- a/schemas/1.21.0
+++ b/schemas/1.21.0
@@ -45,13 +45,6 @@ versions:
               http.url: url.full
               http.request_content_length: http.request.body.size
               http.response_content_length: http.response.body.size
-        # https://github.com/open-telemetry/opentelemetry-specification/pull/3450
-        - rename_attributes:
-            attribute_map:
-              messaging.source.name: messaging.destination_original.name
-              messaging.source.template: messaging.destination_original.template
-              messaging.source.temporary: messaging.destination_original.temporary
-              messaging.source.anonymous: messaging.destination_original.anonymous
     metrics:
       changes:
         # https://github.com/open-telemetry/semantic-conventions/pull/53

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -5,7 +5,7 @@ groups:
     brief: 'Semantic convention describing per-message attributes populated on messaging spans or links.'
     attributes:
       - ref: messaging.destination.name
-      - ref: messaging.source.name
+      - ref: messaging.destination_original.name
       - id: message.id
         type: string
         brief: 'A value used by the messaging system as an identifier for the message, represented as a string.'
@@ -31,6 +31,15 @@ groups:
     prefix: messaging.destination
     type: attribute_group
     brief: 'Semantic convention for attributes that describe messaging destination on broker'
+    note: |
+      Destination attributes should be set on publish, receive, or other spans
+      describing messaging operations.
+
+      Destination attributes should be set when the messaging operation handles
+      single messages. When the operation handles a batch of messages,
+      the destination attributes should only be applied when the attribute value
+      applies to all messages in the batch.
+      In other cases, destination attributes may be set on links.
     attributes:
       - id: name
         type: string
@@ -56,34 +65,47 @@ groups:
         type: boolean
         brief: 'A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).'
 
-  - id: messaging.source
-    prefix: messaging.source
+  - id: messaging.destination_original
+    prefix: messaging.destination_original
     type: attribute_group
-    brief: 'Semantic convention for attributes that describe messaging source on broker'
+    brief: >
+      Semantic convention for attributes that describe original messaging destination on broker.
+      The term Original Destination refers to the destination the message was originally published to.
+      These attributes should be used on the consumer side when original destination
+      is available and different than destination message are consumed from.
+    note: |
+      Original destination attributes should be set on publish, receive,
+      or other spans describing messaging operations.
+
+      Destination attributes should be set when the messaging operation handles
+      single messages. When the operation handles a batch of messages,
+      the destination attributes should only be applied when the attribute value
+      applies to all messages in the batch.
+      In other cases, destination attributes may be set on links.
     attributes:
       - id: name
         type: string
-        brief: 'The message source name'
+        brief: 'The original destination name'
         note: |
-          Source name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
-          the broker does not have such notion, the source name SHOULD uniquely identify the broker.
+          The name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
+          the broker does not have such notion, the original destination name SHOULD uniquely identify the broker.
         examples: ['MyQueue', 'MyTopic']
       - id: template
         type: string
-        brief: 'Low cardinality representation of the messaging source name'
+        brief: 'Low cardinality representation of the original messaging destination name'
         examples: ['/customers/{customerId}']
         note: >
-          Source names could be constructed from templates.
-          An example would be a source name involving a user name or product id.
-          Although the source name in this case is of high cardinality,
+          Destination names could be constructed from templates.
+          An example would be a destination name involving a user name or product id.
+          Although the destination name in this case is of high cardinality,
           the underlying template is of low cardinality and can be effectively
           used for grouping and aggregation.
       - id: temporary
         type: boolean
-        brief: 'A boolean that is true if the message source is temporary and might not exist anymore after messages are processed.'
+        brief: 'A boolean that is true if the original message destination is temporary and might not exist anymore after messages are processed.'
       - id: anonymous
         type: boolean
-        brief: 'A boolean that is true if the message source is anonymous (could be unnamed or have auto-generated name).'
+        brief: 'A boolean that is true if the original message destination is anonymous (could be unnamed or have auto-generated name).'
 
   - id: messaging
     prefix: messaging
@@ -129,6 +151,20 @@ groups:
         brief: >
           A unique identifier for the client that consumes or produces a message.
         examples: ['client-5', 'myhost@8742@s8083jm']
+      - ref: messaging.destination.name
+        requirement_level:
+          conditionally_required: If span describes operation on a single message or if the value applies to all messages in the batch.
+      - ref: messaging.destination.template
+        requirement_level:
+          conditionally_required: >
+            If available. Instrumentations MUST NOT use `messaging.destination.name` as template
+            unless low-cardinality of destination name is guaranteed.
+      - ref: messaging.destination.temporary
+        requirement_level:
+          conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
+      - ref: messaging.destination.anonymous
+        requirement_level:
+          conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
       - ref: messaging.message.id
         requirement_level:
           recommended: Only for spans that represent an operation on a single message.
@@ -162,37 +198,6 @@ groups:
         examples: ['amqp', 'mqtt']
       - ref: network.protocol.version
 
-  - id: messaging.producer
-    prefix: messaging
-    type: span
-    extends: messaging
-    span_kind: producer
-    brief: 'Semantic convention for producers of messages sent to a messaging systems.'
-    attributes:
-      - ref: messaging.destination.name
-        requirement_level:
-          conditionally_required: If one message is being published or if the value applies to all messages in the batch.
-      - ref: messaging.destination.template
-        requirement_level:
-          conditionally_required: >
-            If available. Instrumentations MUST NOT use `messaging.destination.name` as template
-            unless low-cardinality of destination name is guaranteed.
-      - ref: messaging.destination.temporary
-        requirement_level:
-          conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
-      - ref: messaging.destination.anonymous
-        requirement_level:
-          conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
-
-  - id: messaging.producer.synchronous
-    prefix: messaging
-    type: span
-    extends: messaging
-    span_kind: client
-    brief: >
-      Semantic convention for clients of messaging systems that produce messages
-      and synchronously wait for responses.
-
   - id: messaging.consumer
     prefix: messaging
     type: span
@@ -200,38 +205,10 @@ groups:
     span_kind: consumer
     brief: 'Semantic convention for a consumer of messages received from a messaging system'
     attributes:
-      - ref: messaging.source.name
-        requirement_level:
-          conditionally_required: If the value applies to all messages in the batch.
-      - ref: messaging.source.template
-        requirement_level:
-          conditionally_required: >
-            If available. Instrumentations MUST NOT use `messaging.source.name` as template
-            unless low-cardinality of source name is guaranteed.
-      - ref: messaging.source.temporary
-        requirement_level:
-          recommended: When supported by messaging system and only if the source is temporary. When missing, the value is assumed to be `false`.
-      - ref: messaging.source.anonymous
-        requirement_level:
-          recommended: When supported by messaging system and only if the source is anonymous. When missing, the value is assumed to be `false`.
-      - ref: messaging.destination.name
-        requirement_level:
-          recommended: If known on consumer
-      - ref: messaging.destination.temporary
-        requirement_level:
-          recommended: If known on consumer
-      - ref: messaging.destination.anonymous
-        requirement_level:
-          recommended: If known on consumer
-
-  - id: messaging.consumer.synchronous
-    prefix: messaging
-    type: span
-    extends: messaging.consumer
-    span_kind: server
-    brief: >
-      Semantic convention for servers that consume messages received from messaging systems
-      and always send back replies directed to the producers of these messages.
+      - ref: messaging.destination_original.name
+      - ref: messaging.destination_original.template
+      - ref: messaging.destination_original.temporary
+      - ref: messaging.destination_original.anonymous
 
   - id: messaging.rabbitmq
     prefix: messaging.rabbitmq
@@ -275,11 +252,6 @@ groups:
         type: int
         brief: >
           Partition the message is sent to.
-        examples: 2
-      - id: source.partition
-        type: int
-        brief: >
-          Partition the message is received from.
         examples: 2
       - id: message.offset
         type: int

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -5,7 +5,6 @@ groups:
     brief: 'Semantic convention describing per-message attributes populated on messaging spans or links.'
     attributes:
       - ref: messaging.destination.name
-      - ref: messaging.destination_original.name
       - id: message.id
         type: string
         brief: 'A value used by the messaging system as an identifier for the message, represented as a string.'
@@ -64,48 +63,6 @@ groups:
       - id: anonymous
         type: boolean
         brief: 'A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).'
-
-  - id: messaging.destination_original
-    prefix: messaging.destination_original
-    type: attribute_group
-    brief: >
-      Semantic convention for attributes that describe original messaging destination on broker.
-      The term Original Destination refers to the destination the message was originally published to.
-      These attributes should be used on the consumer side when original destination
-      is available and different than destination message are consumed from.
-    note: |
-      Original destination attributes should be set on publish, receive,
-      or other spans describing messaging operations.
-
-      Destination attributes should be set when the messaging operation handles
-      single messages. When the operation handles a batch of messages,
-      the destination attributes should only be applied when the attribute value
-      applies to all messages in the batch.
-      In other cases, destination attributes may be set on links.
-    attributes:
-      - id: name
-        type: string
-        brief: 'The original destination name'
-        note: |
-          The name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
-          the broker does not have such notion, the original destination name SHOULD uniquely identify the broker.
-        examples: ['MyQueue', 'MyTopic']
-      - id: template
-        type: string
-        brief: 'Low cardinality representation of the original messaging destination name'
-        examples: ['/customers/{customerId}']
-        note: >
-          Destination names could be constructed from templates.
-          An example would be a destination name involving a user name or product id.
-          Although the destination name in this case is of high cardinality,
-          the underlying template is of low cardinality and can be effectively
-          used for grouping and aggregation.
-      - id: temporary
-        type: boolean
-        brief: 'A boolean that is true if the original message destination is temporary and might not exist anymore after messages are processed.'
-      - id: anonymous
-        type: boolean
-        brief: 'A boolean that is true if the original message destination is anonymous (could be unnamed or have auto-generated name).'
 
   - id: messaging
     prefix: messaging
@@ -197,18 +154,6 @@ groups:
       - ref: network.protocol.name
         examples: ['amqp', 'mqtt']
       - ref: network.protocol.version
-
-  - id: messaging.consumer
-    prefix: messaging
-    type: span
-    extends: messaging
-    span_kind: consumer
-    brief: 'Semantic convention for a consumer of messages received from a messaging system'
-    attributes:
-      - ref: messaging.destination_original.name
-      - ref: messaging.destination_original.template
-      - ref: messaging.destination_original.temporary
-      - ref: messaging.destination_original.anonymous
 
   - id: messaging.rabbitmq
     prefix: messaging.rabbitmq

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -22,6 +22,7 @@
   * [Operation names](#operation-names)
 - [Messaging attributes](#messaging-attributes)
   * [Attribute namespaces](#attribute-namespaces)
+  * [Consumer attributes](#consumer-attributes)
   * [Per-message attributes](#per-message-attributes)
   * [Attributes specific to certain messaging systems](#attributes-specific-to-certain-messaging-systems)
     + [RabbitMQ](#rabbitmq)
@@ -297,6 +298,15 @@ as described in [Attributes specific to certain messaging systems](#attributes-s
 [network attributes]: span-general.md#server-and-client-attributes
 [`network.transport`]: span-general.md#network-attributes
 [Hangfire]: https://www.hangfire.io/
+
+### Consumer attributes
+
+The *receive* span is used to track the time used for receiving the message(s), whereas the *process* span(s) track the time for processing the message(s).
+Note that one or multiple Spans with `messaging.operation` = `process` may often be the children of a Span with `messaging.operation` = `receive`.
+The distinction between receiving and processing of messages is not always of particular interest or sometimes hidden away in a framework (see the [Message consumption](#message-consumption) section above) and therefore the attribute can be left out.
+For batch receiving and processing (see the [Batch receiving](#batch-receiving) and [Batch processing](#batch-processing) examples below) in particular, the attribute SHOULD be set.
+Even though in that case one might think that the processing span's kind should be `INTERNAL`, that kind MUST NOT be used.
+Instead span kind should be set to either `CONSUMER` or `SERVER` according to the rules defined above.
 
 ### Per-message attributes
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -229,7 +229,7 @@ The following operations related to messages are defined for these semantic conv
 | [`network.transport`](span-general.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Recommended |
 | [`network.type`](span-general.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
 | [`server.address`](span-general.md) | string | Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is not known. [15] | `example.com` | Conditionally Required: If available. |
-| [`server.socket.address`](span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.socket.address`](span-general.md) | string | Physical server IP address or Unix socket address. If set from the client, should simply use the socket's peer address, and not attempt to find any actual server IP (i.e., if set from client, this may represent some proxy server instead of the logical server). | `10.5.3.2` | Recommended: If different than `server.address`. |
 | [`server.socket.domain`](span-general.md) | string | The domain name of an immediate peer. [16] | `proxy.example.com` | Recommended: [17] |
 | [`server.socket.port`](span-general.md) | int | Physical server port. | `16456` | Recommended: If different than `server.port`. |
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -11,7 +11,7 @@
   * [Producer](#producer)
   * [Consumer](#consumer)
   * [Intermediary](#intermediary)
-  * [Destinations and sources](#destinations-and-sources)
+  * [Destinations](#destinations)
   * [Message consumption](#message-consumption)
   * [Conversations](#conversations)
   * [Temporary and anonymous destinations](#temporary-and-anonymous-destinations)
@@ -22,7 +22,6 @@
   * [Operation names](#operation-names)
 - [Messaging attributes](#messaging-attributes)
   * [Attribute namespaces](#attribute-namespaces)
-  * [Producer attributes](#producer-attributes)
   * [Consumer attributes](#consumer-attributes)
   * [Per-message attributes](#per-message-attributes)
   * [Attributes specific to certain messaging systems](#attributes-specific-to-certain-messaging-systems)
@@ -99,14 +98,16 @@ process of notifying an intermediary that a message was processed successfully.
 An "intermediary" receives a message to forward it to the next receiver, which
 might be another intermediary or a consumer.
 
-### Destinations and sources
+### Destinations
 
-A destination is usually uniquely identified by name within the messaging system instance. Examples of a destination name would be a URL or a simple one-word identifier.
-Sending messages to a destination is called "*publish*" in context of this specification.
+A destination represents the entity within a messaging system where
+messages are published to and consumed from.
 
-A source represents an entity within messaging system messages are consumed from. Source and destination for specific message may be the same. However, if message is routed within one or multiple brokers, source and destination can be different.
+A destination is usually uniquely identified by its name within
+the messaging system instance.
+Examples of a destination name would be an URL or a simple one-word identifier.
 
-Typical examples of destinations and sources include Kafka topics, RabbitMQ queues and topics.
+Typical examples of destinations include Kafka topics, RabbitMQ queues and topics.
 
 ### Message consumption
 
@@ -214,17 +215,21 @@ The following operations related to messages are defined for these semantic conv
 | `messaging.operation` | string | A string identifying the kind of messaging operation as defined in the [Operation names](#operation-names) section above. [1] | `publish` | Required |
 | `messaging.batch.message_count` | int | The number of messages sent, received, or processed in the scope of the batching operation. [2] | `0`; `1`; `2` | Conditionally Required: [3] |
 | `messaging.client_id` | string | A unique identifier for the client that consumes or produces a message. | `client-5`; `myhost@8742@s8083jm` | Recommended: If a client id is available |
-| `messaging.message.conversation_id` | string | The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` | Recommended: [4] |
-| `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | Recommended: [5] |
-| `messaging.message.payload_compressed_size_bytes` | int | The compressed size of the message payload in bytes. | `2048` | Recommended: [6] |
-| `messaging.message.payload_size_bytes` | int | The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported. | `2738` | Recommended: [7] |
+| `messaging.destination.anonymous` | boolean | A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name). |  | Conditionally Required: [4] |
+| `messaging.destination.name` | string | The message destination name [5] | `MyQueue`; `MyTopic` | Conditionally Required: [6] |
+| `messaging.destination.template` | string | Low cardinality representation of the messaging destination name [7] | `/customers/{customerId}` | Conditionally Required: [8] |
+| `messaging.destination.temporary` | boolean | A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed. |  | Conditionally Required: [9] |
+| `messaging.message.conversation_id` | string | The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` | Recommended: [10] |
+| `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | Recommended: [11] |
+| `messaging.message.payload_compressed_size_bytes` | int | The compressed size of the message payload in bytes. | `2048` | Recommended: [12] |
+| `messaging.message.payload_size_bytes` | int | The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported. | `2738` | Recommended: [13] |
 | [`network.protocol.name`](span-general.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `mqtt` | Recommended |
-| [`network.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [8] | `3.1.1` | Recommended |
+| [`network.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [14] | `3.1.1` | Recommended |
 | [`network.transport`](span-general.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Recommended |
 | [`network.type`](span-general.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
-| [`server.address`](span-general.md) | string | Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is not known. [9] | `example.com` | Conditionally Required: If available. |
+| [`server.address`](span-general.md) | string | Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is not known. [15] | `example.com` | Conditionally Required: If available. |
 | [`server.socket.address`](span-general.md) | string | Physical server IP address or Unix socket address. | `10.5.3.2` | Recommended: If different than `server.address`. |
-| [`server.socket.domain`](span-general.md) | string | The domain name of an immediate peer. [10] | `proxy.example.com` | Recommended: [11] |
+| [`server.socket.domain`](span-general.md) | string | The domain name of an immediate peer. [16] | `proxy.example.com` | Recommended: [17] |
 | [`server.socket.port`](span-general.md) | int | Physical server port. | `16456` | Recommended: If different than `server.port`. |
 
 **[1]:** If a custom value is used, it MUST be of low cardinality.
@@ -233,21 +238,34 @@ The following operations related to messages are defined for these semantic conv
 
 **[3]:** If the span describes an operation on a batch of messages.
 
-**[4]:** Only if span represents operation on a single message.
+**[4]:** If value is `true`. When missing, the value is assumed to be `false`.
 
-**[5]:** Only for spans that represent an operation on a single message.
+**[5]:** Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
+the broker does not have such notion, the destination name SHOULD uniquely identify the broker.
 
-**[6]:** Only if span represents operation on a single message.
+**[6]:** If span describes operation on a single message or if the value applies to all messages in the batch.
 
-**[7]:** Only if span represents operation on a single message.
+**[7]:** Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
 
-**[8]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[8]:** If available. Instrumentations MUST NOT use `messaging.destination.name` as template unless low-cardinality of destination name is guaranteed.
 
-**[9]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
+**[9]:** If value is `true`. When missing, the value is assumed to be `false`.
 
-**[10]:** Typically observed from the client side, and represents a proxy or other intermediary domain name.
+**[10]:** Only if span represents operation on a single message.
 
-**[11]:** If different than `server.address` and if `server.socket.address` is set.
+**[11]:** Only for spans that represent an operation on a single message.
+
+**[12]:** Only if span represents operation on a single message.
+
+**[13]:** Only if span represents operation on a single message.
+
+**[14]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[15]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
+
+**[16]:** Typically observed from the client side, and represents a proxy or other intermediary domain name.
+
+**[17]:** If different than `server.address` and if `server.socket.address` is set.
 
 `messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -265,9 +283,10 @@ These attributes should be set to the broker to which the message is sent/from w
 ### Attribute namespaces
 
 - `messaging.message`: Contains attributes that describe individual messages
-- `messaging.destination`: Contains attributes that describe the logical entity messages are published to.
-  See [Destinations and sources](#destinations-and-sources) for more details
-- `messaging.source`: Contains attributes that describe the logical entity messages are received from
+- `messaging.destination`: Contains attributes that describe the logical entity
+   messages are published to and received from.
+   See [Destinations](#destinations) for more details
+- `messaging.destination_original`: Contains attributes that describe the logical entity messages were originally published to
 - `messaging.batch`: Contains attributes that describe batch operations
 - `messaging.consumer`: Contains attributes that describe application instance that consumes a message. See [consumer](#consumer) for more details
 
@@ -280,64 +299,28 @@ as described in [Attributes specific to certain messaging systems](#attributes-s
 [`network.transport`]: span-general.md#network-attributes
 [Hangfire]: https://www.hangfire.io/
 
-### Producer attributes
-
-The following additional attributes describe message producer operations.
-
-<!-- semconv messaging.producer -->
-| Attribute  | Type | Description  | Examples  | Requirement Level |
-|---|---|---|---|---|
-| `messaging.destination.anonymous` | boolean | A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name). |  | Conditionally Required: [1] |
-| `messaging.destination.name` | string | The message destination name [2] | `MyQueue`; `MyTopic` | Conditionally Required: [3] |
-| `messaging.destination.template` | string | Low cardinality representation of the messaging destination name [4] | `/customers/{customerId}` | Conditionally Required: [5] |
-| `messaging.destination.temporary` | boolean | A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed. |  | Conditionally Required: [6] |
-
-**[1]:** If value is `true`. When missing, the value is assumed to be `false`.
-
-**[2]:** Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
-the broker does not have such notion, the destination name SHOULD uniquely identify the broker.
-
-**[3]:** If one message is being published or if the value applies to all messages in the batch.
-
-**[4]:** Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
-
-**[5]:** If available. Instrumentations MUST NOT use `messaging.destination.name` as template unless low-cardinality of destination name is guaranteed.
-
-**[6]:** If value is `true`. When missing, the value is assumed to be `false`.
-<!-- endsemconv -->
-
 ### Consumer attributes
 
-The following additional attributes describe message consumer operations.
+The following additional attributes describe message operations on the consumer side.
 
-> Note: Consumer spans can have attributes describing source and destination. Since messages could be routed by brokers, source and destination don't always match. If original destination information is available on the consumer, consumer instrumentations SHOULD populate corresponding `messaging.destination` attributes.
+> Note: Because messages could be routed by brokers, the destination a message
+> is consumed from does not always match the destination it was published to.
+> If information about the original destination is available on the consumer side,
+> consumer instrumentations SHOULD populate the attributes about
+> the original destination under the `messaging.destination_original` namespace.
 
 <!-- semconv messaging.consumer -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `messaging.destination.anonymous` | boolean | A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name). |  | Recommended: If known on consumer |
-| `messaging.destination.name` | string | The message destination name [1] | `MyQueue`; `MyTopic` | Recommended: If known on consumer |
-| `messaging.destination.temporary` | boolean | A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed. |  | Recommended: If known on consumer |
-| `messaging.source.anonymous` | boolean | A boolean that is true if the message source is anonymous (could be unnamed or have auto-generated name). |  | Recommended: [2] |
-| `messaging.source.name` | string | The message source name [3] | `MyQueue`; `MyTopic` | Conditionally Required: [4] |
-| `messaging.source.template` | string | Low cardinality representation of the messaging source name [5] | `/customers/{customerId}` | Conditionally Required: [6] |
-| `messaging.source.temporary` | boolean | A boolean that is true if the message source is temporary and might not exist anymore after messages are processed. |  | Recommended: [7] |
+| `messaging.destination_original.anonymous` | boolean | A boolean that is true if the original message destination is anonymous (could be unnamed or have auto-generated name). |  | Recommended |
+| `messaging.destination_original.name` | string | The original destination name [1] | `MyQueue`; `MyTopic` | Recommended |
+| `messaging.destination_original.template` | string | Low cardinality representation of the original messaging destination name [2] | `/customers/{customerId}` | Recommended |
+| `messaging.destination_original.temporary` | boolean | A boolean that is true if the original message destination is temporary and might not exist anymore after messages are processed. |  | Recommended |
 
-**[1]:** Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
-the broker does not have such notion, the destination name SHOULD uniquely identify the broker.
+**[1]:** The name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
+the broker does not have such notion, the original destination name SHOULD uniquely identify the broker.
 
-**[2]:** When supported by messaging system and only if the source is anonymous. When missing, the value is assumed to be `false`.
-
-**[3]:** Source name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
-the broker does not have such notion, the source name SHOULD uniquely identify the broker.
-
-**[4]:** If the value applies to all messages in the batch.
-
-**[5]:** Source names could be constructed from templates. An example would be a source name involving a user name or product id. Although the source name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
-
-**[6]:** If available. Instrumentations MUST NOT use `messaging.source.name` as template unless low-cardinality of source name is guaranteed.
-
-**[7]:** When supported by messaging system and only if the source is temporary. When missing, the value is assumed to be `false`.
+**[2]:** Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
 <!-- endsemconv -->
 
 The *receive* span is be used to track the time used for receiving the message(s), whereas the *process* span(s) track the time for processing the message(s).
@@ -354,15 +337,16 @@ Attributes in the `messaging.message` or `messaging.{system}.message` namespace 
 
 For batch operations, per-message attributes are usually different and cannot be set on the corresponding span. In such cases the attributes MAY be set on links. See [Batch Receiving](#batch-receiving) and [Batch Processing](#batch-processing) for more information on correlation using links.
 
-Some messaging systems (e.g., Kafka, Azure EventGrid) allow publishing a single batch of messages to different topics. In such cases, the attributes in `messaging.destination` and `messaging.source` MAY be
-set on links. Instrumentations MAY set source and destination attributes on the span if all messages in the batch share the same destination or source.
+Some messaging systems (e.g., Kafka, Azure EventGrid) allow publishing a single batch of messages to different topics. In such cases, the attributes in `messaging.destination` and `messaging.destination_original` MAY be
+set on links. Instrumentations MAY set destination attributes on the span if all messages in the batch share the same destination.
 
 ### Attributes specific to certain messaging systems
 
-All attributes that are specific for a messaging system SHOULD be populated in `messaging.{system}` namespace. Attributes that describe a message, a destination, a source, a consumer or a batch of messages SHOULD be populated under the corresponding namespace:
+All attributes that are specific for a messaging system SHOULD be populated in `messaging.{system}` namespace. Attributes that describe a message, a destination, a consumer, or a batch of messages SHOULD be populated under the corresponding namespace:
 
 * `messaging.{system}.message`: Describes attributes for individual messages
-* `messaging.{system}.destination` and `messaging.{system}.source`: Describe the destination and source a message (or a batch) are published to and received from respectively. The combination of attributes in these namespaces should uniquely identify the entity and include properties significant for this messaging system. For example, Kafka instrumentations should include partition identifier.
+* `messaging.{system}.destination`: Describe the destination a message (or a batch) are published to and received from respectively. The combination of attributes in these namespaces should uniquely identify the entity and include properties significant for this messaging system. For example, Kafka instrumentations should include partition identifier.
+* `messaging.{system}.destination_original`: Describe the original destination a message (or a batch) were published to.
 * `messaging.{system}.consumer`: Describes message consumer properties
 * `messaging.{system}.batch`: Describes message batch properties
 
@@ -387,7 +371,6 @@ For Apache Kafka, the following additional attributes are defined:
 | `messaging.kafka.message.key` | string | Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message.id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set. [1] | `myKey` | Recommended |
 | `messaging.kafka.consumer.group` | string | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. | `my-group` | Recommended |
 | `messaging.kafka.destination.partition` | int | Partition the message is sent to. | `2` | Recommended |
-| `messaging.kafka.source.partition` | int | Partition the message is received from. | `2` | Recommended |
 | `messaging.kafka.message.offset` | int | The offset of a record in the corresponding Kafka partition. | `42` | Recommended |
 | `messaging.kafka.message.tombstone` | boolean | A boolean that is true if the message is a tombstone. |  | Conditionally Required: [2] |
 
@@ -466,8 +449,7 @@ Process CB:                 | Span CB1 |
 | `server.address` | `"ms"` | `"ms"` | `"ms"` |
 | `server.port` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` |
-| `messaging.destination.name` | `"T"` | | |
-| `messaging.source.name` | | `"T"` | `"T"` |
+| `messaging.destination.name` | `"T"` | `"T"` | `"T"` |
 | `messaging.operation` |  | `"process"` | `"process"` |
 | `messaging.message.id` | `"a1"` | `"a1"`| `"a1"` |
 
@@ -501,8 +483,7 @@ Process CB:                           | Span Rcv2 |
 | `peer.service` | `"myKafka"` |  |  | `"myKafka"` |  |
 | `service.name` |  | `"myConsumer1"` | `"myConsumer1"` |  | `"myConsumer2"` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` |
-| `messaging.destination.name` | `"T1"` | | | | |
-| `messaging.source.name` |  | `"T1"` | `"T1"` | `"T2"` | `"T2"` |
+| `messaging.destination.name` | `"T1"` | `"T1"` | `"T1"` | `"T2"` | `"T2"` |
 | `messaging.operation` |  |  | `"process"` |  | `"receive"` |
 | `messaging.client_id` |  | `"5"` | `"5"` | `"5"` | `"8"` |
 | `messaging.kafka.message.key` | `"myKey"` | `"myKey"` | `"myKey"` | `"anotherKey"` | `"anotherKey"` |
@@ -534,8 +515,7 @@ Process C:                      | Span Recv1 |
 | `server.address` | `"ms"` | `"ms"` | `"ms"` | `"ms"` | `"ms"` |
 | `server.port` | `1234` | `1234` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` |
-| `messaging.destination.name` | `"Q"` | `"Q"` | | | |
-| `messaging.source.name` | | | `"Q"` | `"Q"` | `"Q"` |
+| `messaging.destination.name` | `"Q"` | `"Q"` | `"Q"` | `"Q"` | `"Q"` |
 | `messaging.operation` |  |  | `"receive"` | `"process"` | `"process"` |
 | `messaging.message.id` | `"a1"` | `"a2"` | | `"a1"` | `"a2"` |
 | `messaging.batch.message_count` |  |  | 2 |  |  |
@@ -569,8 +549,7 @@ Process C:                              | Span Recv1 | Span Recv2 |
 | `server.address` | `"ms"` | `"ms"` | `"ms"` | `"ms"` | `"ms"` |
 | `server.port` | `1234` | `1234` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` |
-| `messaging.destination.name` | `"Q"` | `"Q"` | | | |
-| `messaging.source.name` | | | `"Q"` | `"Q"` | `"Q"` |
+| `messaging.destination.name` | `"Q"` | `"Q"` | `"Q"` | `"Q"` | `"Q"` |
 | `messaging.operation` |  |  | `"receive"` | `"receive"` | `"process"` |
 | `messaging.message.id` | `"a1"` | `"a2"` | `"a1"` | `"a2"` | |
 | `messaging.batch.message_count` | | | 1 | 1 | 2 |

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -344,11 +344,11 @@ set on links. Instrumentations MAY set destination attributes on the span if all
 
 All attributes that are specific for a messaging system SHOULD be populated in `messaging.{system}` namespace. Attributes that describe a message, a destination, a consumer, or a batch of messages SHOULD be populated under the corresponding namespace:
 
-* `messaging.{system}.message`: Describes attributes for individual messages
-* `messaging.{system}.destination`: Describe the destination a message (or a batch) are published to and received from respectively. The combination of attributes in these namespaces should uniquely identify the entity and include properties significant for this messaging system. For example, Kafka instrumentations should include partition identifier.
-* `messaging.{system}.destination_original`: Describe the original destination a message (or a batch) were published to.
-* `messaging.{system}.consumer`: Describes message consumer properties
-* `messaging.{system}.batch`: Describes message batch properties
+* `messaging.{system}.message.*`: Describes attributes for individual messages
+* `messaging.{system}.destination.*`: Describe the destination a message (or a batch) are published to and received from respectively. The combination of attributes in these namespaces should uniquely identify the entity and include properties significant for this messaging system. For example, Kafka instrumentations should include partition identifier.
+* `messaging.{system}.destination_original.*`: Describe the original destination a message (or a batch) were published to.
+* `messaging.{system}.consumer.*`: Describes message consumer properties
+* `messaging.{system}.batch.*`: Describes message batch properties
 
 #### RabbitMQ
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -345,8 +345,8 @@ set on links. Instrumentations MAY set destination attributes on the span if all
 All attributes that are specific for a messaging system SHOULD be populated in `messaging.{system}` namespace. Attributes that describe a message, a destination, a consumer, or a batch of messages SHOULD be populated under the corresponding namespace:
 
 * `messaging.{system}.message.*`: Describes attributes for individual messages
-* `messaging.{system}.destination.*`: Describe the destination a message (or a batch) are published to and received from respectively. The combination of attributes in these namespaces should uniquely identify the entity and include properties significant for this messaging system. For example, Kafka instrumentations should include partition identifier.
-* `messaging.{system}.destination_original.*`: Describe the original destination a message (or a batch) were published to.
+* `messaging.{system}.destination.*`: Describes the destination a message (or a batch) are published to and received from respectively. The combination of attributes in these namespaces should uniquely identify the entity and include properties significant for this messaging system. For example, Kafka instrumentations should include partition identifier.
+* `messaging.{system}.destination_original.*`: Describes the original destination a message (or a batch) were published to.
 * `messaging.{system}.consumer.*`: Describes message consumer properties
 * `messaging.{system}.batch.*`: Describes message batch properties
 


### PR DESCRIPTION
Port from https://github.com/open-telemetry/opentelemetry-specification/pull/3450
CC @lmolkova 
--

Fixes open-telemetry/opentelemetry-specification#3196

## Changes

- Removes `messaging.source` namespace. `Destination` and `source` namespaces are defined in ECS and unrelated to messaging. Removed to allow attribute reuse across signals (e.g. logs), to decrease confusion with ECS source, and resolve some usability issues with source/destination 
- Not removing `messaging.destination` because it's widely used in messaging 
- Introduces `destination_original`: in some cases when a message is routed,  consumer also knows the original destination and the destination it received a message from. With `messaging.source` removed, we need another namespace for the original destination.