### PR TITLE
Remove pluralization from JVM metric namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ release.
   clients invoking them.
 - BREAKING: Rename all JVM metrics from `process.runtime.jvm.*` to `jvm.*`
   ([#241](https://github.com/open-telemetry/semantic-conventions/pull/241))
+- BREAKING: Remove pluralization from JVM metric namespaces.
+  ([#252](https://github.com/open-telemetry/semantic-conventions/pull/252))
 
 ## v1.21.0 (2023-07-13)
 

--- a/docs/system/runtime-environment-metrics.md
+++ b/docs/system/runtime-environment-metrics.md
@@ -265,15 +265,6 @@ This metric is obtained from [`ClassLoadingMXBean#getUnloadedClassCount()`](http
 This metric is [recommended][MetricRecommended].
 This metric is obtained from [`ClassLoadingMXBean#getLoadedClassCount()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/ClassLoadingMXBean.html#getLoadedClassCount--).
 
-<<<<<<< HEAD
-<!-- semconv metric.jvm.class.current_loaded(metric_table) -->
-| Name     | Instrument Type | Unit (UCUM) | Description    |
-| -------- | --------------- | ----------- | -------------- |
-| `jvm.class.current_loaded` | UpDownCounter | `{class}` | Number of classes currently loaded. |
-<!-- endsemconv -->
-
-<!-- semconv metric.jvm.class.count(full) -->
-=======
 <!-- semconv metric.jvm.class.count(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |

--- a/docs/system/runtime-environment-metrics.md
+++ b/docs/system/runtime-environment-metrics.md
@@ -25,10 +25,10 @@ semantic conventions when instrumenting runtime environments.
   * [Metric: `jvm.memory.limit`](#metric-jvmmemorylimit)
   * [Metric: `jvm.memory.usage_after_last_gc`](#metric-jvmmemoryusage_after_last_gc)
   * [Metric: `jvm.gc.duration`](#metric-jvmgcduration)
-  * [Metric: `jvm.threads.count`](#metric-jvmthreadscount)
-  * [Metric: `jvm.classes.loaded`](#metric-jvmclassesloaded)
-  * [Metric: `jvm.classes.unloaded`](#metric-jvmclassesunloaded)
-  * [Metric: `jvm.classes.current_loaded`](#metric-jvmclassescurrent_loaded)
+  * [Metric: `jvm.thread.count`](#metric-jvmthreadcount)
+  * [Metric: `jvm.class.loaded`](#metric-jvmclassloaded)
+  * [Metric: `jvm.class.unloaded`](#metric-jvmclassunloaded)
+  * [Metric: `jvm.class.current_loaded`](#metric-jvmclasscurrent_loaded)
   * [Metric: `jvm.cpu.time`](#metric-jvmcputime)
   * [Metric: `jvm.cpu.recent_utilization`](#metric-jvmcpurecent_utilization)
 - [JVM Metrics (Experimental)](#jvm-metrics-experimental)
@@ -212,65 +212,65 @@ of `[]` (single bucket histogram capturing count, sum, min, max).
 **[2]:** Garbage collector action is generally obtained via [GarbageCollectionNotificationInfo#getGcAction()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()).
 <!-- endsemconv -->
 
-### Metric: `jvm.threads.count`
+### Metric: `jvm.thread.count`
 
 This metric is [recommended][MetricRecommended].
 This metric is obtained from [`ThreadMXBean#getDaemonThreadCount()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getDaemonThreadCount--) and
 [`ThreadMXBean#getThreadCount()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getThreadCount--).
 Note that this is the number of platform threads (as opposed to virtual threads).
 
-<!-- semconv metric.jvm.threads.count(metric_table) -->
+<!-- semconv metric.jvm.thread.count(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `jvm.threads.count` | UpDownCounter | `{thread}` | Number of executing platform threads. |
+| `jvm.thread.count` | UpDownCounter | `{thread}` | Number of executing platform threads. |
 <!-- endsemconv -->
 
-<!-- semconv metric.jvm.threads.count(full) -->
+<!-- semconv metric.jvm.thread.count(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `daemon` | boolean | Whether the thread is daemon or not. |  | Recommended |
 <!-- endsemconv -->
 
-### Metric: `jvm.classes.loaded`
+### Metric: `jvm.class.loaded`
 
 This metric is [recommended][MetricRecommended].
 This metric is obtained from [`ClassLoadingMXBean#getTotalLoadedClassCount()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/ClassLoadingMXBean.html#getTotalLoadedClassCount--).
 
-<!-- semconv metric.jvm.classes.loaded(metric_table) -->
+<!-- semconv metric.jvm.class.loaded(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `jvm.classes.loaded` | Counter | `{class}` | Number of classes loaded since JVM start. |
+| `jvm.class.loaded` | Counter | `{class}` | Number of classes loaded since JVM start. |
 <!-- endsemconv -->
 
-<!-- semconv metric.jvm.classes.loaded(full) -->
+<!-- semconv metric.jvm.class.loaded(full) -->
 <!-- endsemconv -->
 
-### Metric: `jvm.classes.unloaded`
+### Metric: `jvm.class.unloaded`
 
 This metric is [recommended][MetricRecommended].
 This metric is obtained from [`ClassLoadingMXBean#getUnloadedClassCount()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/ClassLoadingMXBean.html#getUnloadedClassCount--).
 
-<!-- semconv metric.jvm.classes.unloaded(metric_table) -->
+<!-- semconv metric.jvm.class.unloaded(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `jvm.classes.unloaded` | Counter | `{class}` | Number of classes unloaded since JVM start. |
+| `jvm.class.unloaded` | Counter | `{class}` | Number of classes unloaded since JVM start. |
 <!-- endsemconv -->
 
-<!-- semconv metric.jvm.classes.unloaded(full) -->
+<!-- semconv metric.jvm.class.unloaded(full) -->
 <!-- endsemconv -->
 
-### Metric: `jvm.classes.current_loaded`
+### Metric: `jvm.class.current_loaded`
 
 This metric is [recommended][MetricRecommended].
 This metric is obtained from [`ClassLoadingMXBean#getLoadedClassCount()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/ClassLoadingMXBean.html#getLoadedClassCount--).
 
-<!-- semconv metric.jvm.classes.current_loaded(metric_table) -->
+<!-- semconv metric.jvm.class.current_loaded(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `jvm.classes.current_loaded` | UpDownCounter | `{class}` | Number of classes currently loaded. |
+| `jvm.class.current_loaded` | UpDownCounter | `{class}` | Number of classes currently loaded. |
 <!-- endsemconv -->
 
-<!-- semconv metric.jvm.classes.current_loaded(full) -->
+<!-- semconv metric.jvm.class.current_loaded(full) -->
 <!-- endsemconv -->
 
 ### Metric: `jvm.cpu.time`

--- a/model/metrics/process-runtime-jvm-metrics.yaml
+++ b/model/metrics/process-runtime-jvm-metrics.yaml
@@ -81,9 +81,9 @@ groups:
           Garbage collector action is generally obtained via
           [GarbageCollectionNotificationInfo#getGcAction()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()).
 
-  - id: metric.jvm.threads.count
+  - id: metric.jvm.thread.count
     type: metric
-    metric_name: jvm.threads.count
+    metric_name: jvm.thread.count
     brief: "Number of executing platform threads."
     instrument: updowncounter
     unit: "{thread}"
@@ -93,23 +93,23 @@ groups:
         type: boolean
         requirement_level: recommended
 
-  - id: metric.jvm.classes.loaded
+  - id: metric.jvm.class.loaded
     type: metric
-    metric_name: jvm.classes.loaded
+    metric_name: jvm.class.loaded
     brief: "Number of classes loaded since JVM start."
     instrument: counter
     unit: "{class}"
 
-  - id: metric.jvm.classes.unloaded
+  - id: metric.jvm.class.unloaded
     type: metric
-    metric_name: jvm.classes.unloaded
+    metric_name: jvm.class.unloaded
     brief: "Number of classes unloaded since JVM start."
     instrument: counter
     unit: "{class}"
 
-  - id: metric.jvm.classes.current_loaded
+  - id: metric.jvm.class.current_loaded
     type: metric
-    metric_name: jvm.classes.current_loaded
+    metric_name: jvm.class.current_loaded
     brief: "Number of classes currently loaded."
     instrument: updowncounter
     unit: "{class}"

--- a/schema-next.yaml
+++ b/schema-next.yaml
@@ -15,10 +15,14 @@ versions:
             process.runtime.jvm.memory.limit: jvm.memory.limit
             process.runtime.jvm.memory.usage_after_last_gc: jvm.memory.usage_after_last_gc
             process.runtime.jvm.gc.duration: jvm.gc.duration
-            process.runtime.jvm.threads.count: jvm.threads.count
-            process.runtime.jvm.classes.loaded: jvm.classes.loaded
-            process.runtime.jvm.classes.unloaded: jvm.classes.unloaded
-            process.runtime.jvm.classes.current_loaded: jvm.classes.current_loaded
+            # also https://github.com/open-telemetry/semantic-conventions/pull/252
+            process.runtime.jvm.threads.count: jvm.thread.count
+            # also https://github.com/open-telemetry/semantic-conventions/pull/252
+            process.runtime.jvm.classes.loaded: jvm.class.loaded
+            # also https://github.com/open-telemetry/semantic-conventions/pull/252
+            process.runtime.jvm.classes.unloaded: jvm.class.unloaded
+            # also https://github.com/open-telemetry/semantic-conventions/pull/252
+            process.runtime.jvm.classes.current_loaded: jvm.class.current_loaded
             process.runtime.jvm.cpu.time: jvm.cpu.time
             process.runtime.jvm.cpu.recent_utilization: jvm.cpu.recent_utilization
             process.runtime.jvm.memory.init: jvm.memory.init


### PR DESCRIPTION
## Changes

Remove pluralization from JVM metric namespaces.

Related to https://github.com/open-telemetry/semantic-conventions/issues/212 and https://github.com/open-telemetry/opentelemetry-specification/pull/3658

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
