### PR TITLE
`http/dup` has higher precedence than `http` in `OTEL_SEMCONV_STABILITY_OPT_IN`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ release.
   clients invoking them.
 - BREAKING: Rename all JVM metrics from `process.runtime.jvm.*` to `jvm.*`
   ([#241](https://github.com/open-telemetry/semantic-conventions/pull/241))
+- BREAKING: Rename all JVM metrics from `process.runtime.jvm.*` to `jvm.*`
+  ([#241](https://github.com/open-telemetry/semantic-conventions/pull/241))
+- Clarify that `http/dup` has higher precedence than `http` in case both values are present
+  in `OTEL_SEMCONV_STABILITY_OPT_IN`
+  ([#249](https://github.com/open-telemetry/semantic-conventions/pull/249))
 
 ## v1.21.0 (2023-07-13)
 

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -37,6 +37,7 @@ linkTitle: Client Calls
 >   * The default behavior (in the absence of one of these values) is to continue
 >     emitting whatever version of the old experimental networking attributes
 >     the instrumentation was emitting previously.
+>   * Note: `http/dup` has higher precedence than `http` in case both values are present
 > * SHOULD maintain (security patching at a minimum) the existing major version
 >   for at least six months after it starts emitting both sets of attributes.
 > * SHOULD drop the environment variable in the next major version (stable

--- a/docs/http/README.md
+++ b/docs/http/README.md
@@ -33,6 +33,7 @@ and various HTTP versions like 1.1, 2 and SPDY.
 >   * The default behavior (in the absence of one of these values) is to continue
 >     emitting whatever version of the old experimental HTTP and networking attributes
 >     the instrumentation was emitting previously.
+>   * Note: `http/dup` has higher precedence than `http` in case both values are present
 > * SHOULD maintain (security patching at a minimum) the existing major version
 >   for at least six months after it starts emitting both sets of attributes.
 > * SHOULD drop the environment variable in the next major version (stable

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -46,6 +46,7 @@ operations. By adding HTTP attributes to metric events it allows for finely tune
 >   * The default behavior (in the absence of one of these values) is to continue
 >     emitting whatever version of the old experimental HTTP and networking attributes
 >     the instrumentation was emitting previously.
+>   * Note: `http/dup` has higher precedence than `http` in case both values are present
 > * SHOULD maintain (security patching at a minimum) the existing major version
 >   for at least six months after it starts emitting both sets of attributes.
 > * SHOULD drop the environment variable in the next major version (stable

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -52,6 +52,7 @@ and various HTTP versions like 1.1, 2 and SPDY.
 >   * The default behavior (in the absence of one of these values) is to continue
 >     emitting whatever version of the old experimental HTTP and networking attributes
 >     the instrumentation was emitting previously.
+>   * Note: `http/dup` has higher precedence than `http` in case both values are present
 > * SHOULD maintain (security patching at a minimum) the existing major version
 >   for at least six months after it starts emitting both sets of attributes.
 > * SHOULD drop the environment variable in the next major version (stable

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -53,6 +53,7 @@
 >   * The default behavior (in the absence of one of these values) is to continue
 >     emitting whatever version of the old experimental networking attributes
 >     the instrumentation was emitting previously.
+>   * Note: `http/dup` has higher precedence than `http` in case both values are present
 > * SHOULD maintain (security patching at a minimum) the existing major version
 >   for at least six months after it starts emitting both sets of attributes.
 > * SHOULD drop the environment variable in the next major version (stable

--- a/docs/rpc/rpc-metrics.md
+++ b/docs/rpc/rpc-metrics.md
@@ -55,6 +55,7 @@ metrics can be filtered for finer grain analysis.
 >   * The default behavior (in the absence of one of these values) is to continue
 >     emitting whatever version of the old experimental networking attributes
 >     the instrumentation was emitting previously.
+>   * Note: `http/dup` has higher precedence than `http` in case both values are present
 > * SHOULD maintain (security patching at a minimum) the existing major version
 >   for at least six months after it starts emitting both sets of attributes.
 > * SHOULD drop the environment variable in the next major version (stable

--- a/docs/rpc/rpc-spans.md
+++ b/docs/rpc/rpc-spans.md
@@ -45,6 +45,7 @@ This document defines how to describe remote procedure calls
 >   * The default behavior (in the absence of one of these values) is to continue
 >     emitting whatever version of the old experimental networking attributes
 >     the instrumentation was emitting previously.
+>   * Note: `http/dup` has higher precedence than `http` in case both values are present
 > * SHOULD maintain (security patching at a minimum) the existing major version
 >   for at least six months after it starts emitting both sets of attributes.
 > * SHOULD drop the environment variable in the next major version (stable


### PR DESCRIPTION
Fixes #240

## Changes

Clarify that `http/dup` has higher precedence than `http` in case both values are present in user supplied `OTEL_SEMCONV_STABILITY_OPT_IN` value.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [x] ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~
