### PR TITLE
[editorial] Fix doc page titles and add Hugo front matter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,17 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Semantic Conventions
+# no_list: true
+cascade:
+  body_class: otel-docs-spec
+  github_repo: &repo https://github.com/open-telemetry/semantic-conventions
+  github_subdir: docs
+  path_base_for_github_subdir: content/en/docs/specs/semconv/
+  github_project_repo: *repo
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/_index.md
+  to: README.md
+--->
+
 # OpenTelemetry Semantic Conventions
 
 The Semantic Conventions define a common set of (semantic) attributes which provide meaning to data when collecting, producing and consuming it.
@@ -7,8 +21,8 @@ The benefit to using Semantic Conventions is in following a common naming scheme
 Semantic Conventions are defined for the following areas:
 
 * **[General](general/README.md): General Semantic Conventions**.
-* [CloudEvents](cloudevents/README.md): Semantic Conventions for the CloudEvents specification.
 * [Cloud Providers](cloud-providers/README.md): Semantic Conventions for cloud providers libraries.
+* [CloudEvents](cloudevents/README.md): Semantic Conventions for the CloudEvents specification.
 * [Database](database/README.md): Semantic Conventions for database operations.
 * [Exceptions](exceptions/README.md): Semantic Conventions for exceptions.
 * [FaaS](faas/README.md): Semantic Conventions for Function as a Service (FaaS) operations.

--- a/docs/cloud-providers/README.md
+++ b/docs/cloud-providers/README.md
@@ -1,4 +1,11 @@
-# Semantic conventions for cloud providers
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Cloud Providers
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/cloud-providers/_index.md
+  to: cloud-providers/README.md
+--->
+
+# Semantic Conventions for Cloud Providers
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/cloud-providers/aws-sdk.md
+++ b/docs/cloud-providers/aws-sdk.md
@@ -1,4 +1,8 @@
-# Semantic conventions for AWS SDK
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: AWS SDK
+--->
+
+# Semantic Conventions for AWS SDK
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/cloudevents/README.md
+++ b/docs/cloudevents/README.md
@@ -1,4 +1,11 @@
-# Semantic conventions for CloudEvents
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: CloudEvents
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/cloudevents/_index.md
+  to: cloudevents/README.md
+--->
+
+# Semantic Conventions for CloudEvents
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/cloudevents/cloudevents-spans.md
+++ b/docs/cloudevents/cloudevents-spans.md
@@ -1,4 +1,8 @@
-# Semantic conventions for CloudEvents spans
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: CloudEvents Spans
+--->
+
+# Semantic Conventions for CloudEvents Spans
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -1,4 +1,11 @@
-# Semantic conventions for database calls and systems
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Database
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/database/_index.md
+  to: database/README.md
+--->
+
+# Semantic Conventions for Database Calls and Systems
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/database/cassandra.md
+++ b/docs/database/cassandra.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Cassandra
+--->
+
 # Semantic Conventions for Cassandra
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/database/cosmosdb.md
+++ b/docs/database/cosmosdb.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Cosmos DB
+--->
+
 # Semantic Conventions for Microsoft Cosmos DB
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/database/couchdb.md
+++ b/docs/database/couchdb.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: CouchDB
+--->
+
 # Semantic Conventions for CouchDB
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: Database
+linkTitle: Metrics
 --->
 
 # Semantic Conventions for Database Metrics

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -1,4 +1,8 @@
-# Semantic conventions for database client calls
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Client Calls
+--->
+
+# Semantic Conventions for Database Client Calls
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/database/dynamodb.md
+++ b/docs/database/dynamodb.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: AWS DynamoDB
+--->
+
 # Semantic Conventions for AWS DynamoDB
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/database/elasticsearch.md
+++ b/docs/database/elasticsearch.md
@@ -1,4 +1,8 @@
-# Semantic conventions for Elasticsearch
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Elasticsearch
+--->
+
+# Semantic Conventions for Elasticsearch
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/database/graphql.md
+++ b/docs/database/graphql.md
@@ -1,4 +1,8 @@
-# Semantic conventions for GraphQL Server
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: GraphQL Server
+--->
+
+# Semantic Conventions for GraphQL Server
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/database/hbase.md
+++ b/docs/database/hbase.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: HBase
+--->
+
 # Semantic Conventions for HBase
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/database/mongodb.md
+++ b/docs/database/mongodb.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: MongoDB
+--->
+
 # Semantic Conventions for MongoDB
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/database/mssql.md
+++ b/docs/database/mssql.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: MSSQL
+--->
+
 # Semantic Conventions for MSSQL
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/database/redis.md
+++ b/docs/database/redis.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Redis
+--->
+
 # Semantic Conventions for Redis
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/database/sql.md
+++ b/docs/database/sql.md
@@ -1,4 +1,8 @@
-# Semantic Conventions for SQL databases
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: SQL
+--->
+
+# Semantic Conventions for SQL Databases
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/exceptions/README.md
+++ b/docs/exceptions/README.md
@@ -1,4 +1,11 @@
-# Semantic conventions for Exceptions
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Exceptions
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/exceptions/_index.md
+  to: exceptions/README.md
+--->
+
+# Semantic Conventions for Exceptions
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/exceptions/exceptions-logs.md
+++ b/docs/exceptions/exceptions-logs.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Logs
+--->
+
 # Semantic Conventions for Exceptions in Logs
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/exceptions/exceptions-spans.md
+++ b/docs/exceptions/exceptions-spans.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Spans
+--->
+
 # Semantic Conventions for Exceptions on Spans
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/faas/README.md
+++ b/docs/faas/README.md
@@ -1,4 +1,11 @@
-# Semantic conventions for FaaS
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: FaaS
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/faas/_index.md
+  to: faas/README.md
+--->
+
+# Semantic Conventions for Function-as-a-Service
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/faas/faas-metrics.md
+++ b/docs/faas/faas-metrics.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: FaaS
+linkTitle: Metrics
 --->
 
 # Semantic Conventions for FaaS Metrics

