### PR TITLE
Update destination attribute briefs

### DIFF
--- a/docs/general/attributes.md
+++ b/docs/general/attributes.md
@@ -221,8 +221,8 @@ Destination fields capture details about the receiver of a network exchange/pack
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `destination.domain` | string | The domain name of the destination system. [1] | `foo.example.com` | Recommended |
-| `destination.address` | string | Peer address, for example IP address or UNIX socket name. | `10.5.3.2` | Recommended |
-| `destination.port` | int | Peer port number | `3389`; `2888` | Recommended |
+| `destination.address` | string | Destination address, for example IP address or UNIX socket name. | `10.5.3.2` | Recommended |
+| `destination.port` | int | Destination port number | `3389`; `2888` | Recommended |
 
 **[1]:** This value may be a host name, a fully qualified domain name, or another host naming format.
 <!-- endsemconv -->

--- a/model/destination.yaml
+++ b/model/destination.yaml
@@ -16,9 +16,9 @@ groups:
         note: This value may be a host name, a fully qualified domain name, or another host naming format.
       - id: address
         type: string
-        brief: 'Peer address, for example IP address or UNIX socket name.'
+        brief: 'Destination address, for example IP address or UNIX socket name.'
         examples: ['10.5.3.2']
       - id: port
         type: int
-        brief: 'Peer port number'
+        brief: 'Destination port number'
         examples: [3389, 2888]


### PR DESCRIPTION
Based on @Oberon00's https://github.com/open-telemetry/semantic-conventions/issues/206#issue-1819655650

> * destination.address: "Peer address, for example IP address or UNIX socket name." _(why does it use the removed term "peer" here? That would mean something rather different, and would match our old remote/local concept)_
