### PR TITLE
Clarify if/how enduser.role can have multiple roles

### DIFF
--- a/docs/general/attributes.md
+++ b/docs/general/attributes.md
@@ -320,7 +320,7 @@ These attributes may be used for any operation with an authenticated and/or auth
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `enduser.id` | string | Username or client_id extracted from the access token or [Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) header in the inbound request from outside the system. | `username` | Recommended |
-| `enduser.role` | string | Actual/assumed role the client is making the request under extracted from token or application security context. | `admin` | Recommended |
+| `enduser.role` | string | Actual/assumed role(s) the client is making the request under extracted from token or application security context. | `admin, superadmin` | Recommended |
 | `enduser.scope` | string | Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an [OAuth 2.0 Access Token](https://tools.ietf.org/html/rfc6749#section-3.3) or an attribute value in a [SAML 2.0 Assertion](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html). | `read:message, write:files` | Recommended |
 <!-- endsemconv -->
 

--- a/model/network.yaml
+++ b/model/network.yaml
@@ -189,8 +189,8 @@ groups:
         examples: 'username'
       - id: role
         type: string
-        brief: 'Actual/assumed role the client is making the request under extracted from token or application security context.'
-        examples: 'admin'
+        brief: 'Actual/assumed role(s) the client is making the request under extracted from token or application security context.'
+        examples: 'admin, superadmin'
       - id: scope
         type: string
         brief: >


### PR DESCRIPTION
## Changes

Some role-based access control implementations allow assuming multiple roles. For example, in Java's [Spring Security framework](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/userdetails/User.UserBuilder.html#roles(java.lang.String...))

Let me know if it makes sense to clarify that multiple roles are possible in the [enduser.role](https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/span-general/#general-identity-attributes) attribute documentation

I noticed this when looking at a request to capture `enduser.role` with spring security auto-instrumentation (https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9400)

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.