--- a/docs/faas/faas-spans.md
+++ b/docs/faas/faas-spans.md
@@ -1,4 +1,8 @@
-# Semantic conventions for FaaS spans
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Spans
+--->
+
+# Semantic Conventions for FaaS Spans
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/feature-flags/README.md
+++ b/docs/feature-flags/README.md
@@ -1,4 +1,11 @@
-# Semantic conventions for Feature Flags
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Feature Flags
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/feature-flags/_index.md
+  to: feature-flags/README.md
+--->
+
+# Semantic Conventions for Feature Flags
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/feature-flags/feature-flags-logs.md
+++ b/docs/feature-flags/feature-flags-logs.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Logs
+--->
+
 # Semantic Conventions for Feature Flags in Logs
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/feature-flags/feature-flags-spans.md
+++ b/docs/feature-flags/feature-flags-spans.md
@@ -1,4 +1,8 @@
-# Semantic conventions for Feature Flags in Spans
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Spans
+--->
+
+# Semantic Conventions for Feature Flags in Spans
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/general/README.md
+++ b/docs/general/README.md
@@ -1,3 +1,11 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: General
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/general/_index.md
+  to: general/README.md
+weight: -1
+--->
+
 # General Semantic Conventions
 
 This document defines general Semantic Conventions for spans, metrics, logs and events.

--- a/docs/general/events-general.md
+++ b/docs/general/events-general.md
@@ -1,4 +1,8 @@
-# Semantic Convention for event attributes
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Events
+--->
+
+# Semantic Conventions for Event Attributes
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/general/general-attributes.md
+++ b/docs/general/general-attributes.md
@@ -1,4 +1,8 @@
-# General attributes
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Attributes
+--->
+
+# General Attributes
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/general/logs-general.md
+++ b/docs/general/logs-general.md
@@ -1,4 +1,8 @@
-# General logs attributes
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Logs
+--->
+
+# General Logs Attributes
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/general/metrics-general.md
+++ b/docs/general/metrics-general.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Metrics
+--->
+
 # Metrics Semantic Conventions
 
 **Status**: [Mixed][DocumentStatus]

--- a/docs/general/trace-compatibility.md
+++ b/docs/general/trace-compatibility.md
@@ -1,4 +1,8 @@
-# Semantic conventions for tracing Compatibility components
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Tracing Compatibility
+--->
+
+# Semantic Conventions for Tracing Compatibility Components
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/general/trace-general.md
+++ b/docs/general/trace-general.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Trace
+--->
+
 # Trace Semantic Conventions
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/http/README.md
+++ b/docs/http/README.md
@@ -1,4 +1,11 @@
-# Semantic conventions for HTTP
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: HTTP
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/http/_index.md
+  to: http/README.md
+--->
+
+# Semantic Conventions for HTTP
 
 **Status**: [Experimental, Feature-freeze][DocumentStatus]
 

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: HTTP
+linkTitle: Metrics
 --->
 
 # Semantic Conventions for HTTP Metrics

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -1,4 +1,8 @@
-# Semantic conventions for HTTP spans
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Spans
+--->
+
+# Semantic Conventions for HTTP Spans
 
 **Status**: [Experimental, Feature-freeze][DocumentStatus]
 

--- a/docs/messaging/README.md
+++ b/docs/messaging/README.md
@@ -1,4 +1,11 @@
-# Semantic conventions for Messaging systems
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Messaging Systems
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/messaging/_index.md
+  to: messaging/README.md
+--->
+
+# Semantic Conventions for Messaging Systems
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -1,4 +1,4 @@
-# Messaging systems
+# Messaging Systems
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/messaging/rabbitmq.md
+++ b/docs/messaging/rabbitmq.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: RabbitMQ
+--->
+
 # Semantic Conventions for RabbitMQ
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/messaging/rocketmq.md
+++ b/docs/messaging/rocketmq.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: RocketMQ
+--->
+
 # Semantic Conventions for RocketMQ
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/object-stores/README.md
+++ b/docs/object-stores/README.md
@@ -1,4 +1,11 @@
-# Semantic conventions for Object Stores
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Object Stores
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/object-stores/_index.md
+  to: object-stores/README.md
+--->
+
+# Semantic Conventions for Object Stores
 
 **Status**: [Experimental, Feature-freeze][DocumentStatus]
 

