### PR TITLE
Add lacking Compute Engine link to the Services section

### DIFF
--- a/specification/resource/semantic_conventions/cloud_provider/gcp/README.md
+++ b/specification/resource/semantic_conventions/cloud_provider/gcp/README.md
@@ -10,5 +10,6 @@ provider (like account ID, operating system, etc), it belongs in the parent
 ## Services
 
 - [Cloud Run](./cloud_run.md)
+- [Compute Engine](./gce.md)
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/document-status.md


### PR DESCRIPTION
Add a lacking `Compute Engine` link to the Services section.