### PR TITLE
correct link in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ release.
   ([#27](https://github.com/open-telemetry/semantic-conventions/pull/27))
 - Limit `http.request.method` values to a closed set of known values,
   introduce `http.request.method_original` for the original value.
-  ([#17](https://github.com/open-telemetry/opentelemetry-specification/pull/17))
+  ([#17](https://github.com/open-telemetry/semantic-conventions/pull/17))
 - Mark service.version as stable.
   ([#106](https://github.com/open-telemetry/semantic-conventions/pull/106))
 - Mark initial set of HTTP semantic conventions as frozen


### PR DESCRIPTION
Looks like an leftover from the repo move.