### PR TITLE
Add 'as reported by the JVM' qualifier to JVM cpu metrics

### DIFF
--- a/semantic_conventions/metrics/process-runtime-jvm-metrics-experimental.yaml
+++ b/semantic_conventions/metrics/process-runtime-jvm-metrics-experimental.yaml
@@ -10,7 +10,7 @@ groups:
   - id: metric.process.runtime.jvm.system.cpu.utilization
     type: metric
     metric_name: process.runtime.jvm.system.cpu.utilization
-    brief: "Recent CPU utilization for the whole system."
+    brief: "Recent CPU utilization for the whole system as reported by the JVM."
     note: >
       The value range is [0.0,1.0].
       This utilization is not defined as being for the specific interval since last measurement
@@ -22,7 +22,7 @@ groups:
   - id: metric.process.runtime.jvm.system.cpu.load_1m
     type: metric
     metric_name: process.runtime.jvm.system.cpu.load_1m
-    brief: "Average CPU load of the whole system for the last minute."
+    brief: "Average CPU load of the whole system for the last minute as reported by the JVM."
     note: >
       The value range is [0,n], where n is the number of CPU cores - or a negative number if the value is not available.
       This utilization is not defined as being for the specific interval since last measurement

--- a/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
+++ b/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
@@ -117,14 +117,14 @@ groups:
   - id: metric.process.runtime.jvm.cpu.time
     type: metric
     metric_name: process.runtime.jvm.cpu.time
-    brief: "CPU time used by the process."
+    brief: "CPU time used by the process as reported by the JVM."
     instrument: counter
     unit: "s"
 
   - id: metric.process.runtime.jvm.cpu.recent_utilization
     type: metric
     metric_name: process.runtime.jvm.cpu.recent_utilization
-    brief: "Recent CPU utilization for the process."
+    brief: "Recent CPU utilization for the process as reported by the JVM."
     note: >
       The value range is [0.0,1.0].
       This utilization is not defined as being for the specific interval since last measurement

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -283,7 +283,7 @@ and [`com.ibm.lang.management.OperatingSystemMXBean#getProcessCpuTime()`](https:
 <!-- semconv metric.process.runtime.jvm.cpu.time(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `process.runtime.jvm.cpu.time` | Counter | `s` | CPU time used by the process. |
+| `process.runtime.jvm.cpu.time` | Counter | `s` | CPU time used by the process as reported by the JVM. |
 <!-- endsemconv -->
 
 <!-- semconv metric.process.runtime.jvm.cpu.time(full) -->
@@ -299,7 +299,7 @@ Note that the JVM does not provide a definition of what "recent" means.
 <!-- semconv metric.process.runtime.jvm.cpu.recent_utilization(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `process.runtime.jvm.cpu.recent_utilization` | Gauge | `1` | Recent CPU utilization for the process. |
+| `process.runtime.jvm.cpu.recent_utilization` | Gauge | `1` | Recent CPU utilization for the process as reported by the JVM. |
 <!-- endsemconv -->
 
 <!-- semconv metric.process.runtime.jvm.cpu.recent_utilization(full) -->
@@ -345,7 +345,7 @@ and [`com.ibm.lang.management.OperatingSystemMXBean#getSystemCpuLoad()`](https:/
 <!-- semconv metric.process.runtime.jvm.system.cpu.utilization(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `process.runtime.jvm.system.cpu.utilization` | Gauge | `1` | Recent CPU utilization for the whole system. |
+| `process.runtime.jvm.system.cpu.utilization` | Gauge | `1` | Recent CPU utilization for the whole system as reported by the JVM. |
 <!-- endsemconv -->
 
 <!-- semconv metric.process.runtime.jvm.system.cpu.utilization(full) -->
@@ -359,7 +359,7 @@ This metric is obtained from [`OperatingSystemMXBean#getSystemLoadAverage()`](ht
 <!-- semconv metric.process.runtime.jvm.system.cpu.load_1m(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `process.runtime.jvm.system.cpu.load_1m` | Gauge | `1` | Average CPU load of the whole system for the last minute. |
+| `process.runtime.jvm.system.cpu.load_1m` | Gauge | `1` | Average CPU load of the whole system for the last minute as reported by the JVM. |
 <!-- endsemconv -->
 
 <!-- semconv metric.process.runtime.jvm.system.cpu.load_1m(full) -->


### PR DESCRIPTION
Fixes #65