--- a/docs/object-stores/s3.md
+++ b/docs/object-stores/s3.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: AWS S3
+--->
+
 # Semantic Conventions for AWS S3
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -1,3 +1,10 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Resource
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/resource/_index.md
+  to: resource/README.md
+--->
+
 # Resource Semantic Conventions
 
 **Status**: [Mixed][DocumentStatus]

--- a/docs/resource/cloud-provider/README.md
+++ b/docs/resource/cloud-provider/README.md
@@ -1,5 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: Cloud Provider
+linkTitle: Resource Cloud Provider
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/resource/cloud-provider/_index.md
+  to: resource/cloud-provider/README.md
 --->
 
 # Resource Cloud Provider Semantic Conventions

--- a/docs/resource/cloud-provider/aws/README.md
+++ b/docs/resource/cloud-provider/aws/README.md
@@ -1,8 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: AWS
 path_base_for_github_subdir:
-  from: content/en/docs/specs/semconv/resource/cloud_provider/aws/_index.md
-  to: resource/cloud_provider/aws/README.md
+  from: content/en/docs/specs/semconv/resource/cloud-provider/aws/_index.md
+  to: resource/cloud-provider/aws/README.md
 --->
 
 # AWS Semantic Conventions

--- a/docs/resource/cloud-provider/aws/README.md
+++ b/docs/resource/cloud-provider/aws/README.md
@@ -1,3 +1,10 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: AWS
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/resource/cloud_provider/aws/_index.md
+  to: resource/cloud_provider/aws/README.md
+--->
+
 # AWS Semantic Conventions
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/resource/cloud-provider/gcp/README.md
+++ b/docs/resource/cloud-provider/gcp/README.md
@@ -1,8 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: GCP
 path_base_for_github_subdir:
-  from: content/en/docs/specs/semconv/resource/cloud_provider/gcp/_index.md
-  to: resource/cloud_provider/gcp/README.md
+  from: content/en/docs/specs/semconv/resource/cloud-provider/gcp/_index.md
+  to: resource/cloud-provider/gcp/README.md
 --->
 
 # GCP Semantic Conventions

--- a/docs/resource/cloud-provider/gcp/README.md
+++ b/docs/resource/cloud-provider/gcp/README.md
@@ -1,3 +1,10 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: GCP
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/resource/cloud_provider/gcp/_index.md
+  to: resource/cloud_provider/gcp/README.md
+--->
+
 # GCP Semantic Conventions
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/resource/process.md
+++ b/docs/resource/process.md
@@ -1,4 +1,4 @@
-# Process and process runtime resources
+# Process and Process Runtime Resources
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/rpc/README.md
+++ b/docs/rpc/README.md
@@ -1,4 +1,11 @@
-# Semantic conventions for RPC
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: RPC
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/rpc/_index.md
+  to: rpc/README.md
+--->
+
+# Semantic Conventions for RPC
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/rpc/connect-rpc.md
+++ b/docs/rpc/connect-rpc.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Connect
+--->
+
 # Semantic Conventions for Connect RPC
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/rpc/grpc.md
+++ b/docs/rpc/grpc.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: gRPC
+--->
+
 # Semantic Conventions for gRPC
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/rpc/json-rpc.md
+++ b/docs/rpc/json-rpc.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: JSON-RPC
+--->
+
 # Semantic Conventions for JSON-RPC
 
 **Status**: [Experimental][DocumentStatus]

--- a/docs/rpc/rpc-metrics.md
+++ b/docs/rpc/rpc-metrics.md
@@ -1,8 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: RPC
+linkTitle: Metrics
 --->
 
-# Semantic conventions for RPC metrics
+# Semantic Conventions for RPC Metrics
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/rpc/rpc-spans.md
+++ b/docs/rpc/rpc-spans.md
@@ -1,4 +1,8 @@
-# Semantic conventions for RPC spans
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Spans
+--->
+
+# Semantic Conventions for RPC Spans
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/system/README.md
+++ b/docs/system/README.md
@@ -1,4 +1,11 @@
-# System semantic conventions
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: System
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/system/_index.md
+  to: system/README.md
+--->
+
+# System Semantic Conventions
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/url/README.md
+++ b/docs/url/README.md
@@ -1,4 +1,11 @@
-# URL semantic conventions
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: URL
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/url/_index.md
+  to: url/README.md
+--->
+
+# URL Semantic Conventions
 
 **Status**: [Experimental][DocumentStatus]
 

--- a/docs/url/url.md
+++ b/docs/url/url.md
@@ -1,4 +1,8 @@
-# Semantic conventions for URL
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: URL
+--->
+
+# Semantic Conventions for URL
 
 **Status**: [Experimental][DocumentStatus]
 


### PR DESCRIPTION
- Closes #169
- Closes #170 because it supersedes it (either, really, can be merged first)
- Adds the necessary Hugo front matter to be able to publish pages on the OTel website

/cc @svrnm @cartermp @jsuereth @joaopgrassi 