### PR TITLE
Introduce request error type attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ release.
   ([#276](https://github.com/open-telemetry/semantic-conventions/pull/276))
 - Add host cpu resource attributes.
   ([#209](https://github.com/open-telemetry/semantic-conventions/pull/209))
-- Introduce `error.id` attribute and use it in HTTP conventions
+- Introduce `error.type` attribute and use it in HTTP conventions
   ([#205](https://github.com/open-telemetry/semantic-conventions/pull/205))
 
 ## v1.21.0 (2023-07-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,6 @@ release.
 - Clarify that `http/dup` has higher precedence than `http` in case both values are present
   in `OTEL_SEMCONV_STABILITY_OPT_IN`
   ([#249](https://github.com/open-telemetry/semantic-conventions/pull/249))
-<<<<<<< HEAD
 - Add `jvm.cpu.count` metric.
   ([#52](https://github.com/open-telemetry/semantic-conventions/pull/52))
 - BREAKING: Rename metrics `jvm.buffer.usage` to `jvm.buffer.memory.usage`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ release.
 - Clarify that `http/dup` has higher precedence than `http` in case both values are present
   in `OTEL_SEMCONV_STABILITY_OPT_IN`
   ([#249](https://github.com/open-telemetry/semantic-conventions/pull/249))
+<<<<<<< HEAD
 - Add `jvm.cpu.count` metric.
   ([#52](https://github.com/open-telemetry/semantic-conventions/pull/52))
 - BREAKING: Rename metrics `jvm.buffer.usage` to `jvm.buffer.memory.usage`
@@ -61,6 +62,8 @@ release.
   ([#276](https://github.com/open-telemetry/semantic-conventions/pull/276))
 - Add host cpu resource attributes.
   ([#209](https://github.com/open-telemetry/semantic-conventions/pull/209))
+- Introduce `error.id` attribute and use it in HTTP conventions
+  ([#205](https://github.com/open-telemetry/semantic-conventions/pull/205))
 
 ## v1.21.0 (2023-07-13)
 

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -77,7 +77,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.description` | string | Describes a class of error that operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request completed with an error. |
+| `error.description` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request completed with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -89,7 +89,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
-**[2]:** If response status code was sent or received and indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+**[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
 `error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
 returned in the status line or to `_OTHER`.
 
@@ -247,7 +247,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.description` | string | Describes a class of error that operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request completed with an error. |
+| `error.description` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request completed with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -259,7 +259,7 @@ This metric is optional.
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
-**[2]:** If response status code was sent or received and indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+**[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
 `error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
 returned in the status line or to `_OTHER`.
 
@@ -349,7 +349,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.description` | string | Describes a class of error that operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request completed with an error. |
+| `error.description` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request completed with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -361,7 +361,7 @@ This metric is optional.
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
-**[2]:** If response status code was sent or received and indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+**[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
 `error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
 returned in the status line or to `_OTHER`.
 

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -103,8 +103,6 @@ should be prepared for `error.id` to have high cardinality at query time, when n
 additional filters are applied.
 
 If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
-Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
-(as an indication that operation did not fail).
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -144,7 +142,6 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 
 | Value  | Description |
 |---|---|
-| `` | No error. |
 | `_OTHER` | Any error instrumentation does not define custom value for. |
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
@@ -275,8 +272,6 @@ should be prepared for `error.id` to have high cardinality at query time, when n
 additional filters are applied.
 
 If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
-Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
-(as an indication that operation did not fail).
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -316,7 +311,6 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 
 | Value  | Description |
 |---|---|
-| `` | No error. |
 | `_OTHER` | Any error instrumentation does not define custom value for. |
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
@@ -379,8 +373,6 @@ should be prepared for `error.id` to have high cardinality at query time, when n
 additional filters are applied.
 
 If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
-Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
-(as an indication that operation did not fail).
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -420,7 +412,6 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 
 | Value  | Description |
 |---|---|
-| `` | No error. |
 | `_OTHER` | Any error instrumentation does not define custom value for. |
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -77,7 +77,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.id` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
+| `error.id` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -142,7 +142,7 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 
 | Value  | Description |
 |---|---|
-| `_OTHER` | Any error instrumentation does not define custom value for. |
+| `_OTHER` | A fallback error value to be used when the instrumentation does not define a custom value for it. |
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -246,7 +246,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.id` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
+| `error.id` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -311,7 +311,7 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 
 | Value  | Description |
 |---|---|
-| `_OTHER` | Any error instrumentation does not define custom value for. |
+| `_OTHER` | A fallback error value to be used when the instrumentation does not define a custom value for it. |
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -347,7 +347,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.id` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
+| `error.id` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -412,7 +412,7 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 
 | Value  | Description |
 |---|---|
-| `_OTHER` | Any error instrumentation does not define custom value for. |
+| `_OTHER` | A fallback error value to be used when the instrumentation does not define a custom value for it. |
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -77,7 +77,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.type` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
+| `error.type` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `500` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -89,12 +89,13 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
-**[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-corresponding to the returned status code or to `_OTHER`.
+**[2]:** If the request fails with an error before response status code was sent or received,
+`error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
 
-If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+`error.type` SHOULD be set to the string representation of the status code, an exception type (if thrown) or a component-specific error code.
+
+The `error.type` value SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
 The cardinality of `error.type` within one instrumentation library SHOULD be low, but
@@ -102,7 +103,7 @@ telemetry consumers that aggregate data from multiple instrumentation libraries 
 should be prepared for `error.type` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -246,7 +247,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.type` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
+| `error.type` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `500` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -258,12 +259,13 @@ This metric is optional.
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
-**[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-corresponding to the returned status code or to `_OTHER`.
+**[2]:** If the request fails with an error before response status code was sent or received,
+`error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
 
-If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+`error.type` SHOULD be set to the string representation of the status code, an exception type (if thrown) or a component-specific error code.
+
+The `error.type` value SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
 The cardinality of `error.type` within one instrumentation library SHOULD be low, but
@@ -271,7 +273,7 @@ telemetry consumers that aggregate data from multiple instrumentation libraries 
 should be prepared for `error.type` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -347,7 +349,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.type` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
+| `error.type` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `500` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -359,12 +361,13 @@ This metric is optional.
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
-**[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-corresponding to the returned status code or to `_OTHER`.
+**[2]:** If the request fails with an error before response status code was sent or received,
+`error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
 
-If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+`error.type` SHOULD be set to the string representation of the status code, an exception type (if thrown) or a component-specific error code.
+
+The `error.type` value SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
 The cardinality of `error.type` within one instrumentation library SHOULD be low, but
@@ -372,7 +375,7 @@ telemetry consumers that aggregate data from multiple instrumentation libraries 
 should be prepared for `error.type` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -453,7 +456,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 <!-- semconv metric.http.client.request.duration(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `error.type` | string | Describes a class of error the operation ended with. [1] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
+| `error.type` | string | Describes a class of error the operation ended with. [1] | `timeout`; `name_resolution_error`; `500` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -462,12 +465,13 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [5] | `80`; `8080`; `443` | Conditionally Required: [6] |
 | [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [7] | `10.5.3.2` | Recommended: If different than `server.address`. |
 
-**[1]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-corresponding to the returned status code or to `_OTHER`.
+**[1]:** If the request fails with an error before response status code was sent or received,
+`error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
 
-If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+`error.type` SHOULD be set to the string representation of the status code, an exception type (if thrown) or a component-specific error code.
+
+The `error.type` value SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
 The cardinality of `error.type` within one instrumentation library SHOULD be low, but
@@ -475,7 +479,7 @@ telemetry consumers that aggregate data from multiple instrumentation libraries 
 should be prepared for `error.type` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
 **[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -548,7 +552,7 @@ This metric is optional.
 <!-- semconv metric.http.client.request.size(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `error.type` | string | Describes a class of error the operation ended with. [1] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
+| `error.type` | string | Describes a class of error the operation ended with. [1] | `timeout`; `name_resolution_error`; `500` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -557,12 +561,13 @@ This metric is optional.
 | [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [5] | `80`; `8080`; `443` | Conditionally Required: [6] |
 | [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [7] | `10.5.3.2` | Recommended: If different than `server.address`. |
 
-**[1]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-corresponding to the returned status code or to `_OTHER`.
+**[1]:** If the request fails with an error before response status code was sent or received,
+`error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
 
-If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+`error.type` SHOULD be set to the string representation of the status code, an exception type (if thrown) or a component-specific error code.
+
+The `error.type` value SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
 The cardinality of `error.type` within one instrumentation library SHOULD be low, but
@@ -570,7 +575,7 @@ telemetry consumers that aggregate data from multiple instrumentation libraries 
 should be prepared for `error.type` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
 **[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -643,7 +648,7 @@ This metric is optional.
 <!-- semconv metric.http.client.response.size(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `error.type` | string | Describes a class of error the operation ended with. [1] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
+| `error.type` | string | Describes a class of error the operation ended with. [1] | `timeout`; `name_resolution_error`; `500` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -652,12 +657,13 @@ This metric is optional.
 | [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [5] | `80`; `8080`; `443` | Conditionally Required: [6] |
 | [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [7] | `10.5.3.2` | Recommended: If different than `server.address`. |
 
-**[1]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-corresponding to the returned status code or to `_OTHER`.
+**[1]:** If the request fails with an error before response status code was sent or received,
+`error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
 
-If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+`error.type` SHOULD be set to the string representation of the status code, an exception type (if thrown) or a component-specific error code.
+
+The `error.type` value SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
 The cardinality of `error.type` within one instrumentation library SHOULD be low, but
@@ -665,7 +671,7 @@ telemetry consumers that aggregate data from multiple instrumentation libraries 
 should be prepared for `error.type` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
 **[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -77,7 +77,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.description` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request completed with an error. |
+| `error.id` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -90,19 +90,21 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
 **[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-returned in the status line or to `_OTHER`.
+`error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+corresponding to the returned status code or to `_OTHER`.
 
 If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.description` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
-The cardinality of error description within one instrumentation library SHOULD be low, but
+The cardinality of `error.id` within one instrumentation library SHOULD be low, but
 telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-should be prepared for `error.description` to have high cardinality at query time, when no
+should be prepared for `error.id` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD NOT set `error.description`.
+If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
+Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
+(as an indication that operation did not fail).
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -138,12 +140,12 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
 
-`error.description` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`error.id` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|
-| `` | No error. Default value. |
-| `_OTHER` | Any error reason instrumentation does not define custom value for. |
+| `` | No error. |
+| `_OTHER` | Any error instrumentation does not define custom value for. |
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -247,7 +249,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.description` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request completed with an error. |
+| `error.id` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -260,19 +262,21 @@ This metric is optional.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
 **[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-returned in the status line or to `_OTHER`.
+`error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+corresponding to the returned status code or to `_OTHER`.
 
 If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.description` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
-The cardinality of error description within one instrumentation library SHOULD be low, but
+The cardinality of `error.id` within one instrumentation library SHOULD be low, but
 telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-should be prepared for `error.description` to have high cardinality at query time, when no
+should be prepared for `error.id` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD NOT set `error.description`.
+If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
+Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
+(as an indication that operation did not fail).
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -308,12 +312,12 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
 
-`error.description` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`error.id` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|
-| `` | No error. Default value. |
-| `_OTHER` | Any error reason instrumentation does not define custom value for. |
+| `` | No error. |
+| `_OTHER` | Any error instrumentation does not define custom value for. |
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -349,7 +353,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.description` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request completed with an error. |
+| `error.id` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -362,19 +366,21 @@ This metric is optional.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
 **[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-returned in the status line or to `_OTHER`.
+`error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+corresponding to the returned status code or to `_OTHER`.
 
 If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.description` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
-The cardinality of error description within one instrumentation library SHOULD be low, but
+The cardinality of `error.id` within one instrumentation library SHOULD be low, but
 telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-should be prepared for `error.description` to have high cardinality at query time, when no
+should be prepared for `error.id` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD NOT set `error.description`.
+If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
+Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
+(as an indication that operation did not fail).
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -410,12 +416,12 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
 
-`error.description` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`error.id` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|
-| `` | No error. Default value. |
-| `_OTHER` | Any error reason instrumentation does not define custom value for. |
+| `` | No error. |
+| `_OTHER` | Any error instrumentation does not define custom value for. |
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -77,7 +77,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.id` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
+| `error.type` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -90,19 +90,19 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
 **[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+`error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
 corresponding to the returned status code or to `_OTHER`.
 
 If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
-The cardinality of `error.id` within one instrumentation library SHOULD be low, but
+The cardinality of `error.type` within one instrumentation library SHOULD be low, but
 telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-should be prepared for `error.id` to have high cardinality at query time, when no
+should be prepared for `error.type` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
+If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -138,7 +138,7 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
 
-`error.id` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|
@@ -246,7 +246,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.id` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
+| `error.type` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -259,19 +259,19 @@ This metric is optional.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
 **[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+`error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
 corresponding to the returned status code or to `_OTHER`.
 
 If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
-The cardinality of `error.id` within one instrumentation library SHOULD be low, but
+The cardinality of `error.type` within one instrumentation library SHOULD be low, but
 telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-should be prepared for `error.id` to have high cardinality at query time, when no
+should be prepared for `error.type` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
+If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -307,7 +307,7 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
 
-`error.id` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|
@@ -347,7 +347,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `error.id` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
+| `error.type` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `Internal Server Error` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
@@ -360,19 +360,19 @@ This metric is optional.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
 **[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+`error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
 corresponding to the returned status code or to `_OTHER`.
 
 If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
-The cardinality of `error.id` within one instrumentation library SHOULD be low, but
+The cardinality of `error.type` within one instrumentation library SHOULD be low, but
 telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-should be prepared for `error.id` to have high cardinality at query time, when no
+should be prepared for `error.type` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
+If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -408,7 +408,7 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
 
-`error.id` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -94,8 +94,8 @@ Don't set the span status description if the reason can be inferred from `http.r
 HTTP request may fail if it was cancelled or an error occurred preventing
 the client or server from sending/receiving the request/response fully.
 
-When instrumentation detects such errors it MUST to `Error` and MUST set `error.description`
-attribute.
+When instrumentation detects such errors it MUST set span status to `Error`
+and MUST set the `error.id` attribute.
 
 ## Common Attributes
 
@@ -571,7 +571,7 @@ As an example, if a user requested `https://does-not-exist-123.com`, we may have
 | `network.protocol.version` | `"1.1"`                                           |
 | `url.full`           | `"https://does-not-exist-123.com"`                      |
 | `server.address`     | `"does-not-exist-123.com"`                              |
-| `error.description`  | `"java.net.UnknownHostException"`                       |
+| `error.id`           | `"java.net.UnknownHostException"`                       |
 
 ### HTTP client call: Internal Server Error
 
@@ -584,7 +584,7 @@ As an example, if a user requested `https://example.com` and server returned 500
 | `url.full`           | `"https://example.com"`                                 |
 | `server.address`     | `"example.com"`                                         |
 | `http.response.status_code` | `500`                                            |
-| `error.description`  | `"Internal Server Error"`                               |
+| `error.id`           | `"Internal Server Error"`                               |
 
 ### HTTP server call: connection dropped before response body was sent
 
@@ -599,6 +599,6 @@ Span name: `POST /uploads/:document_id`.
 | `url.scheme`         | `"https"`                                       |
 | `http.route`         | `"/uploads/:document_id"`                       |
 | `http.response.status_code` | `201`                                    |
-| `error.description`  | `WebSocketDisconnect`                           |
+| `error.id`           | `WebSocketDisconnect`                           |
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.22.0/specification/document-status.md

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -110,7 +110,7 @@ sections below.
 | `http.request.method_original` | string | Original HTTP method sent by the client in the request line. | `GeT`; `ACL`; `foo` | Conditionally Required: [1] |
 | `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
 | `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
-| `error.description` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `server_certificate_invalid` | Conditionally Required: If request or response has ended prematurely. |
+| `error.id` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `server_certificate_invalid` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `http`; `spdy` | Recommended: if not default (`http`). |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [4] | `1.0`; `1.1`; `2`; `3` | Recommended |
@@ -121,19 +121,21 @@ sections below.
 **[1]:** If and only if it's different than `http.request.method`.
 
 **[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+`error.id` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
 returned in the status line or to `_OTHER`.
 
 If request fails with an error before or after status code was sent or received, such error SHOULD be
-recorded on `error.description` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
-The cardinality of error description within one instrumentation library SHOULD be low, but
+The cardinality of `error.id` within one instrumentation library SHOULD be low, but
 telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-should be prepared for `error.description` to have high cardinality at query time, when no
+should be prepared for `error.id` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD not set `error.description`.
+If operation has completed successfully, instrumentations SHOULD not set `error.id`.
+Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
+(as an indication that operation did not fail).
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -158,12 +160,12 @@ Following attributes MUST be provided **at span creation time** (when provided a
 
 * `http.request.method`
 
-`error.description` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`error.id` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|
-| `` | No error. Default value. |
-| `_OTHER` | Any error reason instrumentation does not define custom value for. |
+| `` | No error. |
+| `_OTHER` | Any error instrumentation does not define custom value for. |
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -134,8 +134,6 @@ should be prepared for `error.id` to have high cardinality at query time, when n
 additional filters are applied.
 
 If operation has completed successfully, instrumentations SHOULD not set `error.id`.
-Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
-(as an indication that operation did not fail).
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -164,7 +162,6 @@ Following attributes MUST be provided **at span creation time** (when provided a
 
 | Value  | Description |
 |---|---|
-| `` | No error. |
 | `_OTHER` | Any error instrumentation does not define custom value for. |
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -110,7 +110,7 @@ sections below.
 | `http.request.method_original` | string | Original HTTP method sent by the client in the request line. | `GeT`; `ACL`; `foo` | Conditionally Required: [1] |
 | `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
 | `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
-| `error.type` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `server_certificate_invalid` | Conditionally Required: If the request has ended with an error. |
+| `error.type` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `500` | Conditionally Required: If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `http`; `spdy` | Recommended: if not default (`http`). |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [4] | `1.0`; `1.1`; `2`; `3` | Recommended |
@@ -120,12 +120,13 @@ sections below.
 
 **[1]:** If and only if it's different than `http.request.method`.
 
-**[2]:** If the response status code was sent/received and the status indicates an error according to the [HTTP span status definition](/docs/http/http-spans.md#status),
-`error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-corresponding to the returned status code, otherwise it SHOULD be set `_OTHER`.
+**[2]:** If the request fails with an error before response status code was sent or received,
+`error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
 
-If the request fails with an error before or after the status code was sent or received, such error SHOULD be
-recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+`error.type` SHOULD be set to the string representation of the status code, an exception type (if thrown) or a component-specific error code.
+
+The `error.type` value SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
 The cardinality of `error.type` within one instrumentation library SHOULD be low, but
@@ -133,7 +134,7 @@ telemetry consumers that aggregate data from multiple instrumentation libraries 
 should be prepared for `error.type` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD not set `error.type`.
+If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -571,7 +572,7 @@ As an example, if a user requested `https://does-not-exist-123.com`, we may have
 | `network.protocol.version` | `"1.1"`                                           |
 | `url.full`           | `"https://does-not-exist-123.com"`                      |
 | `server.address`     | `"does-not-exist-123.com"`                              |
-| `error.type`           | `"java.net.UnknownHostException"`                       |
+| `error.type`         | `"java.net.UnknownHostException"`                       |
 
 ### HTTP client call: Internal Server Error
 
@@ -584,7 +585,7 @@ As an example, if a user requested `https://example.com` and server returned 500
 | `url.full`           | `"https://example.com"`                                 |
 | `server.address`     | `"example.com"`                                         |
 | `http.response.status_code` | `500`                                            |
-| `error.type`           | `"Internal Server Error"`                               |
+| `error.type`         | `"500"`                                                 |
 
 ### HTTP server call: connection dropped before response body was sent
 
@@ -599,6 +600,6 @@ Span name: `POST /uploads/:document_id`.
 | `url.scheme`         | `"https"`                                       |
 | `http.route`         | `"/uploads/:document_id"`                       |
 | `http.response.status_code` | `201`                                    |
-| `error.type`           | `WebSocketDisconnect`                           |
+| `error.type`         | `WebSocketDisconnect`                           |
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.22.0/specification/document-status.md

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -121,8 +121,8 @@ sections below.
 **[1]:** If and only if it's different than `http.request.method`.
 
 **[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-`error.id` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-returned in the status line or to `_OTHER`.
+`error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+corresponding to the returned status code or to `_OTHER`.
 
 If request fails with an error before or after status code was sent or received, such error SHOULD be
 recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -95,7 +95,7 @@ HTTP request may fail if it was cancelled or an error occurred preventing
 the client or server from sending/receiving the request/response fully.
 
 When instrumentation detects such errors it MUST set span status to `Error`
-and MUST set the `error.id` attribute.
+and MUST set the `error.type` attribute.
 
 ## Common Attributes
 
@@ -110,7 +110,7 @@ sections below.
 | `http.request.method_original` | string | Original HTTP method sent by the client in the request line. | `GeT`; `ACL`; `foo` | Conditionally Required: [1] |
 | `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
 | `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
-| `error.id` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `server_certificate_invalid` | Conditionally Required: If the request has ended with an error. |
+| `error.type` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `server_certificate_invalid` | Conditionally Required: If the request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `http`; `spdy` | Recommended: if not default (`http`). |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [4] | `1.0`; `1.1`; `2`; `3` | Recommended |
@@ -121,19 +121,19 @@ sections below.
 **[1]:** If and only if it's different than `http.request.method`.
 
 **[2]:** If the response status code was sent/received and the status indicates an error according to the [HTTP span status definition](/docs/http/http-spans.md),
-`error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+`error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
 corresponding to the returned status code, otherwise it SHOULD be set `_OTHER`.
 
 If the request fails with an error before or after the status code was sent or received, such error SHOULD be
-recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
-The cardinality of `error.id` within one instrumentation library SHOULD be low, but
+The cardinality of `error.type` within one instrumentation library SHOULD be low, but
 telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-should be prepared for `error.id` to have high cardinality at query time, when no
+should be prepared for `error.type` to have high cardinality at query time, when no
 additional filters are applied.
 
-If operation has completed successfully, instrumentations SHOULD not set `error.id`.
+If operation has completed successfully, instrumentations SHOULD not set `error.type`.
 
 **[3]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -158,7 +158,7 @@ Following attributes MUST be provided **at span creation time** (when provided a
 
 * `http.request.method`
 
-`error.id` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|
@@ -571,7 +571,7 @@ As an example, if a user requested `https://does-not-exist-123.com`, we may have
 | `network.protocol.version` | `"1.1"`                                           |
 | `url.full`           | `"https://does-not-exist-123.com"`                      |
 | `server.address`     | `"does-not-exist-123.com"`                              |
-| `error.id`           | `"java.net.UnknownHostException"`                       |
+| `error.type`           | `"java.net.UnknownHostException"`                       |
 
 ### HTTP client call: Internal Server Error
 
@@ -584,7 +584,7 @@ As an example, if a user requested `https://example.com` and server returned 500
 | `url.full`           | `"https://example.com"`                                 |
 | `server.address`     | `"example.com"`                                         |
 | `http.response.status_code` | `500`                                            |
-| `error.id`           | `"Internal Server Error"`                               |
+| `error.type`           | `"Internal Server Error"`                               |
 
 ### HTTP server call: connection dropped before response body was sent
 
@@ -599,6 +599,6 @@ Span name: `POST /uploads/:document_id`.
 | `url.scheme`         | `"https"`                                       |
 | `http.route`         | `"/uploads/:document_id"`                       |
 | `http.response.status_code` | `201`                                    |
-| `error.id`           | `WebSocketDisconnect`                           |
+| `error.type`           | `WebSocketDisconnect`                           |
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.22.0/specification/document-status.md

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -120,7 +120,7 @@ sections below.
 
 **[1]:** If and only if it's different than `http.request.method`.
 
-**[2]:** If the response status code was sent/received and the status indicates an error according to the [HTTP span status definition](/docs/http/http-spans.md),
+**[2]:** If the response status code was sent/received and the status indicates an error according to the [HTTP span status definition](/docs/http/http-spans.md#status),
 `error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
 corresponding to the returned status code, otherwise it SHOULD be set `_OTHER`.
 

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -110,7 +110,7 @@ sections below.
 | `http.request.method_original` | string | Original HTTP method sent by the client in the request line. | `GeT`; `ACL`; `foo` | Conditionally Required: [1] |
 | `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
 | `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
-| `error.id` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `server_certificate_invalid` | Conditionally Required: If request has ended with an error. |
+| `error.id` | string | Describes a class of error the operation ended with. [2] | `timeout`; `name_resolution_error`; `server_certificate_invalid` | Conditionally Required: If the request has ended with an error. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `http`; `spdy` | Recommended: if not default (`http`). |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [4] | `1.0`; `1.1`; `2`; `3` | Recommended |
@@ -120,11 +120,11 @@ sections below.
 
 **[1]:** If and only if it's different than `http.request.method`.
 
-**[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+**[2]:** If the response status code was sent/received and the status indicates an error according to the [HTTP span status definition](/docs/http/http-spans.md),
 `error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-corresponding to the returned status code or to `_OTHER`.
+corresponding to the returned status code, otherwise it SHOULD be set `_OTHER`.
 
-If request fails with an error before or after status code was sent or received, such error SHOULD be
+If the request fails with an error before or after the status code was sent or received, such error SHOULD be
 recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
 
@@ -162,7 +162,7 @@ Following attributes MUST be provided **at span creation time** (when provided a
 
 | Value  | Description |
 |---|---|
-| `_OTHER` | Any error instrumentation does not define custom value for. |
+| `_OTHER` | A fallback error value to be used when the instrumentation does not define a custom value for it. |
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -29,6 +29,9 @@ and various HTTP versions like 1.1, 2 and SPDY.
   * [HTTP client retries examples](#http-client-retries-examples)
   * [HTTP client authorization retry examples](#http-client-authorization-retry-examples)
   * [HTTP client redirects examples](#http-client-redirects-examples)
+  * [HTTP client call: DNS error](#http-client-call-dns-error)
+  * [HTTP client call: Internal Server Error](#http-client-call-internal-server-error)
+  * [HTTP server call: connection dropped before response body was sent](#http-server-call-connection-dropped-before-response-body-was-sent)
 
 <!-- tocstop -->
 
@@ -107,7 +110,7 @@ sections below.
 | `http.request.method_original` | string | Original HTTP method sent by the client in the request line. | `GeT`; `ACL`; `foo` | Conditionally Required: [1] |
 | `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
 | `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
-| `error.description` | string | Describes a class of error that operation ended with. [2] | `timeout`; `name_resolution_error`; `server_certificate_invalid` | Conditionally Required: If request or response has ended prematurely. |
+| `error.description` | string | Describes a class of error operation has ended with. [2] | `timeout`; `name_resolution_error`; `server_certificate_invalid` | Conditionally Required: If request or response has ended prematurely. |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `http`; `spdy` | Recommended: if not default (`http`). |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [4] | `1.0`; `1.1`; `2`; `3` | Recommended |
@@ -117,7 +120,7 @@ sections below.
 
 **[1]:** If and only if it's different than `http.request.method`.
 
-**[2]:** If response status code was sent or received and indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+**[2]:** If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
 `error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
 returned in the status line or to `_OTHER`.
 

--- a/model/error.yaml
+++ b/model/error.yaml
@@ -1,0 +1,34 @@
+groups:
+  - id: error
+    type: attribute_group
+    prefix: error
+    brief: >
+      This document defines the shared attributes used to
+      report an error.
+    attributes:
+      - id: description
+        brief: 'Describes a class of error that operation ended with.'
+        type:
+          allow_custom_values: true
+          members:
+            - id: empty
+              value: ""
+              brief: 'No error. Default value.'
+            - id: other
+              value: "_OTHER"
+              brief: 'Any error reason instrumentation does not define custom value for.'
+        examples: ['timeout', 'java.net.UnknownHostException', 'server_certificate_invalid', 'Internal Server Error']
+        note: |
+          The error description SHOULD be predictable and SHOULD have low cardinality.
+          Instrumentations SHOULD document the list of errors they report.
+
+          The cardinality of error description within one instrumentation library SHOULD be low, but
+          telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+          should be prepared for `error.description` to have high cardinality at query time, when no
+          additional filters are applied.
+
+          If operation has completed successfully, instrumentations SHOULD NOT set `error.description`.
+
+          If a specific domain defines its own set of error codes (such as HTTP or gRPC status codes),
+          it's RECOMMENDED to use a domain-specific attribute and also set `error.description` to capture
+          all errors, regardless of whether they are defined within the domain-specific set or not.

--- a/model/error.yaml
+++ b/model/error.yaml
@@ -11,9 +11,6 @@ groups:
         type:
           allow_custom_values: true
           members:
-            - id: empty
-              value: ""
-              brief: 'No error.'
             - id: other
               value: "_OTHER"
               brief: 'Any error instrumentation does not define custom value for.'
@@ -22,14 +19,12 @@ groups:
           The `error.id` SHOULD be predictable and SHOULD have low cardinality.
           Instrumentations SHOULD document the list of errors they report.
 
-          The cardinality of `error.id`` within one instrumentation library SHOULD be low, but
+          The cardinality of `error.id` within one instrumentation library SHOULD be low, but
           telemetry consumers that aggregate data from multiple instrumentation libraries and applications
           should be prepared for `error.id` to have high cardinality at query time, when no
           additional filters are applied.
 
           If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
-          Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
-          (as an indication that operation did not fail).
 
           If a specific domain defines its own set of error codes (such as HTTP or gRPC status codes),
           it's RECOMMENDED to use a domain-specific attribute and also set `error.id` to capture

--- a/model/error.yaml
+++ b/model/error.yaml
@@ -7,13 +7,13 @@ groups:
       report an error.
     attributes:
       - id: id
-        brief: 'Describes a class of error operation has ended with.'
+        brief: 'Describes a class of error the operation ended with.'
         type:
           allow_custom_values: true
           members:
             - id: other
               value: "_OTHER"
-              brief: 'Any error instrumentation does not define custom value for.'
+              brief: 'A fallback error value to be used when the instrumentation does not define a custom value for it.'
         examples: ['timeout', 'java.net.UnknownHostException', 'server_certificate_invalid', 'Internal Server Error']
         note: |
           The `error.id` SHOULD be predictable and SHOULD have low cardinality.
@@ -24,7 +24,7 @@ groups:
           should be prepared for `error.id` to have high cardinality at query time, when no
           additional filters are applied.
 
-          If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
+          If the operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
 
           If a specific domain defines its own set of error codes (such as HTTP or gRPC status codes),
           it's RECOMMENDED to use a domain-specific attribute and also set `error.id` to capture

--- a/model/error.yaml
+++ b/model/error.yaml
@@ -14,7 +14,7 @@ groups:
             - id: other
               value: "_OTHER"
               brief: 'A fallback error value to be used when the instrumentation does not define a custom value for it.'
-        examples: ['timeout', 'java.net.UnknownHostException', 'server_certificate_invalid', 'Internal Server Error']
+        examples: ['timeout', 'java.net.UnknownHostException', 'server_certificate_invalid', '500']
         note: |
           The `error.type` SHOULD be predictable and SHOULD have low cardinality.
           Instrumentations SHOULD document the list of errors they report.

--- a/model/error.yaml
+++ b/model/error.yaml
@@ -6,29 +6,31 @@ groups:
       This document defines the shared attributes used to
       report an error.
     attributes:
-      - id: description
+      - id: id
         brief: 'Describes a class of error operation has ended with.'
         type:
           allow_custom_values: true
           members:
             - id: empty
               value: ""
-              brief: 'No error. Default value.'
+              brief: 'No error.'
             - id: other
               value: "_OTHER"
-              brief: 'Any error reason instrumentation does not define custom value for.'
+              brief: 'Any error instrumentation does not define custom value for.'
         examples: ['timeout', 'java.net.UnknownHostException', 'server_certificate_invalid', 'Internal Server Error']
         note: |
-          The error description SHOULD be predictable and SHOULD have low cardinality.
+          The `error.id` SHOULD be predictable and SHOULD have low cardinality.
           Instrumentations SHOULD document the list of errors they report.
 
-          The cardinality of error description within one instrumentation library SHOULD be low, but
+          The cardinality of `error.id`` within one instrumentation library SHOULD be low, but
           telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-          should be prepared for `error.description` to have high cardinality at query time, when no
+          should be prepared for `error.id` to have high cardinality at query time, when no
           additional filters are applied.
 
-          If operation has completed successfully, instrumentations SHOULD NOT set `error.description`.
+          If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
+          Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
+          (as an indication that operation did not fail).
 
           If a specific domain defines its own set of error codes (such as HTTP or gRPC status codes),
-          it's RECOMMENDED to use a domain-specific attribute and also set `error.description` to capture
+          it's RECOMMENDED to use a domain-specific attribute and also set `error.id` to capture
           all errors, regardless of whether they are defined within the domain-specific set or not.

--- a/model/error.yaml
+++ b/model/error.yaml
@@ -6,7 +6,7 @@ groups:
       This document defines the shared attributes used to
       report an error.
     attributes:
-      - id: id
+      - id: type
         brief: 'Describes a class of error the operation ended with.'
         type:
           allow_custom_values: true
@@ -16,16 +16,16 @@ groups:
               brief: 'A fallback error value to be used when the instrumentation does not define a custom value for it.'
         examples: ['timeout', 'java.net.UnknownHostException', 'server_certificate_invalid', 'Internal Server Error']
         note: |
-          The `error.id` SHOULD be predictable and SHOULD have low cardinality.
+          The `error.type` SHOULD be predictable and SHOULD have low cardinality.
           Instrumentations SHOULD document the list of errors they report.
 
-          The cardinality of `error.id` within one instrumentation library SHOULD be low, but
+          The cardinality of `error.type` within one instrumentation library SHOULD be low, but
           telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-          should be prepared for `error.id` to have high cardinality at query time, when no
+          should be prepared for `error.type` to have high cardinality at query time, when no
           additional filters are applied.
 
-          If the operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
+          If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
           If a specific domain defines its own set of error codes (such as HTTP or gRPC status codes),
-          it's RECOMMENDED to use a domain-specific attribute and also set `error.id` to capture
+          it's RECOMMENDED to use a domain-specific attribute and also set `error.type` to capture
           all errors, regardless of whether they are defined within the domain-specific set or not.

--- a/model/error.yaml
+++ b/model/error.yaml
@@ -7,7 +7,7 @@ groups:
       report an error.
     attributes:
       - id: description
-        brief: 'Describes a class of error that operation ended with.'
+        brief: 'Describes a class of error operation has ended with.'
         type:
           allow_custom_values: true
           members:

--- a/model/http-common.yaml
+++ b/model/http-common.yaml
@@ -64,14 +64,14 @@ groups:
         examples: [200]
       - ref: error.id
         requirement_level:
-          conditionally_required: If request has ended with an error.
+          conditionally_required: If the request has ended with an error.
         examples: ['timeout', 'name_resolution_error', 'server_certificate_invalid']
         note: |
-          If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+          If the response status code was sent/received and the status indicates an error according to the [HTTP span status definition](/docs/http/http-spans.md),
           `error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-          corresponding to the returned status code or to `_OTHER`.
+          corresponding to the returned status code, otherwise it SHOULD be set `_OTHER`.
 
-          If request fails with an error before or after status code was sent or received, such error SHOULD be
+          If the request fails with an error before or after the status code was sent or received, such error SHOULD be
           recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
           Instrumentations SHOULD document the list of errors they report.
 

--- a/model/http-common.yaml
+++ b/model/http-common.yaml
@@ -68,8 +68,8 @@ groups:
         examples: ['timeout', 'name_resolution_error', 'server_certificate_invalid']
         note: |
           If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-          `error.id` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-          returned in the status line or to `_OTHER`.
+          `error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+          corresponding to the returned status code or to `_OTHER`.
 
           If request fails with an error before or after status code was sent or received, such error SHOULD be
           recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.

--- a/model/http-common.yaml
+++ b/model/http-common.yaml
@@ -62,25 +62,27 @@ groups:
           conditionally_required: If and only if one was received/sent.
         brief: '[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).'
         examples: [200]
-      - ref: error.description
+      - ref: error.id
         requirement_level:
-          conditionally_required: If request or response has ended prematurely.
+          conditionally_required: If request has ended with an error.
         examples: ['timeout', 'name_resolution_error', 'server_certificate_invalid']
         note: |
           If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-          `error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+          `error.id` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
           returned in the status line or to `_OTHER`.
 
           If request fails with an error before or after status code was sent or received, such error SHOULD be
-          recorded on `error.description` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+          recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
           Instrumentations SHOULD document the list of errors they report.
 
-          The cardinality of error description within one instrumentation library SHOULD be low, but
+          The cardinality of `error.id` within one instrumentation library SHOULD be low, but
           telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-          should be prepared for `error.description` to have high cardinality at query time, when no
+          should be prepared for `error.id` to have high cardinality at query time, when no
           additional filters are applied.
 
-          If operation has completed successfully, instrumentations SHOULD not set `error.description`.
+          If operation has completed successfully, instrumentations SHOULD not set `error.id`.
+          Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
+          (as an indication that operation did not fail).
       - ref: network.protocol.name
         examples: ['http', 'spdy']
         requirement_level:

--- a/model/http-common.yaml
+++ b/model/http-common.yaml
@@ -62,25 +62,25 @@ groups:
           conditionally_required: If and only if one was received/sent.
         brief: '[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).'
         examples: [200]
-      - ref: error.id
+      - ref: error.type
         requirement_level:
           conditionally_required: If the request has ended with an error.
         examples: ['timeout', 'name_resolution_error', 'server_certificate_invalid']
         note: |
           If the response status code was sent/received and the status indicates an error according to the [HTTP span status definition](/docs/http/http-spans.md),
-          `error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+          `error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
           corresponding to the returned status code, otherwise it SHOULD be set `_OTHER`.
 
           If the request fails with an error before or after the status code was sent or received, such error SHOULD be
-          recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+          recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
           Instrumentations SHOULD document the list of errors they report.
 
-          The cardinality of `error.id` within one instrumentation library SHOULD be low, but
+          The cardinality of `error.type` within one instrumentation library SHOULD be low, but
           telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-          should be prepared for `error.id` to have high cardinality at query time, when no
+          should be prepared for `error.type` to have high cardinality at query time, when no
           additional filters are applied.
 
-          If operation has completed successfully, instrumentations SHOULD not set `error.id`.
+          If operation has completed successfully, instrumentations SHOULD not set `error.type`.
       - ref: network.protocol.name
         examples: ['http', 'spdy']
         requirement_level:

--- a/model/http-common.yaml
+++ b/model/http-common.yaml
@@ -64,15 +64,16 @@ groups:
         examples: [200]
       - ref: error.type
         requirement_level:
-          conditionally_required: If the request has ended with an error.
-        examples: ['timeout', 'name_resolution_error', 'server_certificate_invalid']
+          conditionally_required: If request has ended with an error.
+        examples: ['timeout', 'name_resolution_error', '500']
         note: |
-          If the response status code was sent/received and the status indicates an error according to the [HTTP span status definition](/docs/http/http-spans.md#status),
-          `error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-          corresponding to the returned status code, otherwise it SHOULD be set `_OTHER`.
+          If the request fails with an error before response status code was sent or received,
+          `error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
 
-          If the request fails with an error before or after the status code was sent or received, such error SHOULD be
-          recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+          If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+          `error.type` SHOULD be set to the string representation of the status code, an exception type (if thrown) or a component-specific error code.
+
+          The `error.type` value SHOULD be predictable and SHOULD have low cardinality.
           Instrumentations SHOULD document the list of errors they report.
 
           The cardinality of `error.type` within one instrumentation library SHOULD be low, but
@@ -80,7 +81,7 @@ groups:
           should be prepared for `error.type` to have high cardinality at query time, when no
           additional filters are applied.
 
-          If operation has completed successfully, instrumentations SHOULD not set `error.type`.
+          If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
       - ref: network.protocol.name
         examples: ['http', 'spdy']
         requirement_level:

--- a/model/http-common.yaml
+++ b/model/http-common.yaml
@@ -62,6 +62,25 @@ groups:
           conditionally_required: If and only if one was received/sent.
         brief: '[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).'
         examples: [200]
+      - ref: error.description
+        requirement_level:
+          conditionally_required: If request or response has ended prematurely.
+        examples: ['timeout', 'name_resolution_error', 'server_certificate_invalid']
+        note: |
+          If response status code was sent or received and indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+          `error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+          returned in the status line or to `_OTHER`.
+
+          If request fails with an error before or after status code was sent or received, such error SHOULD be
+          recorded on `error.description` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+          Instrumentations SHOULD document the list of errors they report.
+
+          The cardinality of error description within one instrumentation library SHOULD be low, but
+          telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+          should be prepared for `error.description` to have high cardinality at query time, when no
+          additional filters are applied.
+
+          If operation has completed successfully, instrumentations SHOULD not set `error.description`.
       - ref: network.protocol.name
         examples: ['http', 'spdy']
         requirement_level:

--- a/model/http-common.yaml
+++ b/model/http-common.yaml
@@ -67,7 +67,7 @@ groups:
           conditionally_required: If request or response has ended prematurely.
         examples: ['timeout', 'name_resolution_error', 'server_certificate_invalid']
         note: |
-          If response status code was sent or received and indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+          If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
           `error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
           returned in the status line or to `_OTHER`.
 

--- a/model/http-common.yaml
+++ b/model/http-common.yaml
@@ -67,7 +67,7 @@ groups:
           conditionally_required: If the request has ended with an error.
         examples: ['timeout', 'name_resolution_error', 'server_certificate_invalid']
         note: |
-          If the response status code was sent/received and the status indicates an error according to the [HTTP span status definition](/docs/http/http-spans.md),
+          If the response status code was sent/received and the status indicates an error according to the [HTTP span status definition](/docs/http/http-spans.md#status),
           `error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
           corresponding to the returned status code, otherwise it SHOULD be set `_OTHER`.
 

--- a/model/http-common.yaml
+++ b/model/http-common.yaml
@@ -81,8 +81,6 @@ groups:
           additional filters are applied.
 
           If operation has completed successfully, instrumentations SHOULD not set `error.id`.
-          Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
-          (as an indication that operation did not fail).
       - ref: network.protocol.name
         examples: ['http', 'spdy']
         requirement_level:

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -31,6 +31,25 @@ groups:
             if it's sent in absolute-form.
           - Port identifier of the `Host` header
       # todo (lmolkova) build tools don't populate grandparent attributes
+      - ref: error.description
+        requirement_level:
+          conditionally_required: If request completed with an error.
+        examples: ['timeout', 'name_resolution_error', 'Internal Server Error']
+        note: |
+          If response status code was sent or received and indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+          `error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+          returned in the status line or to `_OTHER`.
+
+          If request fails with an error before or after status code was sent or received, such error SHOULD be
+          recorded on `error.description` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+          Instrumentations SHOULD document the list of errors they report.
+
+          The cardinality of error description within one instrumentation library SHOULD be low, but
+          telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+          should be prepared for `error.description` to have high cardinality at query time, when no
+          additional filters are applied.
+
+          If operation has completed successfully, instrumentations SHOULD NOT set `error.description`.
       - ref: http.request.method
       - ref: http.response.status_code
       - ref: network.protocol.name

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -34,14 +34,15 @@ groups:
       - ref: error.type
         requirement_level:
           conditionally_required: If request has ended with an error.
-        examples: ['timeout', 'name_resolution_error', 'Internal Server Error']
+        examples: ['timeout', 'name_resolution_error', '500']
         note: |
-          If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-          `error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-          corresponding to the returned status code or to `_OTHER`.
+          If the request fails with an error before response status code was sent or received,
+          `error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
 
-          If request fails with an error before or after status code was sent or received, such error SHOULD be
-          recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+          If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+          `error.type` SHOULD be set to the string representation of the status code, an exception type (if thrown) or a component-specific error code.
+
+          The `error.type` value SHOULD be predictable and SHOULD have low cardinality.
           Instrumentations SHOULD document the list of errors they report.
 
           The cardinality of `error.type` within one instrumentation library SHOULD be low, but
@@ -49,7 +50,7 @@ groups:
           should be prepared for `error.type` to have high cardinality at query time, when no
           additional filters are applied.
 
-          If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+          If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
       - ref: http.request.method
       - ref: http.response.status_code
       - ref: network.protocol.name
@@ -69,14 +70,15 @@ groups:
       - ref: error.type
         requirement_level:
           conditionally_required: If request has ended with an error.
-        examples: ['timeout', 'name_resolution_error', 'Internal Server Error']
+        examples: ['timeout', 'name_resolution_error', '500']
         note: |
-          If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-          `error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-          corresponding to the returned status code or to `_OTHER`.
+          If the request fails with an error before response status code was sent or received,
+          `error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
 
-          If request fails with an error before or after status code was sent or received, such error SHOULD be
-          recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+          If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+          `error.type` SHOULD be set to the string representation of the status code, an exception type (if thrown) or a component-specific error code.
+
+          The `error.type` value SHOULD be predictable and SHOULD have low cardinality.
           Instrumentations SHOULD document the list of errors they report.
 
           The cardinality of `error.type` within one instrumentation library SHOULD be low, but
@@ -84,7 +86,7 @@ groups:
           should be prepared for `error.type` to have high cardinality at query time, when no
           additional filters are applied.
 
-          If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+          If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
   - id: metric.http.server.request.duration
     type: metric

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -36,7 +36,7 @@ groups:
           conditionally_required: If request completed with an error.
         examples: ['timeout', 'name_resolution_error', 'Internal Server Error']
         note: |
-          If response status code was sent or received and indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+          If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
           `error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
           returned in the status line or to `_OTHER`.
 

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -50,8 +50,6 @@ groups:
           additional filters are applied.
 
           If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
-          Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
-          (as an indication that operation did not fail).
       - ref: http.request.method
       - ref: http.response.status_code
       - ref: network.protocol.name

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -31,25 +31,25 @@ groups:
             if it's sent in absolute-form.
           - Port identifier of the `Host` header
       # todo (lmolkova) build tools don't populate grandparent attributes
-      - ref: error.id
+      - ref: error.type
         requirement_level:
           conditionally_required: If request has ended with an error.
         examples: ['timeout', 'name_resolution_error', 'Internal Server Error']
         note: |
           If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-          `error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+          `error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
           corresponding to the returned status code or to `_OTHER`.
 
           If request fails with an error before or after status code was sent or received, such error SHOULD be
-          recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+          recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
           Instrumentations SHOULD document the list of errors they report.
 
-          The cardinality of `error.id` within one instrumentation library SHOULD be low, but
+          The cardinality of `error.type` within one instrumentation library SHOULD be low, but
           telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-          should be prepared for `error.id` to have high cardinality at query time, when no
+          should be prepared for `error.type` to have high cardinality at query time, when no
           additional filters are applied.
 
-          If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
+          If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
       - ref: http.request.method
       - ref: http.response.status_code
       - ref: network.protocol.name

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -66,6 +66,25 @@ groups:
       - ref: network.protocol.name
       - ref: network.protocol.version
       - ref: server.socket.address
+      - ref: error.type
+        requirement_level:
+          conditionally_required: If request has ended with an error.
+        examples: ['timeout', 'name_resolution_error', 'Internal Server Error']
+        note: |
+          If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
+          `error.type` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+          corresponding to the returned status code or to `_OTHER`.
+
+          If request fails with an error before or after status code was sent or received, such error SHOULD be
+          recorded on `error.type` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+          Instrumentations SHOULD document the list of errors they report.
+
+          The cardinality of `error.type` within one instrumentation library SHOULD be low, but
+          telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+          should be prepared for `error.type` to have high cardinality at query time, when no
+          additional filters are applied.
+
+          If operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
   - id: metric.http.server.request.duration
     type: metric

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -31,25 +31,27 @@ groups:
             if it's sent in absolute-form.
           - Port identifier of the `Host` header
       # todo (lmolkova) build tools don't populate grandparent attributes
-      - ref: error.description
+      - ref: error.id
         requirement_level:
-          conditionally_required: If request completed with an error.
+          conditionally_required: If request has ended with an error.
         examples: ['timeout', 'name_resolution_error', 'Internal Server Error']
         note: |
           If response status code was sent or received and status indicates an error according to [HTTP span status definition](/docs/http/http-spans.md),
-          `error.description` SHOULD be set to the [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
-          returned in the status line or to `_OTHER`.
+          `error.id` SHOULD be set to the canonical [Reason Phrase](https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1)
+          corresponding to the returned status code or to `_OTHER`.
 
           If request fails with an error before or after status code was sent or received, such error SHOULD be
-          recorded on `error.description` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
+          recorded on `error.id` attribute. The description SHOULD be predictable and SHOULD have low cardinality.
           Instrumentations SHOULD document the list of errors they report.
 
-          The cardinality of error description within one instrumentation library SHOULD be low, but
+          The cardinality of `error.id` within one instrumentation library SHOULD be low, but
           telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-          should be prepared for `error.description` to have high cardinality at query time, when no
+          should be prepared for `error.id` to have high cardinality at query time, when no
           additional filters are applied.
 
-          If operation has completed successfully, instrumentations SHOULD NOT set `error.description`.
+          If operation has completed successfully, instrumentations SHOULD NOT set `error.id`.
+          Telemetry consumers SHOULD treat absence of `error.id` and empty `error.id` the same
+          (as an indication that operation did not fail).
       - ref: http.request.method
       - ref: http.response.status_code
       - ref: network.protocol.name


### PR DESCRIPTION
Fixes #204 

**Proposal:**

- Reserve an attribute for the error code when response code was not received (or reading response body has failed) - `error.type`  (TBD)
- ~~Start with a small, non-controversial set of error types common across HTTP clients in different languages~~. Don't try to unify common errors initially. Even things like timeout (vs cancellation) can be controversial.
- Define 'other' as a dimension cap
- Allow instrumentations to report custom (known, documented, low-cardinality) error types
- If we see similarities in error types across clients/languages, we can consider adding common valuesit into the enum even after HTTP semconv goes stable

(naming and common error suggestions are welcome!)

**Error rate queries**

- `rate(http_request_duration_count{error_type!=""}[1m]) by error_type`



