### PR TITLE
Faas: Add an option to use the X-Ray env var as main parent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ release.
 - Clarify that `http/dup` has higher precedence than `http` in case both values are present
   in `OTEL_SEMCONV_STABILITY_OPT_IN`
   ([#249](https://github.com/open-telemetry/semantic-conventions/pull/249))
+- FaaS: Add an option to use the X-Ray env var as main parent.
+  ([]())
 
 ## v1.21.0 (2023-07-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ release.
   in `OTEL_SEMCONV_STABILITY_OPT_IN`
   ([#249](https://github.com/open-telemetry/semantic-conventions/pull/249))
 - FaaS: Add an option to use the X-Ray env var as main parent.
-  ([]())
+  ([#263](https://github.com/open-telemetry/semantic-conventions/pull/263))
 
 ## v1.21.0 (2023-07-13)
 

--- a/docs/faas/aws-lambda.md
+++ b/docs/faas/aws-lambda.md
@@ -66,6 +66,10 @@ contain an incomplete trace context which indicates X-Ray isn’t enabled. The e
 `Context` will be valid and sampled only if AWS X-Ray has been enabled for the Lambda function. A user can
 disable AWS X-Ray for the function if the X-Ray Span Link is not desired.
 
+Instrumentation SHOULD include an explicit option to use `Context` in `_X_AMZN_TRACE_ID` as parent insted of `Link`,
+as long as it is a valid `Context`, as described above. Else, it will follow the standard behavior of using the extracted value
+from the user's configured propagators applied to the HTTP headers.
+
 **Note**: When instrumenting a Java AWS Lambda, instrumentation SHOULD first try to parse an OpenTelemetry `Context` out of the system property `com.amazonaws.xray.traceHeader` using the [AWS X-Ray Propagator](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md) before checking and attempting to parse the environment variable above.
 
 [Span Link]: https://opentelemetry.io/docs/concepts/signals/traces/#span-links

--- a/docs/faas/aws-lambda.md
+++ b/docs/faas/aws-lambda.md
@@ -67,7 +67,7 @@ contain an incomplete trace context which indicates X-Ray isn’t enabled. The e
 disable AWS X-Ray for the function if the X-Ray Span Link is not desired.
 
 Instrumentation SHOULD include an explicit option to use `Context` in `_X_AMZN_TRACE_ID` as parent insted of `Link`,
-as long as it is a valid `Context`, as described above. Else, it will follow the standard behavior of using the extracted value
+as long as it is a valid `Context`, as described above. If the option is not present, it will follow the standard behavior of using the extracted value
 from the user's configured propagators applied to the HTTP headers.
 
 **Note**: When instrumenting a Java AWS Lambda, instrumentation SHOULD first try to parse an OpenTelemetry `Context` out of the system property `com.amazonaws.xray.traceHeader` using the [AWS X-Ray Propagator](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md) before checking and attempting to parse the environment variable above.


### PR DESCRIPTION
This is done to offer compatibility to users with the previous behavior (which used the context in this X-Ray environment variable as the main parent). 

Please review @open-telemetry/lambda-extension-approvers @dyladan @open-telemetry/python-maintainers 

Note: I didn't include an actual name for this option, but I'm open to suggestions. 

Closely related to https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1411 
