### PR TITLE
Separation of attribute definitions from attribute usages: URL

### DIFF
--- a/docs/attributes-dictionary/README.md
+++ b/docs/attributes-dictionary/README.md
@@ -3,6 +3,7 @@ linkTitle: Attributes Dictionary
 --->
 
 # Attributes Dictionary
+
 All attributes defined in the semantic conventions are listed by namespace in this dictionary.
 Currently, the following namespaces exist:
 

--- a/docs/attributes-dictionary/README.md
+++ b/docs/attributes-dictionary/README.md
@@ -1,0 +1,9 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Attributes Dictionary
+--->
+
+# Attributes Dictionary
+All attributes defined in the semantic conventions are listed by namespace in this dictionary.
+Currently, the following namespaces exist:
+
+* [HTTP](http.md)

--- a/docs/attributes-dictionary/http.md
+++ b/docs/attributes-dictionary/http.md
@@ -2,6 +2,8 @@
 linkTitle: HTTP
 --->
 
+# HTTP
+
 <!-- semconv registry.http -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|

--- a/docs/attributes-dictionary/http.md
+++ b/docs/attributes-dictionary/http.md
@@ -1,0 +1,51 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: HTTP
+--->
+
+<!-- semconv registry.http -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
+| `http.request.method` | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Recommended |
+| `http.request.method_original` | string | Original HTTP method sent by the client in the request line. | `GeT`; `ACL`; `foo` | Recommended |
+| `http.resend_count` | int | The ordinal number of request resending attempt (for any reason, including redirects). [2] | `3` | Recommended |
+| `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
+| `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Recommended |
+| `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [3] | `/users/:userID?`; `{controller}/{action}/{id?}` | Recommended |
+
+**[1]:** HTTP request method value SHOULD be "known" to the instrumentation.
+By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+
+If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER` and, except if reporting a metric, MUST
+set the exact method received in the request line as value of the `http.request.method_original` attribute.
+
+If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+
+HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+
+**[2]:** The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues, or any other).
+
+**[3]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
+
+`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `CONNECT` | CONNECT method. |
+| `DELETE` | DELETE method. |
+| `GET` | GET method. |
+| `HEAD` | HEAD method. |
+| `OPTIONS` | OPTIONS method. |
+| `PATCH` | PATCH method. |
+| `POST` | POST method. |
+| `PUT` | PUT method. |
+| `TRACE` | TRACE method. |
+| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. |
+<!-- endsemconv -->

--- a/docs/database/elasticsearch.md
+++ b/docs/database/elasticsearch.md
@@ -39,7 +39,7 @@ in order to map the path part values to their names.
 |---|---|---|---|---|
 | [`db.operation`](database-spans.md) | string | The endpoint identifier for the request. [1] | `search`; `ml.close_job`; `cat.aliases` | Required |
 | [`db.statement`](database-spans.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. | `"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"` | Recommended: [2] |
-| `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../attributes-dictionary/http.md) | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
 | [`server.address`](../general/attributes.md) | string | Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is not known. | `example.com` | See below |
 | [`server.port`](../general/attributes.md) | int | Logical server port number | `80`; `8080`; `443` | Recommended |
 | [`url.full`](../url/url.md) | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [4] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -74,19 +74,16 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 <!-- semconv metric.http.server.request.duration(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `http.request.method` | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
-| `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`http.request.method`](../attributes-dictionary/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`http.response.status_code`](../attributes-dictionary/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`http.route`](../attributes-dictionary/http.md) | string | The matched route (path template in the format used by the respective server framework). See note below [2] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
 | [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [4] | `example.com` | Opt-In |
 | [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [5] | `80`; `8080`; `443` | Opt-In |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
-**[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
-SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
-
-**[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
+**[1]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
@@ -101,6 +98,9 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
 Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+
+**[2]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -152,7 +152,7 @@ This metric is optional.
 <!-- semconv metric.http.server.active_requests(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.request.method` | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../attributes-dictionary/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
 | [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [2] | `example.com` | Opt-In |
 | [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [3] | `80`; `8080`; `443` | Opt-In |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
@@ -221,19 +221,16 @@ This metric is optional.
 <!-- semconv metric.http.server.request.size(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `http.request.method` | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
-| `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`http.request.method`](../attributes-dictionary/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`http.response.status_code`](../attributes-dictionary/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`http.route`](../attributes-dictionary/http.md) | string | The matched route (path template in the format used by the respective server framework). See note below [2] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
 | [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [4] | `example.com` | Opt-In |
 | [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [5] | `80`; `8080`; `443` | Opt-In |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
-**[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
-SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
-
-**[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
+**[1]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
@@ -248,6 +245,9 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
 Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+
+**[2]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -299,19 +299,16 @@ This metric is optional.
 <!-- semconv metric.http.server.response.size(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `http.request.method` | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
-| `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`http.request.method`](../attributes-dictionary/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`http.response.status_code`](../attributes-dictionary/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`http.route`](../attributes-dictionary/http.md) | string | The matched route (path template in the format used by the respective server framework). See note below [2] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
 | [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [4] | `example.com` | Opt-In |
 | [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [5] | `80`; `8080`; `443` | Opt-In |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
-**[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
-SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
-
-**[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
+**[1]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
@@ -326,6 +323,9 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
 Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+
+**[2]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
@@ -385,8 +385,8 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 <!-- semconv metric.http.client.request.duration(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.request.method` | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
-| `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`http.request.method`](../attributes-dictionary/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`http.response.status_code`](../attributes-dictionary/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
 | [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `example.com` | Required |
@@ -454,8 +454,8 @@ This metric is optional.
 <!-- semconv metric.http.client.request.size(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.request.method` | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
-| `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`http.request.method`](../attributes-dictionary/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`http.response.status_code`](../attributes-dictionary/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
 | [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `example.com` | Required |
@@ -523,8 +523,8 @@ This metric is optional.
 <!-- semconv metric.http.client.response.size(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.request.method` | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
-| `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`http.request.method`](../attributes-dictionary/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`http.response.status_code`](../attributes-dictionary/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
 | [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `example.com` | Required |

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -95,20 +95,18 @@ sections below.
 <!-- semconv trace.http.common(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| `http.request.method_original` | string | Original HTTP method sent by the client in the request line. | `GeT`; `ACL`; `foo` | Conditionally Required: [1] |
-| `http.request.body.size` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
-| `http.response.body.size` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
-| `http.request.method` | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.body.size`](../attributes-dictionary/http.md) | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
+| [`http.request.method`](../attributes-dictionary/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method_original`](../attributes-dictionary/http.md) | string | Original HTTP method sent by the client in the request line. | `GeT`; `ACL`; `foo` | Conditionally Required: [2] |
+| [`http.response.body.size`](../attributes-dictionary/http.md) | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size. | `3495` | Recommended |
+| [`http.response.status_code`](../attributes-dictionary/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `http`; `spdy` | Recommended: if not default (`http`). |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [3] | `1.0`; `1.1`; `2`; `3` | Recommended |
 | [`network.transport`](../general/attributes.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Conditionally Required: [4] |
 | [`network.type`](../general/attributes.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
 | `user_agent.original` | string | Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | Recommended |
 
-**[1]:** If and only if it's different than `http.request.method`.
-
-**[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
+**[1]:** HTTP request method value SHOULD be "known" to the instrumentation.
 By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 
@@ -124,13 +122,15 @@ HTTP method names are case-sensitive and `http.request.method` attribute value M
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
 Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
 
+**[2]:** If and only if it's different than `http.request.method`.
+
 **[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
 **[4]:** If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
 
 Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
 
-* `http.request.method`
+* [`http.request.method`](../attributes-dictionary/http.md)
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -196,7 +196,7 @@ For an HTTP client span, `SpanKind` MUST be `Client`.
 <!-- semconv trace.http.client(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.resend_count` | int | The ordinal number of request resending attempt (for any reason, including redirects). [1] | `3` | Recommended: if and only if request was retried. |
+| [`http.resend_count`](../attributes-dictionary/http.md) | int | The ordinal number of request resending attempt (for any reason, including redirects). [1] | `3` | Recommended: if and only if request was retried. |
 | [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `example.com` | Required |
 | [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
 | [`server.socket.address`](../general/attributes.md) | string | Physical server IP address or Unix socket address. If set from the client, should simply use the socket's peer address, and not attempt to find any actual server IP (i.e., if set from client, this may represent some proxy server instead of the logical server). | `10.5.3.2` | Recommended: If different than `server.address`. |
@@ -326,11 +326,11 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 <!-- semconv trace.http.server(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| [`client.address`](../general/attributes.md) | string | Client address - unix domain socket name, IPv4 or IPv6 address. [2] | `83.164.160.102` | Recommended |
-| [`client.port`](../general/attributes.md) | int | The port of the original client behind all proxies, if known (e.g. from [Forwarded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded) or a similar header). Otherwise, the immediate client peer port. [3] | `65123` | Recommended |
+| [`client.address`](../general/attributes.md) | string | Client address - unix domain socket name, IPv4 or IPv6 address. [1] | `83.164.160.102` | Recommended |
+| [`client.port`](../general/attributes.md) | int | The port of the original client behind all proxies, if known (e.g. from [Forwarded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded) or a similar header). Otherwise, the immediate client peer port. [2] | `65123` | Recommended |
 | [`client.socket.address`](../general/attributes.md) | string | Immediate client peer address - unix domain socket name, IPv4 or IPv6 address. | `/tmp/my.sock`; `127.0.0.1` | Recommended: If different than `client.address`. |
 | [`client.socket.port`](../general/attributes.md) | int | Immediate client peer port number | `35555` | Recommended: If different than `client.port`. |
+| [`http.route`](../attributes-dictionary/http.md) | string | The matched route (path template in the format used by the respective server framework). See note below [3] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
 | [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [4] | `example.com` | Recommended |
 | [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [5] | `80`; `8080`; `443` | Recommended: [6] |
 | [`server.socket.address`](../general/attributes.md) | string | Local socket address. Useful in case of a multi-IP host. | `10.5.3.2` | Opt-In |
@@ -339,12 +339,12 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 | [`url.query`](../url/url.md) | string | The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component [8] | `q=OpenTelemetry` | Conditionally Required: If and only if one was received/sent. |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
-**[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+**[1]:** The IP address of the original client behind all proxies, if known (e.g. from [Forwarded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded), [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For), or a similar header). Otherwise, the immediate client peer address.
+
+**[2]:** When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent client port behind any intermediaries (e.g. proxies) if it's available.
+
+**[3]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
-
-**[2]:** The IP address of the original client behind all proxies, if known (e.g. from [Forwarded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded), [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For), or a similar header). Otherwise, the immediate client peer address.
-
-**[3]:** When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent client port behind any intermediaries (e.g. proxies) if it's available.
 
 **[4]:** Determined by using the first of the following that applies
 

--- a/model/http-common.yaml
+++ b/model/http-common.yaml
@@ -2,67 +2,12 @@ groups:
   - id: attributes.http.common
     type: attribute_group
     brief: "Describes HTTP attributes."
-    prefix: http
     attributes:
-      - id: request.method
-        type:
-          allow_custom_values: true
-          members:
-            - id: connect
-              value: "CONNECT"
-              brief: 'CONNECT method.'
-            - id: delete
-              value: "DELETE"
-              brief: 'DELETE method.'
-            - id: get
-              value: "GET"
-              brief: 'GET method.'
-            - id: head
-              value: "HEAD"
-              brief: 'HEAD method.'
-            - id: options
-              value: "OPTIONS"
-              brief: 'OPTIONS method.'
-            - id: patch
-              value: "PATCH"
-              brief: 'PATCH method.'
-            - id: post
-              value: "POST"
-              brief: 'POST method.'
-            - id: put
-              value: "PUT"
-              brief: 'PUT method.'
-            - id: trace
-              value: "TRACE"
-              brief: 'TRACE method.'
-            - id: other
-              value: "_OTHER"
-              brief: 'Any HTTP method that the instrumentation has no prior knowledge of.'
+      - ref: http.request.method
         requirement_level: required
-        brief: 'HTTP request method.'
-        examples: ["GET", "POST", "HEAD"]
-        note: |
-          HTTP request method value SHOULD be "known" to the instrumentation.
-          By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-          and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-
-          If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER` and, except if reporting a metric, MUST
-          set the exact method received in the request line as value of the `http.request.method_original` attribute.
-
-          If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
-          the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-          OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-          (this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
-
-          HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
-          Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
-          Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
-      - id: response.status_code
-        type: int
+      - ref: http.response.status_code
         requirement_level:
           conditionally_required: If and only if one was received/sent.
-        brief: '[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).'
-        examples: [200]
       - ref: network.protocol.name
         examples: ['http', 'spdy']
         requirement_level:
@@ -71,7 +16,6 @@ groups:
         examples: ['1.0', '1.1', '2', '3']
 
   - id: attributes.http.client
-    prefix: http
     type: attribute_group
     brief: 'HTTP Client attributes'
     attributes:
@@ -97,21 +41,12 @@ groups:
           URI port identifier, otherwise it MUST match `Host` header port identifier.
 
   - id: attributes.http.server
-    prefix: http
     type: attribute_group
     brief: 'HTTP Server attributes'
     attributes:
-      - id: route
-        type: string
+      - ref: http.route
         requirement_level:
           conditionally_required: If and only if it's available
-        brief: >
-            The matched route (path template in the format used by the respective server framework). See note below
-        examples: ['/users/:userID?', '{controller}/{action}/{id?}']
-        note: >
-          MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
-
-          SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
       - ref: server.address
         brief: >
           Name of the local HTTP server that received the request.

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -32,7 +32,10 @@ groups:
           - Port identifier of the `Host` header
       # todo (lmolkova) build tools don't populate grandparent attributes
       - ref: http.request.method
+        requirement_level: required
       - ref: http.response.status_code
+        requirement_level:
+          conditionally_required: If and only if one was received/sent.
       - ref: network.protocol.name
       - ref: network.protocol.version
 
@@ -43,7 +46,10 @@ groups:
     attributes:
       # todo (lmolkova) build tools don't populate grandparent attributes
       - ref: http.request.method
+        requirement_level: required
       - ref: http.response.status_code
+        requirement_level:
+          conditionally_required: If and only if one was received/sent.
       - ref: network.protocol.name
       - ref: network.protocol.version
       - ref: server.socket.address
@@ -64,6 +70,7 @@ groups:
     unit: "{request}"
     attributes:
       - ref: http.request.method
+        requirement_level: required
       - ref: url.scheme
         requirement_level: required
         examples: ["http", "https"]

--- a/model/registry/http.yaml
+++ b/model/registry/http.yaml
@@ -96,4 +96,3 @@ groups:
           MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 
           SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
-

--- a/model/registry/http.yaml
+++ b/model/registry/http.yaml
@@ -1,0 +1,99 @@
+groups:
+  - id: registry.http
+    prefix: http
+    type: attribute_group
+    brief: 'This document defines semantic convention attributes in the HTTP namespace.'
+    attributes:
+      - id: request.body.size
+        type: int
+        brief: >
+          The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and
+          is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)
+          header. For requests using transport encoding, this should be the compressed size.
+        examples: 3495
+      - id: request.method
+        type:
+          allow_custom_values: true
+          members:
+            - id: connect
+              value: "CONNECT"
+              brief: 'CONNECT method.'
+            - id: delete
+              value: "DELETE"
+              brief: 'DELETE method.'
+            - id: get
+              value: "GET"
+              brief: 'GET method.'
+            - id: head
+              value: "HEAD"
+              brief: 'HEAD method.'
+            - id: options
+              value: "OPTIONS"
+              brief: 'OPTIONS method.'
+            - id: patch
+              value: "PATCH"
+              brief: 'PATCH method.'
+            - id: post
+              value: "POST"
+              brief: 'POST method.'
+            - id: put
+              value: "PUT"
+              brief: 'PUT method.'
+            - id: trace
+              value: "TRACE"
+              brief: 'TRACE method.'
+            - id: other
+              value: "_OTHER"
+              brief: 'Any HTTP method that the instrumentation has no prior knowledge of.'
+        brief: 'HTTP request method.'
+        examples: ["GET", "POST", "HEAD"]
+        note: |
+          HTTP request method value SHOULD be "known" to the instrumentation.
+          By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+          and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+
+          If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER` and, except if reporting a metric, MUST
+          set the exact method received in the request line as value of the `http.request.method_original` attribute.
+
+          If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+          the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+          OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+          (this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+
+          HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+          Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+          Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+      - id: request.method_original
+        type: string
+        brief: Original HTTP method sent by the client in the request line.
+        examples: ["GeT", "ACL", "foo"]
+      - id: resend_count
+        type: int
+        brief: >
+          The ordinal number of request resending attempt (for any reason, including redirects).
+        note: >
+          The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what
+          was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues,
+          or any other).
+        examples: 3
+      - id: response.body.size
+        type: int
+        brief: >
+          The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and
+          is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)
+          header. For requests using transport encoding, this should be the compressed size.
+        examples: 3495
+      - id: response.status_code
+        type: int
+        brief: '[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).'
+        examples: [200]
+      - id: route
+        type: string
+        brief: >
+            The matched route (path template in the format used by the respective server framework). See note below
+        examples: ['/users/:userID?', '{controller}/{action}/{id?}']
+        note: >
+          MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+
+          SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
+

--- a/model/registry/url.yaml
+++ b/model/registry/url.yaml
@@ -1,0 +1,37 @@
+groups:
+  - id: registry.url
+    brief: Attributes describing URL.
+    type: attribute_group
+    prefix: url
+    attributes:
+      - id: scheme
+        type: string
+        brief: 'The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol.'
+        examples: ["https", "ftp", "telnet"]
+      - id: full
+        type: string
+        brief: Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986)
+        note: >
+          For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment
+          is not transmitted over HTTP, but if it is known, it should be included nevertheless.
+
+          `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`.
+          In such case username and password should be redacted and attribute's value should be `https://REDACTED:REDACTED@www.example.com/`.
+
+          `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed)
+          and SHOULD NOT be validated or modified except for sanitizing purposes.
+        examples: ['https://www.foo.bar/search?q=OpenTelemetry#SemConv', '//localhost']
+      - id: path
+        type: string
+        brief: 'The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component'
+        examples: ['/search']
+        note: When missing, the value is assumed to be `/`
+      - id: query
+        type: string
+        brief: 'The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component'
+        examples: ["q=OpenTelemetry"]
+        note: Sensitive content provided in query string SHOULD be scrubbed when instrumentations can identify it.
+      - id: fragment
+        type: string
+        brief: 'The [URI fragment](https://www.rfc-editor.org/rfc/rfc3986#section-3.5) component'
+        examples: ["SemConv"]

--- a/model/trace/http.yaml
+++ b/model/trace/http.yaml
@@ -1,6 +1,5 @@
 groups:
   - id: trace.http.common
-    prefix: http
     extends: attributes.http.common
     type: attribute_group
     brief: 'This document defines semantic conventions for HTTP client and server Spans.'
@@ -8,28 +7,14 @@ groups:
         These conventions can be used for http and https schemes
         and various HTTP versions like 1.1, 2 and SPDY.
     attributes:
-      - id: request.method_original
-        type: string
+      - ref: http.request.method_original
         requirement_level:
           conditionally_required: If and only if it's different than `http.request.method`.
-        brief: Original HTTP method sent by the client in the request line.
-        examples: ["GeT", "ACL", "foo"]
-      - id: request.body.size
-        type: int
-        brief: >
-          The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and
-          is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)
-          header. For requests using transport encoding, this should be the compressed size.
-        examples: 3495
-      - id: response.body.size
-        type: int
-        brief: >
-          The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and
-          is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)
-          header. For requests using transport encoding, this should be the compressed size.
-        examples: 3495
+      - ref: http.request.body.size
+      - ref: http.response.body.size
       - ref: http.request.method
         sampling_relevant: true
+        requirement_level: required
       - ref: network.transport
         requirement_level:
           conditionally_required: If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
@@ -37,23 +22,14 @@ groups:
       - ref: user_agent.original
 
   - id: trace.http.client
-    prefix: http
     type: span
     extends: attributes.http.client
     span_kind: client
     brief: 'Semantic Convention for HTTP Client'
     attributes:
-      - id: resend_count
-        type: int
-        brief: >
-          The ordinal number of request resending attempt (for any reason, including redirects).
-        note: >
-          The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what
-          was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues,
-          or any other).
+      - ref: http.resend_count
         requirement_level:
           recommended: if and only if request was retried.
-        examples: 3
       - ref: server.address
         sampling_relevant: true
         requirement_level: required
@@ -86,7 +62,6 @@ groups:
 
 
   - id: trace.http.server
-    prefix: http
     type: span
     extends: attributes.http.server
     span_kind: server

--- a/model/url.yaml
+++ b/model/url.yaml
@@ -4,36 +4,10 @@ groups:
     type: attribute_group
     prefix: url
     attributes:
-      - id: scheme
-        type: string
-        brief: 'The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol.'
-        examples: ["https", "ftp", "telnet"]
-      - id: full
-        type: string
-        brief: Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986)
-        note: >
-          For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment
-          is not transmitted over HTTP, but if it is known, it should be included nevertheless.
-
-          `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`.
-          In such case username and password should be redacted and attribute's value should be `https://REDACTED:REDACTED@www.example.com/`.
-
-          `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed)
-          and SHOULD NOT be validated or modified except for sanitizing purposes.
-        examples: ['https://www.foo.bar/search?q=OpenTelemetry#SemConv', '//localhost']
+      - ref: url.scheme
+      - ref: url.full
         tag: sensitive-information
-      - id: path
-        type: string
-        brief: 'The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component'
-        examples: ['/search']
-        note: When missing, the value is assumed to be `/`
-      - id: query
-        type: string
-        brief: 'The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component'
-        examples: ["q=OpenTelemetry"]
-        note: Sensitive content provided in query string SHOULD be scrubbed when instrumentations can identify it.
+      - ref: url.path
+      - ref: url.query
         tag: sensitive-information
-      - id: fragment
-        type: string
-        brief: 'The [URI fragment](https://www.rfc-editor.org/rfc/rfc3986#section-3.5) component'
-        examples: ["SemConv"]
+      - ref: url.fragment


### PR DESCRIPTION
## Changes

Please provide a brief description of the changes here.
Continue on separating definitions from usage. This PR will change `url` structure

This PR is based on https://github.com/open-telemetry/semantic-conventions/pull/208 to not have tree conflicts with double creation of new folders etc.

Please note, this is pure refactoring and not a new functionality

