### PR TITLE
Add publish schemas workflow using opentelemetry bot.

### DIFF
--- a/.github/workflows/publish-schemas.yml
+++ b/.github/workflows/publish-schemas.yml
@@ -1,0 +1,36 @@
+name: Update Schema files at OpenTelemetry Website
+
+on:
+  # triggers only on a manual dispatch
+  workflow_dispatch:
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2.3.4
+      - name: make-pr
+        env:
+          API_TOKEN_GITHUB: ${{secrets.OPENTELEMETRYBOT_GITHUB_TOKEN}}
+          # Destination repo should always be 'open-telemetry/opentelemetry.io'
+          DESTINATION_REPO: open-telemetry/opentelemetry.io
+          # Destination path should be the absolute path to directory to publish in
+          DESTINATION_PATH: static/schemas
+          # Source path should be 'schemas', all files and folders are copied from here to dest
+          SOURCE_PATH: schemas
+        run: |
+          TARGET_DIR=$(mktemp -d)
+          export GITHUB_TOKEN=$API_TOKEN_GITHUB
+          git config --global user.name opentelemetrybot
+          git config --global user.email 107717825+opentelemetrybot@users.noreply.github.com
+          git clone "https://$API_TOKEN_GITHUB@github.com/$DESTINATION_REPO.git" "$TARGET_DIR"
+          rsync -av --delete "$SOURCE_PATH/" "$TARGET_DIR/$DESTINATION_PATH/"
+          cd "$TARGET_DIR"
+          git checkout -b schemas-$GITHUB_REPOSITORY-$GITHUB_SHA
+          git add .
+          git commit -m "Schemas update from $GITHUB_REPOSITORY"
+          git push -u origin HEAD:schemas-$GITHUB_REPOSITORY-$GITHUB_SHA
+          gh pr create -t "Schemas Update from $GITHUB_REPOSITORY" -b "This is an automated pull request." -B main -H schemas-$GITHUB_REPOSITORY-$GITHUB_SHA
+          echo "done"
+


### PR DESCRIPTION
Fixes #11


- Moves to OpenTelemetry bot account: https://github.com/open-telemetry/community/blob/main/assets.md#opentelemetry-bot
- Simply copies all schema files when run and opens a PR against the website