### PR TITLE
Add issue templates and clarify expectations for area experts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,33 +6,42 @@
 #
 # Learn about membership in OpenTelemetry community:
 #  https://github.com/open-telemetry/community/blob/main/community-membership.md
-# 
 #
-# Learn about CODEOWNERS file format: 
+#
+# Learn about CODEOWNERS file format:
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-# Global owners, will be the owners for everything in the repo. Membership is tracked via https://github.com/open-telemetry/community/blob/main/community-members.md 
-*   @open-telemetry/specs-semconv-maintainers @open-telemetry/specs-semconv-approvers
+# Global owners, will be the owners for everything in the repo. Membership is tracked via https://github.com/open-telemetry/semantic-conventions/blob/main/README.md#contributing
+
+* @open-telemetry/specs-semconv-maintainers @open-telemetry/specs-semconv-approvers
 
 # Schemas and schema file tooling
-/schemas/                       @open-telemetry/specs-semconv-approvers @tigrannajaryan
-/internal/tools/schema_check.sh @open-telemetry/specs-semconv-approvers @tigrannajaryan
 
-# Logs semantic conventions
-/model/logs/                        @open-telemetry/specs-semconv-approvers @tigrannajaryan
-/docs/exceptions/exceptions-logs.md       @open-telemetry/specs-semconv-approvers @tigrannajaryan
-/docs/feature-flags/feature-flags-logs.md @open-telemetry/specs-semconv-approvers @tigrannajaryan
-/docs/general/events-general.md           @open-telemetry/specs-semconv-approvers @tigrannajaryan
-/docs/general/logs-general.md             @open-telemetry/specs-semconv-approvers @tigrannajaryan
-/docs/logs/                               @open-telemetry/specs-semconv-approvers @tigrannajaryan
-
-# JVM semantic conventions approvers
-/model/metrics/process-runtime-jvm-metrics.yaml              @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-jvm-approvers
-/model/metrics/process-runtime-jvm-metrics-experimental.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-jvm-approvers
+/internal/tools/schema_check.sh                                                 @open-telemetry/specs-semconv-approvers @tigrannajaryan
+/schemas/                                                                       @open-telemetry/specs-semconv-approvers @tigrannajaryan
 
 # HTTP semantic conventions approvers
-/model/metrics/http.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
-/model/trace/http.yaml   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
+
+/model/metrics/http.yaml                                                        @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
+/model/trace/http.yaml                                                          @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
+
+# JVM semantic conventions approvers
+
+/model/metrics/process-runtime-jvm-metrics.yaml                                 @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-jvm-approvers
+/model/metrics/process-runtime-jvm-metrics-experimental.yaml                    @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-jvm-approvers
+
+# Logs semantic conventions
+
+/docs/exceptions/exceptions-logs.md                                             @open-telemetry/specs-semconv-approvers @tigrannajaryan
+/docs/feature-flags/feature-flags-logs.md                                       @open-telemetry/specs-semconv-approvers @tigrannajaryan
+/docs/general/events-general.md                                                 @open-telemetry/specs-semconv-approvers @tigrannajaryan
+/docs/general/logs-general.md                                                   @open-telemetry/specs-semconv-approvers @tigrannajaryan
+/docs/logs/                                                                     @open-telemetry/specs-semconv-approvers @tigrannajaryan
+/model/logs/                                                                    @open-telemetry/specs-semconv-approvers @tigrannajaryan
 
 # TODO - Add semconv area experts
+#
+# Please create an issue in the semantic-conventions repository:
+#  https://github.com/open-telemetry/semantic-conventions/issues/new?assignees=&labels=&projects=&template=add-experts.md
+#

--- a/.github/ISSUE_TEMPLATE/add-experts.md
+++ b/.github/ISSUE_TEMPLATE/add-experts.md
@@ -1,0 +1,24 @@
+---
+name: Add Area Experts
+about: Nominate yourself or others to be an area expert for semantic conventions
+---
+
+# Add Area Experts
+
+**What is the target semantic convention area?**
+
+You can either request a new area to be created or add experts to an existing area. The project maintainers will decide whether there are sufficient area experts before starting a new area. Check the current [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS).
+
+**Who should be added?**
+
+List out the individuals who should be added. Provide the following information.
+
+* Full name
+* GitHub alias
+* Why is this individual a good fit for the area?
+
+Please make sure that you confirm with the individuals before adding them. We need the individuals to explictly reply to the GitHub issue confirming their willingness. Normally we expect the individuals to have contributed to the area in the past, and we expect to have at least one expert who is affliated with the area.
+
+## Additional Context
+
+Add any other context about the request here.

--- a/.github/ISSUE_TEMPLATE/add-experts.md
+++ b/.github/ISSUE_TEMPLATE/add-experts.md
@@ -11,7 +11,7 @@ You can either request a new area to be created or add experts to an existing ar
 
 **Who should be added?**
 
-List out the individuals who should be added. Provide the following information.
+List out the individuals who should be added. Provide the following information:
 
 * Full name
 * GitHub alias

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+labels: bug
+---
+
+# Bug Report
+
+## Symptom
+
+A clear and concise description of what the bug is.
+
+**What is the expected behavior?**
+
+What did you expect to see?
+
+**What is the actual behavior?**
+
+What did you see instead?
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+# Feature Request
+
+**Is your feature request related to a problem?**
+
+If so, provide a concise description of the problem.
+
+**Describe the solution you'd like:**
+
+What do you want to happen instead? What is the expected behavior?
+
+**Describe alternatives you've considered.**
+
+Which alternative solutions or features have you considered?
+
+## Additional Context
+
+Add any other context about the feature request here.


### PR DESCRIPTION
Fixes #12

## Changes

* Improved the format of CODEOWNERS file (removing trailing spaces, indentation, alphabetic sorting)
* Added issue templates
* Added a note in the CODEOWNERS file clarifying how areas and experts can be added.
