### PR TITLE
Fix 'Description' section for GCP Cloud Run Job execution

### DIFF
--- a/specification/resource/semantic_conventions/cloud_provider/gcp/cloud_run.md
+++ b/specification/resource/semantic_conventions/cloud_provider/gcp/cloud_run.md
@@ -6,7 +6,7 @@ These conventions are recommended for resources running on Cloud Run.
 
 **Type:** `gcp.cloud_run`
 
-**Description:** Resource attributes for GCE instances.
+**Description:** Resource attributes for Cloud Run.
 
 <!-- semconv gcp.cloud_run -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |


### PR DESCRIPTION
Fix `Description` section for GCP Cloud Run Job execution.

Related issues:
[Add detail for GCP Cloud Run Job execution](https://github.com/open-telemetry/opentelemetry-specification/pull/3378)