### PR TITLE
Move Joao Grassi from approver to maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Approvers ([@open-telemetry/specs-semconv-approvers](https://github.com/orgs/ope
 - [Alexander Wert](https://github.com/AlexanderWert), Elastic
 - [Christian Neumüller](https://github.com/Oberon00), Dynatrace
 - [James Moessis](https://github.com/jamesmoessis), Atlassian
-- [Joao Grassi](https://github.com/joaopgrassi), Dynatrace
 - [Johannes Tax](https://github.com/pyohannes), Grafana Labs
 - [Liudmila Molkova](https://github.com/lmolkova), Microsoft
 - [Sean Marciniak](https://github.com/MovieStoreGuy), Atlassian
@@ -30,9 +29,10 @@ _Find more about the approver role in [community repository](https://github.com/
 
 Maintainers ([@open-telemetry/specs-semconv-maintainers](https://github.com/orgs/open-telemetry/teams/specs-semconv-maintainers)):
 
-- [Armin Ruech](https://github.com/arminru)
-- [Josh Suereth](https://github.com/jsuereth)
-- [Reiley Yang](https://github.com/reyang)
+- [Armin Ruech](https://github.com/arminru), Dynatrace
+- [Joao Grassi](https://github.com/joaopgrassi), Dynatrace
+- [Josh Suereth](https://github.com/jsuereth), Google
+- [Reiley Yang](https://github.com/reyang), Microsoft
 
 _Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer)._
 


### PR DESCRIPTION
@joaopgrassi has been [actively contributing to the semantic-conventions](https://github.com/open-telemetry/semantic-conventions/pulls?q=+is%3Apr+author%3Ajoaopgrassi), based on the offline discussions with the current maintainers, we would like to invite Joao as a maintainer of this project.

@arminru @jsuereth

FYI @open-telemetry/specs-semconv-approvers.