### PR TITLE
BREAKING: Fix server.address vs all other address attributes inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ release.
   ([#252](https://github.com/open-telemetry/semantic-conventions/pull/252))
 - Simplify HTTP metric briefs.
   ([#276](https://github.com/open-telemetry/semantic-conventions/pull/276))
+- BREAKING: Split server.domain from server.address, no longer allow domain name
+  in address.
 
 ## v1.21.0 (2023-07-13)
 

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -68,26 +68,30 @@ Some database systems may allow a connection to switch to a different `db.user`,
 | `db.user` | string | Username for accessing the database. | `readonly_user`; `reporting_user` | Recommended |
 | [`network.transport`](../general/attributes.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Recommended |
 | [`network.type`](../general/attributes.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Name of the database host. [1] | `example.com` | Conditionally Required: See alternative attributes below. |
-| [`server.port`](../general/attributes.md) | int | Server port number [2] | `80`; `8080`; `443` | Conditionally Required: [3] |
-| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [4] | `10.5.3.2` | See below |
-| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [5] | `16456` | Recommended: If different than `server.port`. |
+| [`server.address`](../general/attributes.md) | string | Server address - IP address or Unix domain socket name. [1] | `127.0.0.1` | Conditionally Required: See alternative attributes below. |
+| [`server.domain`](../general/attributes.md) | string | Name of the database host. [2] | `example.com` | Conditionally Required: See alternative attributes below. |
+| [`server.port`](../general/attributes.md) | int | Server port number [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
+| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [5] | `10.5.3.2` | See below |
+| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [6] | `16456` | Recommended: If different than `server.port`. |
 
 **[1]:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent
 the server address behind any intermediaries (e.g. proxies) if it's available.
 
-**[2]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
+**[2]:** Should only be set to an actual domain name if available without reverse DNS lookup.
 
-**[3]:** If using a port other than the default port for this DBMS and if `server.address` is set.
+**[3]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
 
-**[4]:** When observed from the client side, this SHOULD represent the immediate server peer address.
+**[4]:** If using a port other than the default port for this DBMS and if `server.address` is set.
+
+**[5]:** When observed from the client side, this SHOULD represent the immediate server peer address.
 When observed from the server side, this SHOULD represent the physical server address.
 
-**[5]:** When observed from the client side, this SHOULD represent the immediate server peer port.
+**[6]:** When observed from the client side, this SHOULD represent the immediate server peer port.
 When observed from the server side, this SHOULD represent the physical server port.
 
 **Additional attribute requirements:** At least one of the following sets of attributes is required:
 
+* [`server.domain`](../general/attributes.md)
 * [`server.address`](../general/attributes.md)
 * [`server.socket.address`](../general/attributes.md)
 

--- a/docs/database/elasticsearch.md
+++ b/docs/database/elasticsearch.md
@@ -40,7 +40,7 @@ in order to map the path part values to their names.
 | [`db.operation`](database-spans.md) | string | The endpoint identifier for the request. [1] | `search`; `ml.close_job`; `cat.aliases` | Required |
 | [`db.statement`](database-spans.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. | `"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"` | Recommended: [2] |
 | `http.request.method` | string | HTTP request method. [3] | `GET`; `POST`; `HEAD` | Required |
-| [`server.address`](../general/attributes.md) | string | Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [4] | `example.com` | See below |
+| [`server.address`](../general/attributes.md) | string | Server address - IP address or Unix domain socket name. [4] | `127.0.0.1` | See below |
 | [`server.port`](../general/attributes.md) | int | Server port number [5] | `80`; `8080`; `443` | Recommended |
 | [`url.full`](../url/url.md) | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [6] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |
 

--- a/docs/general/attributes.md
+++ b/docs/general/attributes.md
@@ -55,27 +55,30 @@ if they do not cause breaking changes to HTTP semantic conventions.
 <!-- semconv server -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `server.address` | string | Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [1] | `example.com` | Recommended |
-| `server.port` | int | Server port number [2] | `80`; `8080`; `443` | Recommended |
-| `server.socket.domain` | string | Immediate server peer's domain name if available without reverse DNS lookup [3] | `proxy.example.com` | Recommended: If different than `server.address`. |
-| `server.socket.address` | string | Server address of the socket connection - IP address or Unix domain socket name. [4] | `10.5.3.2` | Recommended: If different than `server.address`. |
-| `server.socket.port` | int | Server port number of the socket connection. [5] | `16456` | Recommended: If different than `server.port`. |
+| `server.address` | string | Server address - IP address or Unix domain socket name. [1] | `127.0.0.1` | Recommended |
+| `server.domain` | string | Domain name of the server. May be set to an address if a domain is required but not available. [2] | `example.com` | Recommended |
+| `server.port` | int | Server port number [3] | `80`; `8080`; `443` | Recommended |
+| `server.socket.domain` | string | Immediate server peer's domain name if available without reverse DNS lookup [4] | `proxy.example.com` | Recommended: If different than `server.address`. |
+| `server.socket.address` | string | Server address of the socket connection - IP address or Unix domain socket name. [5] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| `server.socket.port` | int | Server port number of the socket connection. [6] | `16456` | Recommended: If different than `server.port`. |
 
 **[1]:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent
 the server address behind any intermediaries (e.g. proxies) if it's available.
 
-**[2]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
+**[2]:** Should only be set to an actual domain name if available without reverse DNS lookup.
 
-**[3]:** Typically observed from the client side, and represents a proxy or other intermediary domain name.
+**[3]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
 
-**[4]:** When observed from the client side, this SHOULD represent the immediate server peer address.
+**[4]:** Typically observed from the client side, and represents a proxy or other intermediary domain name.
+
+**[5]:** When observed from the client side, this SHOULD represent the immediate server peer address.
 When observed from the server side, this SHOULD represent the physical server address.
 
-**[5]:** When observed from the client side, this SHOULD represent the immediate server peer port.
+**[6]:** When observed from the client side, this SHOULD represent the immediate server peer port.
 When observed from the server side, this SHOULD represent the physical server port.
 <!-- endsemconv -->
 
-`server.address` and `server.port` represent logical server name and port. Semantic conventions that refer to these attributes SHOULD
+`server.domain`, `server.address` and `server.port` represent logical server name, address and port. Semantic conventions that refer to these attributes SHOULD
 specify what these attributes mean in their context.
 
 Semantic conventions and instrumentations that populate both logical (`server.address` and `server.port`) and socket-level (`server.socket.*`) attributes SHOULD set socket-level attributes only when they don't match logical ones. For example, when direct connection to the remote destination is established and `server.address` is populated, `server.socket.domain` SHOULD NOT be set. Check out [Connecting through intermediary](#connecting-through-intermediary) for more information.
@@ -223,7 +226,7 @@ This also covers unidirectional UDP flows and peer-to-peer communication where t
 <!-- semconv source -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `source.domain` | string | The domain name of the source system. [1] | `foo.example.com` | Recommended |
+| `source.domain` | string | The domain name of the source system. May be set to an address if a domain is required but not available. [1] | `foo.example.com` | Recommended |
 | `source.address` | string | Source address, for example IP address or Unix socket name. | `10.5.3.2` | Recommended |
 | `source.port` | int | Source port number | `3389`; `2888` | Recommended |
 
@@ -237,7 +240,7 @@ Destination fields capture details about the receiver of a network exchange/pack
 <!-- semconv destination -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `destination.domain` | string | The domain name of the destination system. [1] | `foo.example.com` | Recommended |
+| `destination.domain` | string | The domain name of the destination system. May be set to an address if a domain is required but not available. [1] | `foo.example.com` | Recommended |
 | `destination.address` | string | Destination address, for example IP address or UNIX socket name. | `10.5.3.2` | Recommended |
 | `destination.port` | int | Destination port number | `3389`; `2888` | Recommended |
 

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -80,8 +80,9 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [4] | `example.com` | Opt-In |
-| [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [5] | `80`; `8080`; `443` | Opt-In |
+| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [4] | `127.0.0.1` | Recommended |
+| [`server.domain`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [5] | `example.com` | Opt-In |
+| [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [6] | `80`; `8080`; `443` | Opt-In |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
@@ -115,6 +116,16 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
 **[5]:** Determined by using the first of the following that applies
+
+- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
+  include host identifier.
+- Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form.
+- Host identifier of the `Host` header
+
+SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
+
+**[6]:** Determined by using the first of the following that applies
 
 - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
@@ -153,7 +164,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.request.method` | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
-| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [2] | `example.com` | Opt-In |
+| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [2] | `127.0.0.1` | Opt-In |
 | [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [3] | `80`; `8080`; `443` | Opt-In |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
@@ -227,8 +238,9 @@ This metric is optional.
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [4] | `example.com` | Opt-In |
-| [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [5] | `80`; `8080`; `443` | Opt-In |
+| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [4] | `127.0.0.1` | Recommended |
+| [`server.domain`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [5] | `example.com` | Opt-In |
+| [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [6] | `80`; `8080`; `443` | Opt-In |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
@@ -262,6 +274,16 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
 **[5]:** Determined by using the first of the following that applies
+
+- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
+  include host identifier.
+- Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form.
+- Host identifier of the `Host` header
+
+SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
+
+**[6]:** Determined by using the first of the following that applies
 
 - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
@@ -306,8 +328,9 @@ This metric is optional.
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [4] | `example.com` | Opt-In |
-| [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [5] | `80`; `8080`; `443` | Opt-In |
+| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [4] | `127.0.0.1` | Recommended |
+| [`server.domain`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [5] | `example.com` | Opt-In |
+| [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [6] | `80`; `8080`; `443` | Opt-In |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
@@ -341,6 +364,16 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
 **[5]:** Determined by using the first of the following that applies
+
+- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
+  include host identifier.
+- Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form.
+- Host identifier of the `Host` header
+
+SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
+
+**[6]:** Determined by using the first of the following that applies
 
 - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
@@ -390,7 +423,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `example.com` | Required |
+| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `127.0.0.1` | Required |
 | [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
 | [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [6] | `10.5.3.2` | Recommended: If different than `server.address`. |
 
@@ -463,7 +496,7 @@ This metric is optional.
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `example.com` | Required |
+| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `127.0.0.1` | Required |
 | [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
 | [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [6] | `10.5.3.2` | Recommended: If different than `server.address`. |
 
@@ -536,7 +569,7 @@ This metric is optional.
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [2] | `3.1.1` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `example.com` | Required |
+| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `127.0.0.1` | Required |
 | [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
 | [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [6] | `10.5.3.2` | Recommended: If different than `server.address`. |
 

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -232,10 +232,11 @@ The following operations related to messages are defined for these semantic conv
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [14] | `3.1.1` | Recommended |
 | [`network.transport`](../general/attributes.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Recommended |
 | [`network.type`](../general/attributes.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [15] | `example.com` | Conditionally Required: If available. |
-| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [16] | `10.5.3.2` | Recommended: If different than `server.address`. |
-| [`server.socket.domain`](../general/attributes.md) | string | Immediate server peer's domain name if available without reverse DNS lookup [17] | `proxy.example.com` | Recommended: [18] |
-| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [19] | `16456` | Recommended: If different than `server.port`. |
+| [`server.address`](../general/attributes.md) | string | Server address - IP address or Unix domain socket name. [15] | `127.0.0.1` | Conditionally Required: [16] |
+| [`server.domain`](../general/attributes.md) | string | Domain name of the server. May be set to an address if a domain is required but not available. [17] | `example.com` | Conditionally Required: If available. |
+| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [18] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.socket.domain`](../general/attributes.md) | string | Immediate server peer's domain name if available without reverse DNS lookup [19] | `proxy.example.com` | Recommended: [20] |
+| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [21] | `16456` | Recommended: If different than `server.port`. |
 
 **[1]:** If a custom value is used, it MUST be of low cardinality.
 
@@ -266,16 +267,20 @@ the broker does not have such notion, the destination name SHOULD uniquely ident
 
 **[14]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
-**[15]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
+**[15]:** This should be the IP of the broker (or other network-level peer) this specific message is sent to/received from.
 
-**[16]:** When observed from the client side, this SHOULD represent the immediate server peer address.
+**[16]:** If available and especially if `server.domain` is not set.
+
+**[17]:** This should be the hostname of the broker (or other network-level peer) this specific message is sent to/received from.
+
+**[18]:** When observed from the client side, this SHOULD represent the immediate server peer address.
 When observed from the server side, this SHOULD represent the physical server address.
 
-**[17]:** Typically observed from the client side, and represents a proxy or other intermediary domain name.
+**[19]:** Typically observed from the client side, and represents a proxy or other intermediary domain name.
 
-**[18]:** If different than `server.address` and if `server.socket.address` is set.
+**[20]:** If different than `server.address` and if `server.socket.address` is set.
 
-**[19]:** When observed from the client side, this SHOULD represent the immediate server peer port.
+**[21]:** When observed from the client side, this SHOULD represent the immediate server peer port.
 When observed from the server side, this SHOULD represent the physical server port.
 
 `messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.

--- a/docs/rpc/rpc-metrics.md
+++ b/docs/rpc/rpc-metrics.md
@@ -196,31 +196,30 @@ measurements.
 | [`rpc.method`](rpc-spans.md) | string | The name of the (logical) method being called, must be equal to the $method part in the span name. [2] | `exampleMethod` | Recommended |
 | [`network.transport`](../general/attributes.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Recommended |
 | [`network.type`](../general/attributes.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
-| [`server.address`](../general/attributes.md) | string | RPC server [host name](https://grpc.github.io/grpc/core/md_doc_naming.html). [3] | `example.com` | Required |
-| [`server.port`](../general/attributes.md) | int | Server port number [4] | `80`; `8080`; `443` | Conditionally Required: See below |
-| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [5] | `10.5.3.2` | See below |
-| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [6] | `16456` | Recommended: [7] |
+| [`server.address`](../general/attributes.md) | string | Server address - IP address or Unix domain socket name. [3] | `127.0.0.1` | Recommended |
+| [`server.domain`](../general/attributes.md) | string | RPC server [host name](https://grpc.github.io/grpc/core/md_doc_naming.html). [4] | `example.com` | Required |
+| [`server.port`](../general/attributes.md) | int | Server port number [5] | `80`; `8080`; `443` | Conditionally Required: See below |
+| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [6] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [7] | `16456` | Recommended: [8] |
 
 **[1]:** This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
 
 **[2]:** This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
 
-**[3]:** May contain server IP address, DNS name, or local socket name. When host component is an IP address, instrumentations SHOULD NOT do a reverse proxy lookup to obtain DNS name and SHOULD set `server.address` to the IP address provided in the host component.
+**[3]:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent
+the server address behind any intermediaries (e.g. proxies) if it's available.
 
-**[4]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
+**[4]:** May contain server IP address, DNS name, or local socket name. When host component is an IP address, instrumentations SHOULD NOT do a reverse proxy lookup to obtain DNS name and SHOULD set `server.domain` to the IP address provided in the host component.
 
-**[5]:** When observed from the client side, this SHOULD represent the immediate server peer address.
+**[5]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
+
+**[6]:** When observed from the client side, this SHOULD represent the immediate server peer address.
 When observed from the server side, this SHOULD represent the physical server address.
 
-**[6]:** When observed from the client side, this SHOULD represent the immediate server peer port.
+**[7]:** When observed from the client side, this SHOULD represent the immediate server peer port.
 When observed from the server side, this SHOULD represent the physical server port.
 
-**[7]:** If different than `server.port` and if `server.socket.address` is set.
-
-**Additional attribute requirements:** At least one of the following sets of attributes is required:
-
-* [`server.socket.address`](../general/attributes.md)
-* [`server.address`](../general/attributes.md)
+**[8]:** If different than `server.port` and if `server.socket.address` is set.
 
 `rpc.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/rpc/rpc-spans.md
+++ b/docs/rpc/rpc-spans.md
@@ -89,31 +89,30 @@ Examples of span names:
 | `rpc.method` | string | The name of the (logical) method being called, must be equal to the $method part in the span name. [2] | `exampleMethod` | Recommended |
 | [`network.transport`](../general/attributes.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Recommended |
 | [`network.type`](../general/attributes.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
-| [`server.address`](../general/attributes.md) | string | RPC server [host name](https://grpc.github.io/grpc/core/md_doc_naming.html). [3] | `example.com` | Required |
-| [`server.port`](../general/attributes.md) | int | Server port number [4] | `80`; `8080`; `443` | Conditionally Required: See below |
-| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [5] | `10.5.3.2` | See below |
-| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [6] | `16456` | Recommended: [7] |
+| [`server.address`](../general/attributes.md) | string | Server address - IP address or Unix domain socket name. [3] | `127.0.0.1` | Recommended |
+| [`server.domain`](../general/attributes.md) | string | RPC server [host name](https://grpc.github.io/grpc/core/md_doc_naming.html). [4] | `example.com` | Required |
+| [`server.port`](../general/attributes.md) | int | Server port number [5] | `80`; `8080`; `443` | Conditionally Required: See below |
+| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [6] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [7] | `16456` | Recommended: [8] |
 
 **[1]:** This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
 
 **[2]:** This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
 
-**[3]:** May contain server IP address, DNS name, or local socket name. When host component is an IP address, instrumentations SHOULD NOT do a reverse proxy lookup to obtain DNS name and SHOULD set `server.address` to the IP address provided in the host component.
+**[3]:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent
+the server address behind any intermediaries (e.g. proxies) if it's available.
 
-**[4]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
+**[4]:** May contain server IP address, DNS name, or local socket name. When host component is an IP address, instrumentations SHOULD NOT do a reverse proxy lookup to obtain DNS name and SHOULD set `server.domain` to the IP address provided in the host component.
 
-**[5]:** When observed from the client side, this SHOULD represent the immediate server peer address.
+**[5]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
+
+**[6]:** When observed from the client side, this SHOULD represent the immediate server peer address.
 When observed from the server side, this SHOULD represent the physical server address.
 
-**[6]:** When observed from the client side, this SHOULD represent the immediate server peer port.
+**[7]:** When observed from the client side, this SHOULD represent the immediate server peer port.
 When observed from the server side, this SHOULD represent the physical server port.
 
-**[7]:** If different than `server.port` and if `server.socket.address` is set.
-
-**Additional attribute requirements:** At least one of the following sets of attributes is required:
-
-* [`server.socket.address`](../general/attributes.md)
-* [`server.address`](../general/attributes.md)
+**[8]:** If different than `server.port` and if `server.socket.address` is set.
 
 `rpc.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/model/destination.yaml
+++ b/model/destination.yaml
@@ -11,7 +11,7 @@ groups:
     attributes:
       - id: domain
         type: string
-        brief: The domain name of the destination system.
+        brief: The domain name of the destination system. May be set to an address if a domain is required but not available.
         examples: ['foo.example.com']
         note: This value may be a host name, a fully qualified domain name, or another host naming format.
       - id: address

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -4,7 +4,7 @@ groups:
     brief: 'HTTP server attributes'
     extends: attributes.http.server
     attributes:
-      - ref: server.address
+      - ref: server.domain
         brief: >
           Name of the local HTTP server that received the request.
         requirement_level: opt_in

--- a/model/metrics/rpc-metrics.yaml
+++ b/model/metrics/rpc-metrics.yaml
@@ -11,6 +11,7 @@ groups:
       - ref: rpc.method
       - ref: network.transport
       - ref: network.type
+      - ref: server.domain
       - ref: server.address
       - ref: server.port
       - ref: server.socket.address

--- a/model/server.yaml
+++ b/model/server.yaml
@@ -12,10 +12,15 @@ groups:
     attributes:
       - id: address
         type: string
-        brief: Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name.
+        brief: Server address - IP address or Unix domain socket name.
         note: |
           When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent
           the server address behind any intermediaries (e.g. proxies) if it's available.
+        examples: "127.0.0.1"
+      - id: domain
+        brief: Domain name of the server. May be set to an address if a domain is required but not available.
+        note: Should only be set to an actual domain name if available without reverse DNS lookup.
+        type: string
         examples: ['example.com']
       - id: port
         type: int

--- a/model/source.yaml
+++ b/model/source.yaml
@@ -11,7 +11,7 @@ groups:
     attributes:
       - id: domain
         type: string
-        brief: The domain name of the source system.
+        brief: The domain name of the source system. May be set to an address if a domain is required but not available.
         examples: ['foo.example.com']
         note: This value may be a host name, a fully qualified domain name, or another host naming format.
       - id: address

--- a/model/trace/database.yaml
+++ b/model/trace/database.yaml
@@ -228,7 +228,7 @@ groups:
           If the SQL statement has an ambiguous operation, or performs more
           than one operation, this value may be omitted.
         examples: ['findAndModify', 'HMSET', 'SELECT']
-      - ref: server.address
+      - ref: server.domain
         tag: connection-level
         requirement_level:
           conditionally_required: See alternative attributes below.
@@ -238,6 +238,10 @@ groups:
         tag: connection-level
         requirement_level:
           conditionally_required: If using a port other than the default port for this DBMS and if `server.address` is set.
+      - ref: server.address
+        tag: connection-level
+        requirement_level:
+          conditionally_required: See alternative attributes below.
       - ref: server.socket.address
         tag: connection-level
       - ref: server.socket.port
@@ -248,9 +252,10 @@ groups:
         tag: connection-level
       - ref: server.socket.domain
         requirement_level:
-          recommended: If different than `server.address` and if `server.socket.address` is set.
+          recommended: If different than `server.domain` and if `server.socket.address` is set.
     constraints:
       - any_of:
+          - 'server.domain'
           - 'server.address'
           - 'server.socket.address'
 

--- a/model/trace/http.yaml
+++ b/model/trace/http.yaml
@@ -54,7 +54,7 @@ groups:
         requirement_level:
           recommended: if and only if request was retried.
         examples: 3
-      - ref: server.address
+      - ref: server.domain
         sampling_relevant: true
         requirement_level: required
         brief: >
@@ -67,7 +67,7 @@ groups:
           - Host identifier of the `Host` header
 
           If an HTTP client request is explicitly made to an IP address, e.g. `http://x.x.x.x:8080`, then
-          `server.address` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
+          `server.domain` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
       - ref: server.port
         sampling_relevant: true
         requirement_level:
@@ -77,6 +77,7 @@ groups:
         note: >
           When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match
           URI port identifier, otherwise it MUST match `Host` header port identifier.
+      - ref: server.address
       - ref: server.socket.domain
       - ref: server.socket.address
       - ref: server.socket.port
@@ -92,7 +93,7 @@ groups:
     span_kind: server
     brief: 'Semantic Convention for HTTP Server'
     attributes:
-      - ref: server.address
+      - ref: server.domain
         requirement_level: recommended
         sampling_relevant: true
         brief: >
@@ -138,6 +139,7 @@ groups:
             The port of the original client behind all proxies, if
             known (e.g. from [Forwarded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded) or a similar header).
             Otherwise, the immediate client peer port.
+      - ref: server.address
       - ref: client.socket.address
       - ref: client.socket.port
       - ref: url.path

--- a/model/trace/messaging.yaml
+++ b/model/trace/messaging.yaml
@@ -162,11 +162,16 @@ groups:
       - ref: messaging.message.payload_compressed_size_bytes
         requirement_level:
           recommended: Only if span represents operation on a single message.
-      - ref: server.address
+      - ref: server.domain
         note: >
-          This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
+          This should be the hostname of the broker (or other network-level peer) this specific message is sent to/received from.
         requirement_level:
           conditionally_required: If available.
+      - ref: server.address
+        note: >
+          This should be the IP of the broker (or other network-level peer) this specific message is sent to/received from.
+        requirement_level:
+          conditionally_required: If available and especially if `server.domain` is not set.
       - ref: server.socket.address
         tag: connection-level
       - ref: server.socket.port

--- a/model/trace/rpc.yaml
+++ b/model/trace/rpc.yaml
@@ -55,21 +55,18 @@ groups:
           recommended: If different than `server.port` and if `server.socket.address` is set.
       - ref: network.transport
       - ref: network.type
-      - ref: server.address
+      - ref: server.domain
         requirement_level: required
         brief: >
           RPC server [host name](https://grpc.github.io/grpc/core/md_doc_naming.html).
         note: >
           May contain server IP address, DNS name, or local socket name. When host component is an IP address,
           instrumentations SHOULD NOT do a reverse proxy lookup to obtain DNS name and SHOULD set
-          `server.address` to the IP address provided in the host component.
+          `server.domain` to the IP address provided in the host component.
+      - ref: server.address
       - ref: server.port
         requirement_level:
           conditionally_required: See below
-    constraints:
-      - any_of:
-          - server.socket.address
-          - server.address
 
   - id: rpc.client
     type: span

--- a/schema-next.yaml
+++ b/schema-next.yaml
@@ -63,6 +63,10 @@ versions:
               - jvm.buffer.usage
               - jvm.buffer.limit
               - jvm.buffer.count
+        - rename_attributes:
+          attribute_map:
+            net.host.name: server.domain # This is re-renamed from the 1.21.0 renaming to server.address
+
   1.21.0:
     spans:
       changes:


### PR DESCRIPTION
⚠️ (Likely superseded by #302)

----

Fixes #251

Many conventions reference the very recently introduced server.address to store the server domain name, or maybe actually the server IP? Who knows... Now you do again (well at least you could know, actually I always left the alternative open and did not check if it previously was peer/host.name/ip, i.e. tried to keep the relaxation done through the intermediate attribute renaming).

We have many address attributes, all of which contain the address (server.socket.address, client.address, client.socket.address, source.address, destination.address), only server.address stood out as also allowing a host name (aka domain). This PR fixes that inconsistency.

## Changes

- BREAKING: Split server.domain from server.address, no longer allow domain name
  in address.

## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [X] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
