### PR TITLE
Add container metric fields (from ECS)

### DIFF
--- a/.chloggen/add_new_container_metrics.yaml
+++ b/.chloggen/add_new_container_metrics.yaml
@@ -1,0 +1,21 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: "container"
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add new container metrics for `cpu`, `memory`, `disk` and `network`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [282, 72]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,6 +364,8 @@ stabilized.
 - Make `network.protocol.name|version` description consistent between HTTP
   spans and metrics.
   ([#367](https://github.com/open-telemetry/semantic-conventions/pull/367))
+- Add container metric fields (from ECS).
+  ([#282](https://github.com/open-telemetry/semantic-conventions/pull/282))
 
 ## v1.21.0 (2023-07-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,8 +364,6 @@ stabilized.
 - Make `network.protocol.name|version` description consistent between HTTP
   spans and metrics.
   ([#367](https://github.com/open-telemetry/semantic-conventions/pull/367))
-- Add container metric fields (from ECS).
-  ([#282](https://github.com/open-telemetry/semantic-conventions/pull/282))
 
 ## v1.21.0 (2023-07-13)
 

--- a/docs/attributes-registry/container.md
+++ b/docs/attributes-registry/container.md
@@ -28,3 +28,17 @@ The ID is assinged by the container runtime and can vary in different environmen
 
 **[3]:** [Docker](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect) and [CRI](https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238) report those under the `RepoDigests` field.
 <!-- endsemconv -->
+
+<!-- semconv registry.container.cpu(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  |
+|---|---|---|---|
+| `container.cpu.state` | string | The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `user`; `kernel` |
+
+`container.cpu.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `user` | When tasks of the cgroup are in user mode (Linux). When all container processes are in user mode (Windows). |
+| `system` | When CPU is used by the system (host OS) |
+| `kernel` | When tasks of the cgroup are in kernel mode (Linux). When all container processes are in kernel mode (Windows). |
+<!-- endsemconv -->

--- a/docs/attributes-registry/container.md
+++ b/docs/attributes-registry/container.md
@@ -11,7 +11,7 @@
 | `container.command` | string | The command used to run the container (i.e. the command name). [1] | `otelcontribcol` |
 | `container.command_args` | string[] | All the command arguments (including the command/executable itself) run by the container. [2] | `[otelcontribcol, --config, config.yaml]` |
 | `container.command_line` | string | The full command run by the container as a single string representing the full command. [2] | `otelcontribcol --config config.yaml` |
-| `container.cpu.state` | string | The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `user`; `kernel` |
+| `container.cpu.state` | string | The CPU state for this data point. | `user`; `kernel` |
 | `container.id` | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` |
 | `container.image.id` | string | Runtime specific image identifier. Usually a hash algorithm followed by a UUID. [2] | `sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f` |
 | `container.image.name` | string | Name of the image the container was built on. | `gcr.io/opentelemetry/operator` |

--- a/docs/attributes-registry/container.md
+++ b/docs/attributes-registry/container.md
@@ -11,6 +11,7 @@
 | `container.command` | string | The command used to run the container (i.e. the command name). [1] | `otelcontribcol` |
 | `container.command_args` | string[] | All the command arguments (including the command/executable itself) run by the container. [2] | `[otelcontribcol, --config, config.yaml]` |
 | `container.command_line` | string | The full command run by the container as a single string representing the full command. [2] | `otelcontribcol --config config.yaml` |
+| `container.cpu.state` | string | The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `user`; `kernel` |
 | `container.id` | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` |
 | `container.image.id` | string | Runtime specific image identifier. Usually a hash algorithm followed by a UUID. [2] | `sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f` |
 | `container.image.name` | string | Name of the image the container was built on. | `gcr.io/opentelemetry/operator` |
@@ -27,12 +28,6 @@ K8s defines a link to the container registry repository with digest `"imageID": 
 The ID is assinged by the container runtime and can vary in different environments. Consider using `oci.manifest.digest` if it is important to identify the same image in different environments/runtimes.
 
 **[3]:** [Docker](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect) and [CRI](https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238) report those under the `RepoDigests` field.
-<!-- endsemconv -->
-
-<!-- semconv registry.container.cpu(omit_requirement_level) -->
-| Attribute  | Type | Description  | Examples  |
-|---|---|---|---|
-| `container.cpu.state` | string | The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `user`; `kernel` |
 
 `container.cpu.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -8,7 +8,7 @@ linkTitle: Container
 
 ## Container Metrics
 
-### Metric: `container.cpu.utilization`
+### Metric: `container.cpu.time`
 
 This metric is optional.
 
@@ -23,10 +23,10 @@ This metric is optional.
 <!-- semconv metric.container.cpu.time(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `container.cpu.state` | string | The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `user`; `kernel` | Opt-In |
+| [`container.cpu.state`](../attributes-registry/container.md) | string | The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `user`; `kernel` | Opt-In |
 | [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
 
-`container.cpu.state` MUST be one of the following:
+`container.cpu.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|
@@ -35,7 +35,7 @@ This metric is optional.
 | `kernel` | When tasks of the cgroup are in kernel mode (Linux). When all container processes are in kernel mode (Windows). |
 <!-- endsemconv -->
 
-### Metric: `container.memory.utilization`
+### Metric: `container.memory.usage`
 
 This metric is optional.
 
@@ -70,6 +70,7 @@ This metric is optional.
 |---|---|---|---|---|
 | [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
 | [`disk.io.direction`](../attributes-registry/disk.md) | string | The disk IO operation direction. | `read` | Recommended |
+| `system.device` | string | The device identifier | `(identifier)` | Recommended |
 
 `disk.io.direction` MUST be one of the following:
 
@@ -96,6 +97,7 @@ This metric is optional.
 |---|---|---|---|---|
 | [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
 | [`network.io.direction`](../attributes-registry/network.md) | string | The network IO operation direction. | `transmit` | Recommended |
+| `system.device` | string | The device identifier | `(identifier)` | Recommended |
 
 `network.io.direction` MUST be one of the following:
 

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -15,7 +15,7 @@ This metric is optional.
 <!-- semconv metric.container.cpu.time(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `container.cpu.time` | Counter | `ns` | Total CPU time consumed [1] |
+| `container.cpu.time` | Counter | `s` | Total CPU time consumed [1] |
 
 **[1]:** Total CPU time consumed by the specific container.
 <!-- endsemconv -->

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -8,94 +8,92 @@ linkTitle: Container
 
 ## Container Metrics
 
-### Metric: `container.cpu.usage`
+### Metric: `container.cpu.utilization`
 
 This metric is optional.
 
-<!-- semconv metric.container.cpu.usage(metric_table) -->
+<!-- semconv metric.container.cpu.utilization(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `container.cpu.usage` | Gauge | `1` | Recent CPU utilization for the container. [1] |
+| `container.cpu.utilization` | Gauge | `1` | Recent CPU utilization for the container. [1] |
 
 **[1]:** CPU usage percentage normalized by the number of CPU cores. The value range is [0.0,1.0].
 <!-- endsemconv -->
 
-<!-- semconv metric.container.cpu.usage(full) -->
+<!-- semconv metric.container.cpu.utilization(full) -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`container.id`](../resource/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
 <!-- endsemconv -->
 
-### Metric: `container.memory.usage`
+### Metric: `container.memory.utilization`
 
 This metric is optional.
 
-<!-- semconv metric.container.memory.usage(metric_table) -->
+<!-- semconv metric.container.memory.utilization(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `container.memory.usage` | Gauge | `1` | Recent memory utilization for the container. [1] |
+| `container.memory.utilization` | Gauge | `1` | Recent memory utilization for the container. [1] |
 
 **[1]:** Memory usage percentage. The value range is [0.0,1.0].
 <!-- endsemconv -->
 
-<!-- semconv metric.container.memory.usage(full) -->
+<!-- semconv metric.container.memory.utilization(full) -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`container.id`](../resource/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
 <!-- endsemconv -->
 
-### Metric: `container.disk.read.bytes`
+### Metric: `container.disk.io.bytes`
 
 This metric is optional.
 
-<!-- semconv metric.container.disk.read.bytes(metric_table) -->
+<!-- semconv metric.container.disk.io.bytes(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `container.disk.read.bytes` | Counter | `By` | Disk read bytes for the container. [1] |
+| `container.disk.io.bytes` | Counter | `By` | Disk bytes for the container. [1] |
 
-**[1]:** The total number of bytes read successfully (aggregated from all disks).
+**[1]:** The total number of bytes read/written successfully (aggregated from all disks).
 <!-- endsemconv -->
 
-<!-- semconv metric.container.disk.read.bytes(full) -->
+<!-- semconv metric.container.disk.io.bytes(full) -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `container.disk.io.direction` | string | The disk IO operation's direction | `read`; `write` | Recommended |
+| [`container.id`](../resource/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+
+`container.disk.io.direction` MUST be one of the following:
+
+| Value  | Description |
+|---|---|
+| `read` | read |
+| `write` | write |
 <!-- endsemconv -->
 
-### Metric: `container.disk.write.bytes`
+### Metric: `container.network.io.bytes`
 
 This metric is optional.
 
-<!-- semconv metric.container.disk.write.bytes(metric_table) -->
+<!-- semconv metric.container.network.io.bytes(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `container.disk.write.bytes` | Counter | `By` | Disk write bytes for the container. [1] |
+| `container.disk.io.bytes` | Counter | `By` | Network bytes for the container. [1] |
 
-**[1]:** The total number of bytes written successfully (aggregated from all disks).
+**[1]:** The number of bytes sent/received on all network interfaces by the container.
 <!-- endsemconv -->
 
-<!-- semconv metric.container.disk.write.bytes(full) -->
-<!-- endsemconv -->
+<!-- semconv metric.container.network.io.bytes(full) -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`container.id`](../resource/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+| `container.network.io.direction` | string | The Network IO direction | `ingress`; `egress` | Recommended |
 
-### Metric: `container.network.ingress.bytes`
+`container.network.io.direction` MUST be one of the following:
 
-This metric is optional.
-
-<!-- semconv metric.container.network.ingress.bytes(metric_table) -->
-| Name     | Instrument Type | Unit (UCUM) | Description    |
-| -------- | --------------- | ----------- | -------------- |
-| `container.network.ingress.bytes` | Counter | `By` | Network ingress bytes for the container. [1] |
-
-**[1]:** The number of bytes received on all network interfaces by the container.
-<!-- endsemconv -->
-
-<!-- semconv metric.container.network.ingress.bytes(full) -->
-<!-- endsemconv -->
-
-### Metric: `container.network.egress.bytes`
-
-This metric is optional.
-
-<!-- semconv metric.container.network.egress.bytes(metric_table) -->
-| Name     | Instrument Type | Unit (UCUM) | Description    |
-| -------- | --------------- | ----------- | -------------- |
-| `container.network.egress.bytes` | Counter | `By` | Network egress bytes for the container. [1] |
-
-**[1]:** The number of bytes sent out on all network interfaces by the container.
-<!-- endsemconv -->
-
-<!-- semconv metric.container.network.egress.bytes(full) -->
+| Value  | Description |
+|---|---|
+| `ingress` | ingress |
+| `egress` | egress |
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.22.0/specification/document-status.md

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -31,7 +31,7 @@ This metric is optional.
 | Value  | Description |
 |---|---|
 | `user` | When tasks of the cgroup are in user mode (Linux). When all container processes are in user mode (Windows). |
-| `system` | When CPU is used by the system |
+| `system` | When CPU is used by the system (host OS) |
 | `kernel` | When tasks of the cgroup are in kernel mode (Linux). When all container processes are in kernel mode (Windows). |
 <!-- endsemconv -->
 

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -12,33 +12,42 @@ linkTitle: Container
 
 This metric is optional.
 
-<!-- semconv metric.container.cpu.utilization(metric_table) -->
+<!-- semconv metric.container.cpu.time(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `container.cpu.utilization` | Gauge | `1` | Recent CPU utilization for the container. [1] |
+| `container.cpu.time` | Counter | `ns` | Total CPU time consumed [1] |
 
-**[1]:** CPU usage percentage normalized by the number of CPU cores. The value range is [0.0,1.0].
+**[1]:** Total CPU time consumed by the specific container.
 <!-- endsemconv -->
 
-<!-- semconv metric.container.cpu.utilization(full) -->
+<!-- semconv metric.container.cpu.time(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
+| `container.cpu.state` | string | The state of the CPU | `user`; `kernel` | Opt-In |
 | [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+
+`container.cpu.state` MUST be one of the following:
+
+| Value  | Description |
+|---|---|
+| `user` | user |
+| `system` | system |
+| `kernel` | kernel |
 <!-- endsemconv -->
 
 ### Metric: `container.memory.utilization`
 
 This metric is optional.
 
-<!-- semconv metric.container.memory.utilization(metric_table) -->
+<!-- semconv metric.container.memory.usage(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `container.memory.utilization` | Gauge | `1` | Recent memory utilization for the container. [1] |
+| `container.memory.usage` | Counter | `By` | Memory usage of the container. [1] |
 
-**[1]:** Memory usage percentage. The value range is [0.0,1.0].
+**[1]:** Memory usage of the container.
 <!-- endsemconv -->
 
-<!-- semconv metric.container.memory.utilization(full) -->
+<!-- semconv metric.container.memory.usage(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -17,7 +17,7 @@ This metric is optional.
 | -------- | --------------- | ----------- | -------------- |
 | `container.cpu.time` | Counter | `s` | Total CPU time consumed [1] |
 
-**[1]:** Total CPU time consumed by the specific container.
+**[1]:** Total CPU time consumed by the specific container on all available CPU cores
 <!-- endsemconv -->
 
 <!-- semconv metric.container.cpu.time(full) -->

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -23,7 +23,7 @@ This metric is optional.
 <!-- semconv metric.container.cpu.utilization(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`container.id`](../resource/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+| [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
 <!-- endsemconv -->
 
 ### Metric: `container.memory.utilization`
@@ -41,28 +41,28 @@ This metric is optional.
 <!-- semconv metric.container.memory.utilization(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`container.id`](../resource/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+| [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
 <!-- endsemconv -->
 
-### Metric: `container.disk.io.bytes`
+### Metric: `container.disk.io`
 
 This metric is optional.
 
-<!-- semconv metric.container.disk.io.bytes(metric_table) -->
+<!-- semconv metric.container.disk.io(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `container.disk.io.bytes` | Counter | `By` | Disk bytes for the container. [1] |
+| `container.disk.io` | Counter | `By` | Disk bytes for the container. [1] |
 
 **[1]:** The total number of bytes read/written successfully (aggregated from all disks).
 <!-- endsemconv -->
 
-<!-- semconv metric.container.disk.io.bytes(full) -->
+<!-- semconv metric.container.disk.io(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `container.disk.io.direction` | string | The disk IO operation's direction | `read`; `write` | Recommended |
-| [`container.id`](../resource/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+| [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+| `disk.io.direction` | string | The disk IO operation direction. | `read` | Recommended |
 
-`container.disk.io.direction` MUST be one of the following:
+`disk.io.direction` MUST be one of the following:
 
 | Value  | Description |
 |---|---|
@@ -70,30 +70,30 @@ This metric is optional.
 | `write` | write |
 <!-- endsemconv -->
 
-### Metric: `container.network.io.bytes`
+### Metric: `container.network.io`
 
 This metric is optional.
 
-<!-- semconv metric.container.network.io.bytes(metric_table) -->
+<!-- semconv metric.container.network.io(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `container.disk.io.bytes` | Counter | `By` | Network bytes for the container. [1] |
+| `container.network.io` | Counter | `By` | Network bytes for the container. [1] |
 
 **[1]:** The number of bytes sent/received on all network interfaces by the container.
 <!-- endsemconv -->
 
-<!-- semconv metric.container.network.io.bytes(full) -->
+<!-- semconv metric.container.network.io(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`container.id`](../resource/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
-| `container.network.io.direction` | string | The Network IO direction | `ingress`; `egress` | Recommended |
+| [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
+| [`network.io.direction`](../attributes-registry/network.md) | string | The network IO operation direction. | `transmit` | Recommended |
 
-`container.network.io.direction` MUST be one of the following:
+`network.io.direction` MUST be one of the following:
 
 | Value  | Description |
 |---|---|
-| `ingress` | ingress |
-| `egress` | egress |
+| `transmit` | transmit |
+| `receive` | receive |
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.22.0/specification/document-status.md

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -24,7 +24,6 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`container.cpu.state`](../attributes-registry/container.md) | string | The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `user`; `kernel` | Opt-In |
-| [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
 
 `container.cpu.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -48,9 +47,6 @@ This metric is optional.
 <!-- endsemconv -->
 
 <!-- semconv metric.container.memory.usage(full) -->
-| Attribute  | Type | Description  | Examples  | Requirement Level |
-|---|---|---|---|---|
-| [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
 <!-- endsemconv -->
 
 ### Metric: `container.disk.io`
@@ -68,7 +64,6 @@ This metric is optional.
 <!-- semconv metric.container.disk.io(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
 | [`disk.io.direction`](../attributes-registry/disk.md) | string | The disk IO operation direction. | `read` | Recommended |
 | `system.device` | string | The device identifier | `(identifier)` | Recommended |
 
@@ -95,7 +90,6 @@ This metric is optional.
 <!-- semconv metric.container.network.io(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
 | [`network.io.direction`](../attributes-registry/network.md) | string | The network IO operation direction. | `transmit` | Recommended |
 | `system.device` | string | The device identifier | `(identifier)` | Recommended |
 

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -60,7 +60,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
-| `disk.io.direction` | string | The disk IO operation direction. | `read` | Recommended |
+| [`disk.io.direction`](../attributes-registry/disk.md) | string | The disk IO operation direction. | `read` | Recommended |
 
 `disk.io.direction` MUST be one of the following:
 

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -23,16 +23,16 @@ This metric is optional.
 <!-- semconv metric.container.cpu.time(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `container.cpu.state` | string | The state of the CPU | `user`; `kernel` | Opt-In |
+| `container.cpu.state` | string | The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `user`; `kernel` | Opt-In |
 | [`container.id`](../attributes-registry/container.md) | string | Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated. | `a3bf90e006b2` | Recommended |
 
 `container.cpu.state` MUST be one of the following:
 
 | Value  | Description |
 |---|---|
-| `user` | user |
-| `system` | system |
-| `kernel` | kernel |
+| `user` | When tasks of the cgroup are in user mode (Linux). When all container processes are in user mode (Windows). |
+| `system` | When CPU is used by the system |
+| `kernel` | When tasks of the cgroup are in kernel mode (Linux). When all container processes are in kernel mode (Windows). |
 <!-- endsemconv -->
 
 ### Metric: `container.memory.utilization`

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -1,0 +1,101 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Container
+--->
+
+# Semantic Conventions for Container Metrics
+
+**Status**: [Experimental][DocumentStatus]
+
+## Container Metrics
+
+### Metric: `container.cpu.usage`
+
+This metric is optional.
+
+<!-- semconv metric.container.cpu.usage(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `container.cpu.usage` | Gauge | `1` | Recent CPU utilization for the container. [1] |
+
+**[1]:** CPU usage percentage normalized by the number of CPU cores. The value range is [0.0,1.0].
+<!-- endsemconv -->
+
+<!-- semconv metric.container.cpu.usage(full) -->
+<!-- endsemconv -->
+
+### Metric: `container.memory.usage`
+
+This metric is optional.
+
+<!-- semconv metric.container.memory.usage(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `container.memory.usage` | Gauge | `1` | Recent memory utilization for the container. [1] |
+
+**[1]:** Memory usage percentage. The value range is [0.0,1.0].
+<!-- endsemconv -->
+
+<!-- semconv metric.container.memory.usage(full) -->
+<!-- endsemconv -->
+
+### Metric: `container.disk.read.bytes`
+
+This metric is optional.
+
+<!-- semconv metric.container.disk.read.bytes(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `container.disk.read.bytes` | Counter | `By` | Disk read bytes for the container. [1] |
+
+**[1]:** The total number of bytes read successfully (aggregated from all disks).
+<!-- endsemconv -->
+
+<!-- semconv metric.container.disk.read.bytes(full) -->
+<!-- endsemconv -->
+
+### Metric: `container.disk.write.bytes`
+
+This metric is optional.
+
+<!-- semconv metric.container.disk.write.bytes(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `container.disk.write.bytes` | Counter | `By` | Disk write bytes for the container. [1] |
+
+**[1]:** The total number of bytes written successfully (aggregated from all disks).
+<!-- endsemconv -->
+
+<!-- semconv metric.container.disk.write.bytes(full) -->
+<!-- endsemconv -->
+
+### Metric: `container.network.ingress.bytes`
+
+This metric is optional.
+
+<!-- semconv metric.container.network.ingress.bytes(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `container.network.ingress.bytes` | Counter | `By` | Network ingress bytes for the container. [1] |
+
+**[1]:** The number of bytes received on all network interfaces by the container.
+<!-- endsemconv -->
+
+<!-- semconv metric.container.network.ingress.bytes(full) -->
+<!-- endsemconv -->
+
+### Metric: `container.network.egress.bytes`
+
+This metric is optional.
+
+<!-- semconv metric.container.network.egress.bytes(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `container.network.egress.bytes` | Counter | `By` | Network egress bytes for the container. [1] |
+
+**[1]:** The number of bytes sent out on all network interfaces by the container.
+<!-- endsemconv -->
+
+<!-- semconv metric.container.network.egress.bytes(full) -->
+<!-- endsemconv -->
+
+[DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.22.0/specification/document-status.md

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -10,7 +10,7 @@ linkTitle: Container
 
 ### Metric: `container.cpu.time`
 
-This metric is optional.
+This metric is [opt-in][MetricOptIn].
 
 <!-- semconv metric.container.cpu.time(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
@@ -36,7 +36,7 @@ This metric is optional.
 
 ### Metric: `container.memory.usage`
 
-This metric is optional.
+This metric is [opt-in][MetricOptIn].
 
 <!-- semconv metric.container.memory.usage(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
@@ -51,7 +51,7 @@ This metric is optional.
 
 ### Metric: `container.disk.io`
 
-This metric is optional.
+This metric is [opt-in][MetricOptIn].
 
 <!-- semconv metric.container.disk.io(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
@@ -77,7 +77,7 @@ This metric is optional.
 
 ### Metric: `container.network.io`
 
-This metric is optional.
+This metric is [opt-in][MetricOptIn].
 
 <!-- semconv metric.container.network.io(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
@@ -102,3 +102,4 @@ This metric is optional.
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.22.0/specification/document-status.md
+[MetricOptIn]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.26.0/specification/metrics/metric-requirement-level.md#opt-in

--- a/model/metrics/container.yaml
+++ b/model/metrics/container.yaml
@@ -6,16 +6,19 @@ groups:
     brief: "Describes Container CPU metric attributes"
     attributes:
       - id: state
+        brief: "The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels."
         type:
           allow_custom_values: false
           members:
             - id: user
               value: 'user'
+              brief: "When tasks of the cgroup are in user mode (Linux). When all container processes are in user mode (Windows)."
             - id: system
               value: 'system'
+              brief: "When CPU is used by the system"
             - id: kernel
               value: 'kernel'
-        brief: "The state of the CPU"
+              brief: "When tasks of the cgroup are in kernel mode (Linux). When all container processes are in kernel mode (Windows)."
         examples: ["user", "kernel"]
   - id: metric.container.cpu.time
     type: metric

--- a/model/metrics/container.yaml
+++ b/model/metrics/container.yaml
@@ -10,9 +10,10 @@ groups:
     unit: "s"
     attributes:
       - ref: container.cpu.state
+        brief: "The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels."
         requirement_level: opt_in
 
-    # container.memory.* metrics and attribute group
+  # container.memory.* metrics and attribute group
   - id: metric.container.memory.usage
     type: metric
     metric_name: container.memory.usage

--- a/model/metrics/container.yaml
+++ b/model/metrics/container.yaml
@@ -1,0 +1,57 @@
+groups:
+  - id: metric.container.cpu.usage
+    type: metric
+    metric_name: container.cpu.usage
+    brief: "Recent CPU utilization for the container."
+    note: >
+      CPU usage percentage normalized by the number of CPU cores.
+      The value range is [0.0,1.0].
+    instrument: gauge
+    unit: "1"
+  - id: metric.container.memory.usage
+    type: metric
+    metric_name: container.memory.usage
+    brief: "Recent memory utilization for the container."
+    note: >
+      Memory usage percentage.
+      The value range is [0.0,1.0].
+    instrument: gauge
+    unit: "1"
+  - id: metric.container.disk.read.bytes
+    type: metric
+    metric_name: container.disk.read.bytes
+    brief: "Disk read bytes for the container."
+    note: >
+      The total number of bytes read
+      successfully (aggregated from all disks).
+    instrument: counter
+    unit: "By"
+  - id: metric.container.disk.write.bytes
+    type: metric
+    metric_name: container.disk.write.bytes
+    brief: "Disk write bytes for the container."
+    note: >
+      The total number of bytes written
+      successfully (aggregated from all disks).
+    instrument: counter
+    unit: "By"
+  - id: metric.container.network.ingress.bytes
+    type: metric
+    metric_name: container.network.ingress.bytes
+    brief: "Network ingress bytes for the container."
+    note: >
+      The number of bytes received
+      on all network interfaces
+      by the container.
+    instrument: counter
+    unit: "By"
+  - id: metric.container.network.egress.bytes
+    type: metric
+    metric_name: container.network.egress.bytes
+    brief: "Network egress bytes for the container."
+    note: >
+      The number of bytes sent out
+      on all network interfaces
+      by the container.
+    instrument: counter
+    unit: "By"

--- a/model/metrics/container.yaml
+++ b/model/metrics/container.yaml
@@ -7,7 +7,7 @@ groups:
     note: >
       Total CPU time consumed by the specific container.
     instrument: counter
-    unit: "ns"
+    unit: "s"
     attributes:
       - ref: container.cpu.state
         requirement_level: opt_in

--- a/model/metrics/container.yaml
+++ b/model/metrics/container.yaml
@@ -15,7 +15,7 @@ groups:
               brief: "When tasks of the cgroup are in user mode (Linux). When all container processes are in user mode (Windows)."
             - id: system
               value: 'system'
-              brief: "When CPU is used by the system"
+              brief: "When CPU is used by the system (host OS)"
             - id: kernel
               value: 'kernel'
               brief: "When tasks of the cgroup are in kernel mode (Linux). When all container processes are in kernel mode (Windows)."

--- a/model/metrics/container.yaml
+++ b/model/metrics/container.yaml
@@ -23,24 +23,9 @@ groups:
       - ref: container.id
 
   # container.disk.io.* metrics and attribute group
-  - id: attributes.container.disk.io
-    prefix: container.disk.io
-    type: attribute_group
-    brief: "Describes Container Disk IO metric attributes"
-    attributes:
-      - id: direction
-        type:
-          allow_custom_values: false
-          members:
-            - id: read
-              value: 'read'
-            - id: write
-              value: 'write'
-        brief: "The disk IO operation's direction"
-        examples: [ "read", "write" ]
-  - id: metric.container.disk.io.bytes
+  - id: metric.container.disk.io
     type: metric
-    metric_name: container.disk.io.bytes
+    metric_name: container.disk.io
     brief: "Disk bytes for the container."
     note: >
       The total number of bytes read/written
@@ -49,27 +34,12 @@ groups:
     unit: "By"
     attributes:
       - ref: container.id
-      - ref: container.disk.io.direction
+      - ref: disk.io.direction
 
   # container.network.io.* metrics and attribute group
-  - id: attributes.container.network.io
-    prefix: container.network.io
-    type: attribute_group
-    brief: "Describes Container Network IO metric attributes"
-    attributes:
-      - id: direction
-        type:
-          allow_custom_values: false
-          members:
-            - id: ingress
-              value: 'ingress'
-            - id: egress
-              value: 'egress'
-        brief: "The Network IO direction"
-        examples: [ "ingress", "egress" ]
-  - id: metric.container.network.io.bytes
+  - id: metric.container.network.io
     type: metric
-    metric_name: container.disk.io.bytes
+    metric_name: container.network.io
     brief: "Network bytes for the container."
     note: >
       The number of bytes sent/received
@@ -79,4 +49,4 @@ groups:
     unit: "By"
     attributes:
       - ref: container.id
-      - ref: container.network.io.direction
+      - ref: network.io.direction

--- a/model/metrics/container.yaml
+++ b/model/metrics/container.yaml
@@ -1,25 +1,5 @@
 groups:
   # container.cpu.* metrics and attribute group
-  - id: attributes.container.cpu
-    prefix: container.cpu
-    type: attribute_group
-    brief: "Describes Container CPU metric attributes"
-    attributes:
-      - id: state
-        brief: "The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels."
-        type:
-          allow_custom_values: false
-          members:
-            - id: user
-              value: 'user'
-              brief: "When tasks of the cgroup are in user mode (Linux). When all container processes are in user mode (Windows)."
-            - id: system
-              value: 'system'
-              brief: "When CPU is used by the system (host OS)"
-            - id: kernel
-              value: 'kernel'
-              brief: "When tasks of the cgroup are in kernel mode (Linux). When all container processes are in kernel mode (Windows)."
-        examples: ["user", "kernel"]
   - id: metric.container.cpu.time
     type: metric
     metric_name: container.cpu.time
@@ -58,6 +38,7 @@ groups:
     attributes:
       - ref: container.id
       - ref: disk.io.direction
+      - ref: system.device
 
   # container.network.io.* metrics and attribute group
   - id: metric.container.network.io
@@ -73,3 +54,4 @@ groups:
     attributes:
       - ref: container.id
       - ref: network.io.direction
+      - ref: system.device

--- a/model/metrics/container.yaml
+++ b/model/metrics/container.yaml
@@ -5,7 +5,7 @@ groups:
     metric_name: container.cpu.time
     brief: "Total CPU time consumed"
     note: >
-      Total CPU time consumed by the specific container.
+      Total CPU time consumed by the specific container on all available CPU cores
     instrument: counter
     unit: "s"
     attributes:

--- a/model/metrics/container.yaml
+++ b/model/metrics/container.yaml
@@ -11,7 +11,6 @@ groups:
     attributes:
       - ref: container.cpu.state
         requirement_level: opt_in
-      - ref: container.id
 
     # container.memory.* metrics and attribute group
   - id: metric.container.memory.usage
@@ -22,8 +21,6 @@ groups:
       Memory usage of the container.
     instrument: counter
     unit: "By"
-    attributes:
-      - ref: container.id
 
   # container.disk.io.* metrics and attribute group
   - id: metric.container.disk.io
@@ -36,7 +33,6 @@ groups:
     instrument: counter
     unit: "By"
     attributes:
-      - ref: container.id
       - ref: disk.io.direction
       - ref: system.device
 
@@ -52,6 +48,5 @@ groups:
     instrument: counter
     unit: "By"
     attributes:
-      - ref: container.id
       - ref: network.io.direction
       - ref: system.device

--- a/model/metrics/container.yaml
+++ b/model/metrics/container.yaml
@@ -1,57 +1,82 @@
 groups:
-  - id: metric.container.cpu.usage
+  - id: metric.container.cpu.utilization
     type: metric
-    metric_name: container.cpu.usage
+    metric_name: container.cpu.utilization
     brief: "Recent CPU utilization for the container."
     note: >
       CPU usage percentage normalized by the number of CPU cores.
       The value range is [0.0,1.0].
     instrument: gauge
     unit: "1"
-  - id: metric.container.memory.usage
+    attributes:
+      - ref: container.id
+  - id: metric.container.memory.utilization
     type: metric
-    metric_name: container.memory.usage
+    metric_name: container.memory.utilization
     brief: "Recent memory utilization for the container."
     note: >
       Memory usage percentage.
       The value range is [0.0,1.0].
     instrument: gauge
     unit: "1"
-  - id: metric.container.disk.read.bytes
+    attributes:
+      - ref: container.id
+
+  # container.disk.io.* metrics and attribute group
+  - id: attributes.container.disk.io
+    prefix: container.disk.io
+    type: attribute_group
+    brief: "Describes Container Disk IO metric attributes"
+    attributes:
+      - id: direction
+        type:
+          allow_custom_values: false
+          members:
+            - id: read
+              value: 'read'
+            - id: write
+              value: 'write'
+        brief: "The disk IO operation's direction"
+        examples: [ "read", "write" ]
+  - id: metric.container.disk.io.bytes
     type: metric
-    metric_name: container.disk.read.bytes
-    brief: "Disk read bytes for the container."
+    metric_name: container.disk.io.bytes
+    brief: "Disk bytes for the container."
     note: >
-      The total number of bytes read
+      The total number of bytes read/written
       successfully (aggregated from all disks).
     instrument: counter
     unit: "By"
-  - id: metric.container.disk.write.bytes
+    attributes:
+      - ref: container.id
+      - ref: container.disk.io.direction
+
+  # container.network.io.* metrics and attribute group
+  - id: attributes.container.network.io
+    prefix: container.network.io
+    type: attribute_group
+    brief: "Describes Container Network IO metric attributes"
+    attributes:
+      - id: direction
+        type:
+          allow_custom_values: false
+          members:
+            - id: ingress
+              value: 'ingress'
+            - id: egress
+              value: 'egress'
+        brief: "The Network IO direction"
+        examples: [ "ingress", "egress" ]
+  - id: metric.container.network.io.bytes
     type: metric
-    metric_name: container.disk.write.bytes
-    brief: "Disk write bytes for the container."
+    metric_name: container.disk.io.bytes
+    brief: "Network bytes for the container."
     note: >
-      The total number of bytes written
-      successfully (aggregated from all disks).
-    instrument: counter
-    unit: "By"
-  - id: metric.container.network.ingress.bytes
-    type: metric
-    metric_name: container.network.ingress.bytes
-    brief: "Network ingress bytes for the container."
-    note: >
-      The number of bytes received
+      The number of bytes sent/received
       on all network interfaces
       by the container.
     instrument: counter
     unit: "By"
-  - id: metric.container.network.egress.bytes
-    type: metric
-    metric_name: container.network.egress.bytes
-    brief: "Network egress bytes for the container."
-    note: >
-      The number of bytes sent out
-      on all network interfaces
-      by the container.
-    instrument: counter
-    unit: "By"
+    attributes:
+      - ref: container.id
+      - ref: container.network.io.direction

--- a/model/metrics/container.yaml
+++ b/model/metrics/container.yaml
@@ -1,24 +1,44 @@
 groups:
-  - id: metric.container.cpu.utilization
-    type: metric
-    metric_name: container.cpu.utilization
-    brief: "Recent CPU utilization for the container."
-    note: >
-      CPU usage percentage normalized by the number of CPU cores.
-      The value range is [0.0,1.0].
-    instrument: gauge
-    unit: "1"
+  # container.cpu.* metrics and attribute group
+  - id: attributes.container.cpu
+    prefix: container.cpu
+    type: attribute_group
+    brief: "Describes Container CPU metric attributes"
     attributes:
-      - ref: container.id
-  - id: metric.container.memory.utilization
+      - id: state
+        type:
+          allow_custom_values: false
+          members:
+            - id: user
+              value: 'user'
+            - id: system
+              value: 'system'
+            - id: kernel
+              value: 'kernel'
+        brief: "The state of the CPU"
+        examples: ["user", "kernel"]
+  - id: metric.container.cpu.time
     type: metric
-    metric_name: container.memory.utilization
-    brief: "Recent memory utilization for the container."
+    metric_name: container.cpu.time
+    brief: "Total CPU time consumed"
     note: >
-      Memory usage percentage.
-      The value range is [0.0,1.0].
-    instrument: gauge
-    unit: "1"
+      Total CPU time consumed by the specific container.
+    instrument: counter
+    unit: "ns"
+    attributes:
+      - ref: container.cpu.state
+        requirement_level: opt_in
+      - ref: container.id
+
+    # container.memory.* metrics and attribute group
+  - id: metric.container.memory.usage
+    type: metric
+    metric_name: container.memory.usage
+    brief: "Memory usage of the container."
+    note: >
+      Memory usage of the container.
+    instrument: counter
+    unit: "By"
     attributes:
       - ref: container.id
 

--- a/model/registry/container.yaml
+++ b/model/registry/container.yaml
@@ -96,7 +96,7 @@ groups:
           Container labels, `<key>` being the label name, the value being the label value.
         examples: [ 'container.label.app=nginx' ]
       - id: cpu.state
-        brief: "The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels."
+        brief: "The CPU state for this data point."
         type:
           allow_custom_values: true
           members:

--- a/model/registry/container.yaml
+++ b/model/registry/container.yaml
@@ -95,12 +95,7 @@ groups:
         brief: >
           Container labels, `<key>` being the label name, the value being the label value.
         examples: [ 'container.label.app=nginx' ]
-  - id: registry.container.cpu
-    prefix: container.cpu
-    type: attribute_group
-    brief: "Describes Container CPU metric attributes"
-    attributes:
-      - id: state
+      - id: cpu.state
         brief: "The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels."
         type:
           allow_custom_values: true

--- a/model/registry/container.yaml
+++ b/model/registry/container.yaml
@@ -95,3 +95,23 @@ groups:
         brief: >
           Container labels, `<key>` being the label name, the value being the label value.
         examples: [ 'container.label.app=nginx' ]
+  - id: registry.container.cpu
+    prefix: container.cpu
+    type: attribute_group
+    brief: "Describes Container CPU metric attributes"
+    attributes:
+      - id: state
+        brief: "The CPU state for this data point. A container SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels."
+        type:
+          allow_custom_values: true
+          members:
+            - id: user
+              value: 'user'
+              brief: "When tasks of the cgroup are in user mode (Linux). When all container processes are in user mode (Windows)."
+            - id: system
+              value: 'system'
+              brief: "When CPU is used by the system (host OS)"
+            - id: kernel
+              value: 'kernel'
+              brief: "When tasks of the cgroup are in kernel mode (Linux). When all container processes are in kernel mode (Windows)."
+        examples: ["user", "kernel"]


### PR DESCRIPTION
This PR adds container related metrics fields as part of https://github.com/open-telemetry/semantic-conventions/issues/72.

Continues https://github.com/open-telemetry/semantic-conventions/pull/87 on top of the project restructuring. 

Based on the comparison between ECS and Otel collector the result is the following (see https://github.com/open-telemetry/semantic-conventions/pull/282#issuecomment-1757735366). 

### Summary of added fields

1) `container.cpu.time` (ok for the Collector implementation: https://github.com/open-telemetry/semantic-conventions/pull/282#issuecomment-1909118310)
2) `container.memory.usage` (more accurate and aligned with system metrics) 
3) `container.disk.io` which has as dimension the already existent `disk.io.direction` (Otel collector only provides the Linux specific metric and hence a generic one capable to cover Windows as well would be better)
4) `container.network.io` which has as dimension the already existent `network.io.direction` (better alignment with disko.io and use of dimension).

All of those also refer to `container.id` as attribute as well.