### PR TITLE
[editorial] Add missing `README.md` for Resource Cloud Provider semconv

### DIFF
--- a/docs/resource/cloud_provider/README.md
+++ b/docs/resource/cloud_provider/README.md
@@ -8,7 +8,8 @@ linkTitle: Cloud Provider
 
 This document defines semantic conventions for resource cloud providers.
 
-* [AWS](aws/readme.md): Semantic Conventions for Amazon Web Services.
-* [GCP](gcp/readme.md): Semantic Conventions for Google Cloud Platform.
+* [AWS](aws/README.md): Semantic Conventions for Amazon Web Services.
+* [GCP](gcp/README.md): Semantic Conventions for Google Cloud Platform.
 * [Heroku](heroku.md): Semantic Conventions for Heroku.
+
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/document-status.md

--- a/docs/resource/cloud_provider/README.md
+++ b/docs/resource/cloud_provider/README.md
@@ -1,0 +1,11 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Cloud Provider
+--->
+
+# Resource Cloud Provider Semantic Conventions
+
+**Status**: [Experimental][DocumentStatus]
+
+This document defines semantic conventions for resource cloud providers.
+
+[DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/document-status.md

--- a/docs/resource/cloud_provider/README.md
+++ b/docs/resource/cloud_provider/README.md
@@ -8,4 +8,7 @@ linkTitle: Cloud Provider
 
 This document defines semantic conventions for resource cloud providers.
 
+* [AWS](aws/readme.md): Semantic Conventions for Amazon Web Services.
+* [GCP](gcp/readme.md): Semantic Conventions for Google Cloud Platform.
+* [Heroku](heroku.md): Semantic Conventions for Heroku.
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/document-status.md


### PR DESCRIPTION
Publishing the docs to the OTel website requires that all sections have a README.md file. This adds a README.md that is missing from https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource/cloud_provider.

@jsuereth @joaopgrassi 

/cc @svrnm @cartermp 