### PR TITLE
Remove http.request.method_original attribute from HTTP metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ release.
   ([#224](https://github.com/open-telemetry/semantic-conventions/pull/224))
 - Update HTTP `network.protocol.version` examples to match HTTP RFCs.
   ([#228](https://github.com/open-telemetry/semantic-conventions/pull/228))
+- Remove unnecessary `http.request.method_original` attribute from HTTP metrics.
+  ([#231](https://github.com/open-telemetry/semantic-conventions/pull/231))
 
 ## v1.21.0 (2023-07-13)
 

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -90,8 +90,7 @@ SHOULD include the [application root](/docs/http/http-spans.md#http-server-defin
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
-If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER` and, except if reporting a metric, MUST
-set the exact method received in the request line as value of the `http.request.method_original` attribute.
+If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
@@ -100,7 +99,6 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
-Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 


### PR DESCRIPTION
This is a bugfix after (most likely) a copy-paste.

## Changes

The `http.request.method_original` attribute is intended for tracing. For metrics it would leads to unbound cardinality metrics.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
