### PR TITLE
chore: fix doc reference to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository is currently using [this specification version][SpecificationVer
 
 ## Read the docs
 
-The documentation currently resides in the [doc](docs/README.md) folder.
+The documentation currently resides in the [docs](docs/README.md) folder.
 
 ## Contributing
 


### PR DESCRIPTION
Fixes #

## Changes

Updating the `doc` reference to `docs` as per the folder's actually name.

I feel like this is pretty insignificant and a changelog entry isn't required. Do let me know if otherwise!

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
