### PR TITLE
Simplify HTTP metric briefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ release.
   ([#60](https://github.com/open-telemetry/semantic-conventions/pull/60))
 - BREAKING: Remove pluralization from JVM metric namespaces.
   ([#252](https://github.com/open-telemetry/semantic-conventions/pull/252))
+- Simplify HTTP metric briefs.
+  ([#276](https://github.com/open-telemetry/semantic-conventions/pull/276))
 
 ## v1.21.0 (2023-07-13)
 

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -214,7 +214,9 @@ This metric is optional.
 <!-- semconv metric.http.server.request.size(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `http.server.request.size` | Histogram | `By` | Measures the size of HTTP request messages (compressed). |
+| `http.server.request.size` | Histogram | `By` | Measures the size of HTTP request messages. [1] |
+
+**[1]:** Size as measured over the wire (compressed size if messages are compressed).
 <!-- endsemconv -->
 
 <!-- semconv metric.http.server.request.size(full) -->
@@ -291,7 +293,9 @@ This metric is optional.
 <!-- semconv metric.http.server.response.size(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `http.server.response.size` | Histogram | `By` | Measures the size of HTTP response messages (compressed). |
+| `http.server.response.size` | Histogram | `By` | Measures the size of HTTP response messages. [1] |
+
+**[1]:** Size as measured over the wire (compressed size if messages are compressed).
 <!-- endsemconv -->
 
 <!-- semconv metric.http.server.response.size(full) -->
@@ -447,7 +451,9 @@ This metric is optional.
 <!-- semconv metric.http.client.request.size(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `http.client.request.size` | Histogram | `By` | Measures the size of HTTP request messages (compressed). |
+| `http.client.request.size` | Histogram | `By` | Measures the size of HTTP request messages. [1] |
+
+**[1]:** Size as measured over the wire (compressed size if messages are compressed).
 <!-- endsemconv -->
 
 <!-- semconv metric.http.client.request.size(full) -->
@@ -518,7 +524,9 @@ This metric is optional.
 <!-- semconv metric.http.client.response.size(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `http.client.response.size` | Histogram | `By` | Measures the size of HTTP response messages (compressed). |
+| `http.client.response.size` | Histogram | `By` | Measures the size of HTTP response messages. [1] |
+
+**[1]:** Size as measured over the wire (compressed size if messages are compressed).
 <!-- endsemconv -->
 
 <!-- semconv metric.http.client.response.size(full) -->

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -97,17 +97,19 @@ groups:
   - id: metric.http.server.request.size
     type: metric
     metric_name: http.server.request.size
-    brief: "Measures the size of HTTP request messages (compressed)."
+    brief: "Measures the size of HTTP request messages."
     instrument: histogram
     unit: "By"
+    note: Size as measured over the wire (compressed size if messages are compressed).
     extends: metric_attributes.http.server
 
   - id: metric.http.server.response.size
     type: metric
     metric_name: http.server.response.size
-    brief: "Measures the size of HTTP response messages (compressed)."
+    brief: "Measures the size of HTTP response messages."
     instrument: histogram
     unit: "By"
+    note: Size as measured over the wire (compressed size if messages are compressed).
     extends: metric_attributes.http.server
 
   - id: metric.http.client.request.duration
@@ -121,15 +123,17 @@ groups:
   - id: metric.http.client.request.size
     type: metric
     metric_name: http.client.request.size
-    brief: "Measures the size of HTTP request messages (compressed)."
+    brief: "Measures the size of HTTP request messages."
     instrument: histogram
     unit: "By"
+    note: Size as measured over the wire (compressed size if messages are compressed).
     extends: metric_attributes.http.client
 
   - id: metric.http.client.response.size
     type: metric
     metric_name: http.client.response.size
-    brief: "Measures the size of HTTP response messages (compressed)."
+    brief: "Measures the size of HTTP response messages."
     instrument: histogram
     unit: "By"
+    note: Size as measured over the wire (compressed size if messages are compressed).
     extends: metric_attributes.http.client


### PR DESCRIPTION
Similar motivation to #275

## Changes

Simplify HTTP metric briefs

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [x] ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~
