### PR TITLE
Make `url.query` conditionally required for HTTP spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,3 +84,5 @@ release.
   ([#55](https://github.com/open-telemetry/semantic-conventions/pull/55))
 - Split out sections for proposed stable JVM metrics and experimental JVM metrics.
   ([#56](https://github.com/open-telemetry/semantic-conventions/pull/56))
+- Make `url.query` conditionally required for HTTP spans.
+  ([#118](https://github.com/open-telemetry/semantic-conventions/pull/118))

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -138,6 +138,8 @@ groups:
         requirement_level: required
         sampling_relevant: true
       - ref: url.query
+        requirement_level:
+          conditionally_required: If and only if one was received/sent.
         sampling_relevant: true
       - ref: url.scheme
         sampling_relevant: true

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -298,7 +298,7 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 | [`server.socket.address`](span-general.md) | string | Local socket address. Useful in case of a multi-IP host. | `10.5.3.2` | Opt-In |
 | [`server.socket.port`](span-general.md) | int | Local socket port. Useful in case of a multi-port host. | `16456` | Opt-In |
 | `url.path` | string | The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component [7] | `/search` | Required |
-| `url.query` | string | The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component [8] | `q=OpenTelemetry` | Recommended |
+| `url.query` | string | The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component [8] | `q=OpenTelemetry` | Conditionally Required: If and only if one was received/sent. |
 | `url.scheme` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.


### PR DESCRIPTION
Fixes #112

Aligns the requirement level of `url.query` with the requirement level of `url.path`.

It was also the previous behavior when those two attributes were combined in the single field `http.target`, and appears to have been a bug that slipped into https://github.com/open-telemetry/opentelemetry-specification/pull/3355 when that field was split into `url.path` and `url.query`.

