### PR TITLE
Define a common algorithm for service.instance.id

### DIFF
--- a/.chloggen/service-instance-id.yaml
+++ b/.chloggen/service-instance-id.yaml
@@ -1,0 +1,4 @@
+change_type: 'enhancement'
+component: resource
+note: Define a common algorithm for `service.instance.id`.
+issues: [312]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,6 @@
   ([#597](https://github.com/open-telemetry/semantic-conventions/pull/597))
 - Add Azure Service Bus and Event Hubs messaging attributes
   ([#572](https://github.com/open-telemetry/semantic-conventions/pull/572))
-- Define a common algorithm for `service.instance.id`.
-  ([#312](https://github.com/open-telemetry/semantic-conventions/pull/312))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
   ([#597](https://github.com/open-telemetry/semantic-conventions/pull/597))
 - Add Azure Service Bus and Event Hubs messaging attributes
   ([#572](https://github.com/open-telemetry/semantic-conventions/pull/572))
+- Define a common algorithm for `service.instance.id`.
+  ([#312](https://github.com/open-telemetry/semantic-conventions/pull/312))
 
 ### Fixes
 

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -104,7 +104,6 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 
 **[1]:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. Services aiming for reproducible UUIDs may also use Version 5.
 SDKs are required to follow the following algorithm when generating `service.instance.id`:
-
 - If the user has provided a `service.instance.id`, via environment
   variable, configuration or custom resource detection, this will
   always be used and honored over generated IDs.
@@ -113,7 +112,7 @@ SDKs are required to follow the following algorithm when generating `service.ins
 - When the SDK can detect it's running on Kubernetes or derivatives, such as by checking the
   availability of a directory named `/var/run/secrets/kubernetes.io`, it should use
   the contents of the file `/var/run/secrets/kubernetes.io/serviceaccount/namespace`,
-  along with the hostname and separated with a dot ("namespace.hostname") as the input
+  along with the hostname and process ID (PID) separated with a dot ("namespace.hostname.pid") as the input
   for generating a UUID v5.
 - When the SDK is running in an environment where a `/etc/machine-id` (see MACHINE-ID(5))
   is available, the machine-id should be used as the input for generating a UUID v5.

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -137,8 +137,7 @@ are encouraged to set the `service.instance.id` on a per-worker basis.
 SDKs MUST use the following algorithm when generating `service.instance.id`:
 
 - If the user has provided a `service.instance.id`, via environment
-  variable, configuration or custom resource detection, this will
-  always be used and honored over generated IDs.
+  variable, configuration or custom resource detection, this MUST take priority over generated IDs.
 - When any of the below combinations of resource attribute are provided, they MUST be used as the input
   for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
   * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -124,7 +124,7 @@ thread in unicorn) to have its own instance.id.
 
 It's not recommended for a Collector to set `service.instance.id` if it can't unambiguously determine the
 service instance that is generating that telemetry. For instance, creating an UUID based on `pod.name` will
-likely be wrong, as the Collector likely doesn't know whether there are multiple containers within that pod.
+likely be wrong, as the Collector might not know from which container within that pod the telemetry originated.
 However, Collectors can set the `service.instance.id` if they can unambiguously determine the service instance
 for that telemetry. This is typically the case for scraping receivers, as they know the target address and
 port.

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -112,18 +112,18 @@ the ID is ephemeral and changes during important lifetime events for the service
 
 If the instance has no inherent unique ID that can be used as the value of this attribute,
 implementations MAY to generate a random Version 1 or Version 4
-[RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. When enough data is available, 
-implementations SHOULD use Version 5 and MUST use the following UUID as the namespace: 
+[RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. When enough data is available,
+implementations SHOULD use Version 5 and MUST use the following UUID as the namespace:
 `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
 
 UUIDs are typically recommended, as we only need an opaque yet reproducible value for
 the purposes of identifying a service instance. Similar to what can be seen in the man page for the
-[`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file, 
+[`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file,
 the underlying data, such as pod name and namespace should be treated as
 confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
 
 When a UUID v5 is generated, the input MUST be prefixed with
-`${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the 
+`${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the
 the workload identifier, which should tentatively stable. This means that the same service yields the
 same UUID if the same identifier (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
 yield different results for different services on the same host or namespace. When no namespaces or equivalent fields
@@ -142,11 +142,12 @@ SDKs MUST use the following algorithm when generating `service.instance.id`:
 - When any of the below combinations of resource attribute are provided, they MUST be used as the input
   for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
   * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`
-  * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`
+  * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input
+  `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`
   * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`
 - When the SDK is running in an environment where a `/etc/machine-id`
   (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
-  is available, the machine-id should be used in the input for generating a UUID v5: 
+  is available, the machine-id should be used in the input for generating a UUID v5:
   `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${machine.id}`
 - When the SDK is running on a Windows environment and there's a reasonable way to read
   registry keys for the SDK, the registry key

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -131,12 +131,15 @@ same UUID if the same identifier (`host.id`, `/etc/machine-id`, and so on) remai
 yield different results for different services on the same host or namespace. When no namespaces or equivalent fields
 are available, the prefix MUST then be `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`.
 
+For applications running behind an application server, such as unicorn, a stable identifier is not desirable, as
+each worker thread typically is seen as a different instance.
+
 SDKs SHOULD use the following algorithm when generating `service.instance.id`:
 
 - If the user has provided a `service.instance.id`, via environment
-  variable, configuration or custom resource detection, this MUST take priority over generated IDs.
-- When the language, framework, or platform has a native mechanism allowing workloads to be uniquely idenfiable, like Erlang's
-  clustering identity, this mechanism MAY be used.
+  variable, configuration or custom resource detection, this MUST take priority over generated IDs. The special value `uuidv4` means
+  that a UUID v4 should be generated.
+- When the language, framework, or platform has a native mechanism allowing workloads to be uniquely idenfiable, this mechanism MAY be used.
 - When any of the below combinations of resource attribute are provided, they MUST be used as the input
   for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
   * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -107,8 +107,11 @@ SDKs are required to follow the following algorithm when generating `service.ins
 - If the user has provided a `service.instance.id`, via environment
   variable, configuration or custom resource detection, this will
   always be used and honored over generated IDs.
-- When the `container.id` resource attribute is provided, it should be used as the input
-  for generating a UUID v5.
+- When any of the below combinations of resource attribute are provided, they should be used as the input
+  for generating a UUID v5. The values within each combination should be separated with dots:
+  * `container.id`
+  * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`
+  * `host.id`
 - When the SDK can detect it's running on Kubernetes or derivatives, such as by checking the
   availability of a directory named `/var/run/secrets/kubernetes.io`, it should use
   the contents of the file `/var/run/secrets/kubernetes.io/serviceaccount/namespace`,

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -104,6 +104,7 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 
 **[1]:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. Services aiming for reproducible UUIDs may also use Version 5.
 SDKs are required to follow the following algorithm when generating `service.instance.id`:
+
 - If the user has provided a `service.instance.id`, via environment
   variable, configuration or custom resource detection, this will
   always be used and honored over generated IDs.

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -107,7 +107,7 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled
 service).
 
-Implementations are recommended to generate a random Version 1 or Version 4 [RFC
+Implementations, such as SDKs, are recommended to generate a random Version 1 or Version 4 [RFC
 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID, but are free to use an inherent unique ID as the source of
 this value if stability is desirable. In that case, the ID SHOULD be used as source of a UUID Version 5 and
 SHOULD use the following UUID as the namespace: `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
@@ -118,16 +118,16 @@ needed. Similar to what can be seen in the man page for the
 data, such as pod name and namespace should be treated as confidential, being the user's choice to expose it
 or not via another resource attribute.
 
-For applications running behind an application server, such as unicorn, a stable identifier is not desirable,
-as each worker thread typically is seen as a different instance. For those cases, a UUID v1/v4 is always
-recommended.
+For applications running behind an application server (like unicorn), we do not recommend using one identifier
+for all processes participating in the application. Instead, it's recommended each division (e.g. a worker
+thread in unicorn) to have its own instance.id.
 
-Collectors aren't recommended to set a `service.instance.id`: any identifying information that the Collector
-can infer should be added as a regular resource attribute, and it's unlikely that the Collector will have all
-the information to be certain from which instance of a service a data point originated. As an example, a
-Kubernetes pod might have multiple containers, and a Collector may not be able to confidently infer from which
-container the telemetry is coming from. However, if the Collector can confidently infer the source of
-telemetry unambiguously, it MAY use the information at its disposal and generate a UUID Version 5 with it.
+It's not recommended for a Collector to set `service.instance.id` if it can't unambiguously determine the
+service instance that is generating that telemetry. For instance, creating an UUID based on `pod.name` will
+likely be wrong, as the Collector likely doesn't know whether there are multiple containers within that pod.
+However, Collectors can set the `service.instance.id` if they can unambiguously determine the service instance
+for that telemetry. This is typically the case for scraping receivers, as they know the target address and
+port.
 
 **[2]:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
 <!-- endsemconv -->

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -116,31 +116,41 @@ implementations MAY to generate a random Version 1 or Version 4
 implementations SHOULD use Version 5 and MUST use the following UUID as the namespace:
 `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
 
-UUIDs are typically recommended, as we only need an opaque yet reproducible value for
-the purposes of identifying a service instance. Similar to what can be seen in the man page for the
+UUIDs are typically recommended, as only an opaque yet reproducible value for
+the purposes of identifying a service instance is needed. Similar to what can be seen in the man page for the
 [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file,
 the underlying data, such as pod name and namespace should be treated as
 confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
 
 When a UUID v5 is generated, the input MUST be prefixed with
 `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the
-the workload identifier, which should tentatively stable. This means that the same service yields the
+the workload identifier, which should tentatively stable. The workload identifier is the final piece of
+information making the source of telemetry to be uniquely idenfiable. For instance, it might be the `container.id`
+or `container.name` in containerized or Kubernetes environments. This means that the same service yields the
 same UUID if the same identifier (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
 yield different results for different services on the same host or namespace. When no namespaces or equivalent fields
 are available, the prefix MUST then be `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`.
 
-Users running their services on platforms such as Kubernetes are encouraged to explicitly set the
-`service.instance.id` using their existing automation, or by setting a value that can be used for a
-consistent value, such as `container.id`. Similarly, users of application servers such as `unicorn`
-are encouraged to set the `service.instance.id` on a per-worker basis.
+Users are encouraged to explicitly set the `service.instance.id` themselves, given they are in the best position
+to determine what's a service instance. For instance, in some cases, all containers in a given pod might be part
+of the same service, while in other cases, each container would independently generate their own telemetry. When
+it's not possible or desirable to explicitly generate a `service.instance.id`, users are encouraged to set set
+enough information via their workload automation, such as Helm. In that case, SDKs would have enough information to
+generate a `service.instance.id`. Future versions of the OpenTelemetry Operator might also have the ability to
+generate the `service.instance.id` and set container-specific labels, given it is in a position to know all that
+metadata. When SDKs don't have sufficient information to generate a stable UUID, a random one is generated.
 
-SDKs MUST use the following algorithm when generating `service.instance.id`:
+In more concrete terms: users running their services on platforms such as Kubernetes are encouraged to explicitly
+set the `service.instance.id` using their existing automation, or set a value that can be used for a
+consistent value, such as `container.id`. Similarly, users of application servers such as `unicorn`
+are encouraged to set the `service.instance.id` on a per-worker basis. SDKs MUST use the following algorithm when
+generating `service.instance.id`:
 
 - If the user has provided a `service.instance.id`, via environment
   variable, configuration or custom resource detection, this MUST take priority over generated IDs.
 - When any of the below combinations of resource attribute are provided, they MUST be used as the input
   for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
-  * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`, 
+  * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`,
   possibly without the namespace.
   * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input
   `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`. In this case,

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -111,7 +111,7 @@ the ID is ephemeral and changes during important lifetime events for the service
 (e.g. service instance restarts).
 
 If the instance has no inherent unique ID that can be used as the value of this attribute,
-implementations MAY to generate a random Version 1 or Version 4
+implementations MAY generate a random Version 1 or Version 4
 [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. When enough data is available,
 implementations SHOULD use Version 5 and MUST use the following UUID as the namespace:
 `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
@@ -124,7 +124,7 @@ confidential by this algorithm, being the user's choice to expose it or not via 
 
 When a UUID v5 is generated, the input MUST be prefixed with
 `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the
-the workload identifier, which should tentatively stable. The workload identifier is the final piece of
+the workload identifier, which should tentatively be stable. The workload identifier is the final piece of
 information making the source of telemetry to be uniquely idenfiable. For instance, it might be the `container.id`
 or `container.name` in containerized or Kubernetes environments. This means that the same service yields the
 same UUID if the same identifier (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
@@ -134,11 +134,11 @@ are available, the prefix MUST then be `${telemetry.sdk.name}.${telemetry.sdk.la
 Users are encouraged to explicitly set the `service.instance.id` themselves, given they are in the best position
 to determine what's a service instance. For instance, in some cases, all containers in a given pod might be part
 of the same service, while in other cases, each container would independently generate their own telemetry. When
-it's not possible or desirable to explicitly generate a `service.instance.id`, users are encouraged to set set
-enough information via their workload automation, such as Helm. In that case, SDKs would have enough information to
+it's not possible or desirable to explicitly generate a `service.instance.id`, users are encouraged to set
+enough information via their workload automation, such as Helm. In that case, SDKs would have enough data to
 generate a `service.instance.id`. Future versions of the OpenTelemetry Operator might also have the ability to
 generate the `service.instance.id` and set container-specific labels, given it is in a position to know all that
-metadata. When SDKs don't have sufficient information to generate a stable UUID, a random one is generated.
+metadata. When SDKs don't have sufficient data to generate a stable UUID, a random one is generated.
 
 In more concrete terms: users running their services on platforms such as Kubernetes are encouraged to explicitly
 set the `service.instance.id` using their existing automation, or set a value that can be used for a
@@ -159,7 +159,7 @@ generating `service.instance.id`:
   possibly without the namespace.
 - When the SDK is running in an environment where a `/etc/machine-id`
   (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
-  is available, the machine-id should be used in the input for generating a UUID v5 (possibly without the namespace):
+  is available, the machine-id SHOULD be used in the input for generating a UUID v5 (possibly without the namespace):
   `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${machine.id}`
 - When the SDK is running on a Windows environment and there's a reasonable way to read
   registry keys for the SDK, the registry key

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -163,6 +163,7 @@ SDKs MUST use the following algorithm when generating `service.instance.id`:
   no different than a completely new UUID per process.
 
 Examples in Go, using the package "github.com/google/uuid" to generate the UUIDs:
+
 ```go
 package main
 

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -140,13 +140,16 @@ SDKs MUST use the following algorithm when generating `service.instance.id`:
   variable, configuration or custom resource detection, this MUST take priority over generated IDs.
 - When any of the below combinations of resource attribute are provided, they MUST be used as the input
   for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
-  * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`
+  * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`, 
+  possibly without the namespace.
   * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input
-  `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`
-  * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`
+  `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`. In this case,
+  the namespace MUST be used.
+  * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`,
+  possibly without the namespace.
 - When the SDK is running in an environment where a `/etc/machine-id`
   (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
-  is available, the machine-id should be used in the input for generating a UUID v5:
+  is available, the machine-id should be used in the input for generating a UUID v5 (possibly without the namespace):
   `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${machine.id}`
 - When the SDK is running on a Windows environment and there's a reasonable way to read
   registry keys for the SDK, the registry key

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -102,7 +102,7 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 | `service.instance.id` | string | The string ID of the service instance. [1] | `my-k8s-pod-deployment-1`; `627cc493-f310-47de-96bd-71410b7dec09` | Recommended |
 | `service.namespace` | string | A namespace for `service.name`. [2] | `Shop` | Recommended |
 
-**[1]:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. Services aiming for reproducible UUIDs may also use Version 5.
+**[1]:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. Services aiming for reproducible UUIDs may also use Version 5. UUIDs are typically recommended, as we only need an opaque yet reproducible value for the purposes of identifying a service instance. Similar to what can be seen in the man page for the `/etc/machine-id` file, the underlying data, such as pod name and namespace should be treated as confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
 SDKs are required to follow the following algorithm when generating `service.instance.id`:
 - If the user has provided a `service.instance.id`, via environment
   variable, configuration or custom resource detection, this will
@@ -112,12 +112,8 @@ SDKs are required to follow the following algorithm when generating `service.ins
   * `container.id`
   * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`
   * `host.id`
-- When the SDK can detect it's running on Kubernetes or derivatives, such as by checking the
-  availability of a directory named `/var/run/secrets/kubernetes.io`, it should use
-  the contents of the file `/var/run/secrets/kubernetes.io/serviceaccount/namespace`,
-  along with the hostname and process ID (PID) separated with a dot ("namespace.hostname.pid") as the input
-  for generating a UUID v5.
-- When the SDK is running in an environment where a `/etc/machine-id` (see MACHINE-ID(5))
+- When the SDK is running in an environment where a `/etc/machine-id` 
+  (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
   is available, the machine-id should be used as the input for generating a UUID v5 along with
   the `service.name`.
 - When the SDK is running on a Windows environment and there's a reasonable way to read
@@ -125,7 +121,12 @@ SDKs are required to follow the following algorithm when generating `service.ins
   `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid` can be used in a
   similar way to Linux' machine-id above.
 - When no other source is available the SDK MUST generate an ID. This
-  ID SHOULD follow version 1 or 4 of RFC 4122 UUIDs.
+  ID SHOULD follow version 1 or 4 of RFC 4122 UUIDs. This would also typically be the case for
+  service instances running on Kubernetes, given that the pod's name and namespace are not unique
+  enough to determine a service instance's identity: on pods with multiple containers, the
+  `service.instance.id` would yield the same results for all containers, which is not desirable.
+  And given that the services are ephemeral on Kubernetes, the `service.instance.id` would change
+  on each restart, being therefore no different than a completely new UUID per process.
 
 **[2]:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
 <!-- endsemconv -->

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -99,113 +99,35 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 <!-- semconv service_experimental -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `service.instance.id` | string | The string ID of the service instance. [1] | `my-k8s-pod-deployment-1`; `627cc493-f310-47de-96bd-71410b7dec09` | Recommended |
+| `service.instance.id` | string | The string ID of the service instance. [1] | `627cc493-f310-47de-96bd-71410b7dec09` | Recommended |
 | `service.namespace` | string | A namespace for `service.name`. [2] | `Shop` | Recommended |
 
-**[1]:** MUST be unique for each instance of the same `service.namespace,service.name` pair
-(in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique).
-The ID helps to distinguish instances of the same service that exist at the same time
-(e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent
-and stay the same for the lifetime of the service instance, however it is acceptable that
-the ID is ephemeral and changes during important lifetime events for the service
-(e.g. service instance restarts).
+**[1]:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words
+`service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to
+distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled
+service).
 
-If the instance has no inherent unique ID that can be used as the value of this attribute,
-implementations MAY generate a random Version 1 or Version 4
-[RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. When enough data is available,
-implementations SHOULD use Version 5 and SHOULD use the following UUID as the namespace:
-`4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
+Implementations are recommended to generate a random Version 1 or Version 4 [RFC
+4122](https://www.ietf.org/rfc/rfc4122.txt) UUID, but are free to use an inherent unique ID as the source of
+this value if stability is desirable. In that case, the ID SHOULD be used as source of a UUID Version 5 and
+SHOULD use the following UUID as the namespace: `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
 
-UUIDs are typically recommended, as only an opaque yet reproducible value for
-the purposes of identifying a service instance is needed. Similar to what can be seen in the man page for the
-[`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file,
-the underlying data, such as pod name and namespace should be treated as
-confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
+UUIDs are typically recommended, as only an opaque value for the purposes of identifying a service instance is
+needed. Similar to what can be seen in the man page for the
+[`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file, the underlying
+data, such as pod name and namespace should be treated as confidential, being the user's choice to expose it
+or not via another resource attribute.
 
-When a UUID v5 is generated, the input SHOULD be prefixed with
-`${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the
-the workload identifier, which should tentatively be stable. The workload identifier is the final piece of
-information making the source of telemetry to be uniquely idenfiable. For instance, it might be the `container.name`
-in containerized or Kubernetes environments. This means that the same service yields the
-same UUID if the same identifier (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
-yield different results for different services on the same host or namespace. When no namespaces or equivalent fields
-are available, the prefix MUST then be `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`.
+For applications running behind an application server, such as unicorn, a stable identifier is not desirable,
+as each worker thread typically is seen as a different instance. For those cases, a UUID v1/v4 is always
+recommended.
 
-For applications running behind an application server, such as unicorn, a stable identifier is not desirable, as
-each worker thread typically is seen as a different instance.
-
-SDKs SHOULD use the following algorithm when generating `service.instance.id`:
-
-- If the user has provided a `service.instance.id`, via environment
-  variable, configuration or custom resource detection, this MUST take priority over generated IDs. The special value `uuidv4` means
-  that a UUID v4 should be generated.
-- When the language, framework, or platform has a native mechanism allowing workloads to be uniquely idenfiable, this mechanism MAY be used,
-  either directly or as an input when generating UUID v5. A generated UUID v5 is preferable if the provided identifier isn't opaque and can
-  leak unwanted information about the workload (like a node name). An example of such native mechanism is Erlang's `erlang:node()`.
-- When any of the below combinations of resource attribute are provided, they MUST be used as the input
-  for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
-  * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input
-  `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`. In this case,
-  the namespace MUST be used.
-  * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`,
-  possibly without the `${service.namespace}`.
-  * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`,
-  possibly without `${service.namespace}`.
-- When the SDK is running in an environment where a `/etc/machine-id`
-  (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
-  is available, the machine-id SHOULD be used in the input for generating a UUID v5 (possibly without the namespace):
-  `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${machine.id}`
-- When the SDK is running on a Windows environment and there's a reasonable way to read
-  registry keys for the SDK, the registry key
-  `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid` can be used in a
-  similar way to Linux' machine-id above.
-- When no other source is available the SDK MUST generate a value using UUID v1 or v4.
-  For service instances running on Kubernetes, this is typically the case where a pod's name +
-  namespace are not unique enough to determine a service instance's identity and the container name
-  cannot easily be inferred. If we created a UUID without `container.name`, on pods with multiple
-  containers, the `service.instance.id` would yield the same results for all containers, which is undesirable.
-  Given that services are ephemeral on Kubernetes, the `service.instance.id` would change on each
-  restart, therefore being no different than a completely new UUID per process.
-
-Examples in Go, using the package "github.com/google/uuid" to generate the UUIDs:
-
-```go
-package main
-
-import (
-  "fmt"
-
-  "github.com/google/uuid"
-)
-
-func main() {
-  // fixed namespace for the purposes of this OTEP
-  ns := uuid.MustParse("4d63009a-8d0f-11ee-aad7-4c796ed8e320")
-
-  // prefix when no namespace is available
-  prefix := "${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}"
-
-  // prefix when a namespace is available
-  prefix = "${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}"
-
-  // actual prefix for the OTel Go SDK, for a service named "customers"
-  prefix = "opentelemetry.go.customers"
-
-  // the generated service.instance.id where a host.id is used
-  host := "graviola"
-  id := uuid.NewSHA1(ns, []byte(fmt.Sprintf("%s.%s", prefix, host))) // 17ffc8fd-6ed7-5069-a5fb-2fed78f5455f
-  fmt.Printf("v5 host id: %v\n", id)
-
-  // the generated service.instance.id where a typical kubernetes values are available
-  namespace := "accounting"
-  name := "vendors" // typically, the deployment name
-  pod := "vendors-pqr-jh7d2"
-  container := "some-sidecar"
-  input := fmt.Sprintf("opentelemetry.go.%s.%s.%s.%s", namespace, name, pod, container)
-  id = uuid.NewSHA1(ns, []byte(input)) // f3a5f61b-9fff-5707-8d41-d3a9d2423b7d
-  fmt.Printf("v5 id: %v\n", id)
-}
-```
+Collectors aren't recommended to set a `service.instance.id`: any identifying information that the Collector
+can infer should be added as a regular resource attribute, and it's unlikely that the Collector will have all
+the information to be certain from which instance of a service a data point originated. As an example, a
+Kubernetes pod might have multiple containers, and a Collector may not be able to confidently infer from which
+container the telemetry is coming from. However, if the Collector can confidently infer the source of
+telemetry unambiguously, it MAY use the information at its disposal and generate a UUID Version 5 with it.
 
 **[2]:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
 <!-- endsemconv -->

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -113,7 +113,7 @@ the ID is ephemeral and changes during important lifetime events for the service
 If the instance has no inherent unique ID that can be used as the value of this attribute,
 implementations MAY generate a random Version 1 or Version 4
 [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. When enough data is available,
-implementations SHOULD use Version 5 and MUST use the following UUID as the namespace:
+implementations SHOULD use Version 5 and SHOULD use the following UUID as the namespace:
 `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
 
 UUIDs are typically recommended, as only an opaque yet reproducible value for
@@ -122,41 +122,28 @@ the purposes of identifying a service instance is needed. Similar to what can be
 the underlying data, such as pod name and namespace should be treated as
 confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
 
-When a UUID v5 is generated, the input MUST be prefixed with
+When a UUID v5 is generated, the input SHOULD be prefixed with
 `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the
 the workload identifier, which should tentatively be stable. The workload identifier is the final piece of
-information making the source of telemetry to be uniquely idenfiable. For instance, it might be the `container.id`
-or `container.name` in containerized or Kubernetes environments. This means that the same service yields the
+information making the source of telemetry to be uniquely idenfiable. For instance, it might be the `container.name`
+in containerized or Kubernetes environments. This means that the same service yields the
 same UUID if the same identifier (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
 yield different results for different services on the same host or namespace. When no namespaces or equivalent fields
 are available, the prefix MUST then be `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`.
 
-Users are encouraged to explicitly set the `service.instance.id` themselves, given they are in the best position
-to determine what's a service instance. For instance, in some cases, all containers in a given pod might be part
-of the same service, while in other cases, each container would independently generate their own telemetry. When
-it's not possible or desirable to explicitly generate a `service.instance.id`, users are encouraged to set
-enough information via their workload automation, such as Helm. In that case, SDKs would have enough data to
-generate a `service.instance.id`. Future versions of the OpenTelemetry Operator might also have the ability to
-generate the `service.instance.id` and set container-specific labels, given it is in a position to know all that
-metadata. When SDKs don't have sufficient data to generate a stable UUID, a random one is generated.
-
-In more concrete terms: users running their services on platforms such as Kubernetes are encouraged to explicitly
-set the `service.instance.id` using their existing automation, or set a value that can be used for a
-consistent value, such as `container.id`. Similarly, users of application servers such as `unicorn`
-are encouraged to set the `service.instance.id` on a per-worker basis. SDKs MUST use the following algorithm when
-generating `service.instance.id`:
+SDKs MUST provide a `service.instance.id`. SDKs SHOULD use the following algorithm when generating `service.instance.id`:
 
 - If the user has provided a `service.instance.id`, via environment
   variable, configuration or custom resource detection, this MUST take priority over generated IDs.
 - When any of the below combinations of resource attribute are provided, they MUST be used as the input
   for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
-  * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`,
-  possibly without the namespace.
   * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input
   `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`. In this case,
   the namespace MUST be used.
-  * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`,
+  * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`,
   possibly without the namespace.
+  * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`,
+  possibly without `${service.namespace}`.
 - When the SDK is running in an environment where a `/etc/machine-id`
   (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
   is available, the machine-id SHOULD be used in the input for generating a UUID v5 (possibly without the namespace):
@@ -166,7 +153,7 @@ generating `service.instance.id`:
   `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid` can be used in a
   similar way to Linux' machine-id above.
 - When no other source is available the SDK MUST generate a value using UUID v1 or v4.
-  This would also typically be the case for service instances running on Kubernetes,
+  This would typically be the case for service instances running on Kubernetes,
   given that the pod's name and namespace are not unique enough to determine a service
   instance's identity and the container name cannot easily be inferred: on pods with
   multiple containers, the `service.instance.id` would yield the same results for all

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -139,7 +139,9 @@ SDKs SHOULD use the following algorithm when generating `service.instance.id`:
 - If the user has provided a `service.instance.id`, via environment
   variable, configuration or custom resource detection, this MUST take priority over generated IDs. The special value `uuidv4` means
   that a UUID v4 should be generated.
-- When the language, framework, or platform has a native mechanism allowing workloads to be uniquely idenfiable, this mechanism MAY be used.
+- When the language, framework, or platform has a native mechanism allowing workloads to be uniquely idenfiable, this mechanism MAY be used,
+  either directly or as an input when generating UUID v5. A generated UUID v5 is preferable if the provided identifier isn't opaque and can
+  leak unwanted information about the workload (like a node name). An example of such native mechanism is Erlang's `erlang:node()`.
 - When any of the below combinations of resource attribute are provided, they MUST be used as the input
   for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
   * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -108,19 +108,24 @@ The ID helps to distinguish instances of the same service that exist at the same
 (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent
 and stay the same for the lifetime of the service instance, however it is acceptable that
 the ID is ephemeral and changes during important lifetime events for the service
-(e.g. service restarts).
-If the service has no inherent unique ID that can be used as the value of this attribute
+(e.g. service instance restarts).
+If the instance has no inherent unique ID that can be used as the value of this attribute
 it is recommended to generate a random Version 1 or Version 4
 [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. Services aiming for reproducible UUIDs may also
 use Version 5. UUIDs are typically recommended, as we only need an opaque yet reproducible value for
 the purposes of identifying a service instance. Similar to what can be seen in the man page for the
-`/etc/machine-id` file, the underlying data, such as pod name and namespace should be treated as
+[`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file, the underlying data, such as pod name and namespace should be treated as
 confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
 
 When a UUID v5 is generated, the UUID's namespace MUST be set to:
 `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`, so that the same service yields the
 same ID if the same value (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
 yield different results for different services on the same host.
+
+Users running their services on platforms such as Kubernetes are encouraged to explicitly set the
+`service.instance.id` using their existing automation, or by setting a value that can be used for a
+consistent value, such as `container.id`. Similarly, users of application servers such as `unicorn`
+are encouraged to set the `service.instance.id` on a per-worker basis.
 
 SDKs are required to use the following algorithm when generating `service.instance.id`:
 
@@ -142,7 +147,7 @@ SDKs are required to use the following algorithm when generating `service.instan
 - When no other source is available the SDK MUST generate a value using UUID v1 or v4.
   This would also typically be the case for service instances running on Kubernetes,
   given that the pod's name and namespace are not unique enough to determine a service
-  instance's identity and the container name cannot easily be infered: on pods with
+  instance's identity and the container name cannot easily be inferred: on pods with
   multiple containers, the `service.instance.id` would yield the same results for all
   containers, which is not desirable. And given that the services are ephemeral on
   Kubernetes, the `service.instance.id` would change on each restart, being therefore

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -115,7 +115,8 @@ SDKs are required to follow the following algorithm when generating `service.ins
   along with the hostname and process ID (PID) separated with a dot ("namespace.hostname.pid") as the input
   for generating a UUID v5.
 - When the SDK is running in an environment where a `/etc/machine-id` (see MACHINE-ID(5))
-  is available, the machine-id should be used as the input for generating a UUID v5.
+  is available, the machine-id should be used as the input for generating a UUID v5 along with
+  the `service.name`.
 - When the SDK is running on a Windows environment and there's a reasonable way to read
   registry keys for the SDK, the registry key
   `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid` can be used in a

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -102,9 +102,28 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 | `service.instance.id` | string | The string ID of the service instance. [1] | `my-k8s-pod-deployment-1`; `627cc493-f310-47de-96bd-71410b7dec09` | Recommended |
 | `service.namespace` | string | A namespace for `service.name`. [2] | `Shop` | Recommended |
 
-**[1]:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. Services aiming for reproducible UUIDs may also use Version 5. UUIDs are typically recommended, as we only need an opaque yet reproducible value for the purposes of identifying a service instance. Similar to what can be seen in the man page for the `/etc/machine-id` file, the underlying data, such as pod name and namespace should be treated as confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
-When a UUID v5 is generated, the UUID's namespace MUST be set to: `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`, so that the same service yields the same ID if the same value (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still yield different results for different services on the same host.
+**[1]:** MUST be unique for each instance of the same `service.namespace,service.name` pair
+(in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique).
+The ID helps to distinguish instances of the same service that exist at the same time
+(e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent
+and stay the same for the lifetime of the service instance, however it is acceptable that
+the ID is ephemeral and changes during important lifetime events for the service
+(e.g. service restarts).
+If the service has no inherent unique ID that can be used as the value of this attribute
+it is recommended to generate a random Version 1 or Version 4
+[RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. Services aiming for reproducible UUIDs may also
+use Version 5. UUIDs are typically recommended, as we only need an opaque yet reproducible value for
+the purposes of identifying a service instance. Similar to what can be seen in the man page for the
+`/etc/machine-id` file, the underlying data, such as pod name and namespace should be treated as
+confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
+
+When a UUID v5 is generated, the UUID's namespace MUST be set to:
+`${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`, so that the same service yields the
+same ID if the same value (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
+yield different results for different services on the same host.
+
 SDKs are required to use the following algorithm when generating `service.instance.id`:
+
 - If the user has provided a `service.instance.id`, via environment
   variable, configuration or custom resource detection, this will
   always be used and honored over generated IDs.
@@ -113,7 +132,7 @@ SDKs are required to use the following algorithm when generating `service.instan
   * `container.id`
   * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`
   * `host.id`
-- When the SDK is running in an environment where a `/etc/machine-id` 
+- When the SDK is running in an environment where a `/etc/machine-id`
   (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
   is available, the machine-id should be used as the input for generating a UUID v5.
 - When the SDK is running on a Windows environment and there's a reasonable way to read

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -28,7 +28,7 @@ groups:
           distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled
           service).
 
-          Implementations are recommended to generate a random Version 1 or Version 4 [RFC
+          Implementations, such as SDKs, are recommended to generate a random Version 1 or Version 4 [RFC
           4122](https://www.ietf.org/rfc/rfc4122.txt) UUID, but are free to use an inherent unique ID as the source of
           this value if stability is desirable. In that case, the ID SHOULD be used as source of a UUID Version 5 and
           SHOULD use the following UUID as the namespace: `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
@@ -39,14 +39,14 @@ groups:
           data, such as pod name and namespace should be treated as confidential, being the user's choice to expose it
           or not via another resource attribute.
 
-          For applications running behind an application server, such as unicorn, a stable identifier is not desirable,
-          as each worker thread typically is seen as a different instance. For those cases, a UUID v1/v4 is always
-          recommended.
+          For applications running behind an application server (like unicorn), we do not recommend using one identifier
+          for all processes participating in the application. Instead, it's recommended each division (e.g. a worker
+          thread in unicorn) to have its own instance.id.
 
-          Collectors aren't recommended to set a `service.instance.id`: any identifying information that the Collector
-          can infer should be added as a regular resource attribute, and it's unlikely that the Collector will have all
-          the information to be certain from which instance of a service a data point originated. As an example, a
-          Kubernetes pod might have multiple containers, and a Collector may not be able to confidently infer from which
-          container the telemetry is coming from. However, if the Collector can confidently infer the source of
-          telemetry unambiguously, it MAY use the information at its disposal and generate a UUID Version 5 with it.
+          It's not recommended for a Collector to set `service.instance.id` if it can't unambiguously determine the
+          service instance that is generating that telemetry. For instance, creating an UUID based on `pod.name` will
+          likely be wrong, as the Collector likely doesn't know whether there are multiple containers within that pod.
+          However, Collectors can set the `service.instance.id` if they can unambiguously determine the service instance
+          for that telemetry. This is typically the case for scraping receivers, as they know the target address and
+          port.
         examples: ["627cc493-f310-47de-96bd-71410b7dec09"]

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -52,17 +52,19 @@ groups:
           yield different results for different services on the same host or namespace. When no namespaces or equivalent fields
           are available, the prefix MUST then be `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`.
 
-          SDKs MUST provide a `service.instance.id`. SDKs SHOULD use the following algorithm when generating `service.instance.id`:
+          SDKs SHOULD use the following algorithm when generating `service.instance.id`:
 
           - If the user has provided a `service.instance.id`, via environment
             variable, configuration or custom resource detection, this MUST take priority over generated IDs.
+          - When the language, framework, or platform has a native mechanism allowing workloads to be uniquely idenfiable, like Erlang's
+            clustering identity, this mechanism MAY be used.
           - When any of the below combinations of resource attribute are provided, they MUST be used as the input
             for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
             * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input
             `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`. In this case,
             the namespace MUST be used.
             * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`,
-            possibly without the namespace.
+            possibly without the `${service.namespace}`.
             * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`,
             possibly without `${service.namespace}`.
           - When the SDK is running in an environment where a `/etc/machine-id`
@@ -74,13 +76,12 @@ groups:
             `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid` can be used in a
             similar way to Linux' machine-id above.
           - When no other source is available the SDK MUST generate a value using UUID v1 or v4.
-            This would typically be the case for service instances running on Kubernetes,
-            given that the pod's name and namespace are not unique enough to determine a service
-            instance's identity and the container name cannot easily be inferred: on pods with
-            multiple containers, the `service.instance.id` would yield the same results for all
-            containers, which is not desirable. And given that the services are ephemeral on
-            Kubernetes, the `service.instance.id` would change on each restart, being therefore
-            no different than a completely new UUID per process.
+            For service instances running on Kubernetes, this is typically the case where a pod's name +
+            namespace are not unique enough to determine a service instance's identity and the container name
+            cannot easily be inferred. If we created a UUID without `container.name`, on pods with multiple
+            containers, the `service.instance.id` would yield the same results for all containers, which is undesirable.
+            Given that services are ephemeral on Kubernetes, the `service.instance.id` would change on each
+            restart, therefore being no different than a completely new UUID per process.
 
           Examples in Go, using the package "github.com/google/uuid" to generate the UUIDs:
 

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -32,7 +32,7 @@ groups:
           (e.g. service instance restarts).
 
           If the instance has no inherent unique ID that can be used as the value of this attribute,
-          implementations MAY to generate a random Version 1 or Version 4
+          implementations MAY generate a random Version 1 or Version 4
           [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. When enough data is available,
           implementations SHOULD use Version 5 and MUST use the following UUID as the namespace:
           `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
@@ -45,7 +45,7 @@ groups:
 
           When a UUID v5 is generated, the input MUST be prefixed with
           `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the
-          the workload identifier, which should tentatively stable. The workload identifier is the final piece of
+          the workload identifier, which should tentatively be stable. The workload identifier is the final piece of
           information making the source of telemetry to be uniquely idenfiable. For instance, it might be the `container.id`
           or `container.name` in containerized or Kubernetes environments. This means that the same service yields the
           same UUID if the same identifier (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
@@ -55,11 +55,11 @@ groups:
           Users are encouraged to explicitly set the `service.instance.id` themselves, given they are in the best position
           to determine what's a service instance. For instance, in some cases, all containers in a given pod might be part
           of the same service, while in other cases, each container would independently generate their own telemetry. When
-          it's not possible or desirable to explicitly generate a `service.instance.id`, users are encouraged to set set
-          enough information via their workload automation, such as Helm. In that case, SDKs would have enough information to
+          it's not possible or desirable to explicitly generate a `service.instance.id`, users are encouraged to set
+          enough information via their workload automation, such as Helm. In that case, SDKs would have enough data to
           generate a `service.instance.id`. Future versions of the OpenTelemetry Operator might also have the ability to
           generate the `service.instance.id` and set container-specific labels, given it is in a position to know all that
-          metadata. When SDKs don't have sufficient information to generate a stable UUID, a random one is generated.
+          metadata. When SDKs don't have sufficient data to generate a stable UUID, a random one is generated.
 
           In more concrete terms: users running their services on platforms such as Kubernetes are encouraged to explicitly
           set the `service.instance.id` using their existing automation, or set a value that can be used for a
@@ -80,7 +80,7 @@ groups:
             possibly without the namespace.
           - When the SDK is running in an environment where a `/etc/machine-id`
             (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
-            is available, the machine-id should be used in the input for generating a UUID v5 (possibly without the namespace):
+            is available, the machine-id SHOULD be used in the input for generating a UUID v5 (possibly without the namespace):
             `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${machine.id}`
           - When the SDK is running on a Windows environment and there's a reasonable way to read
             registry keys for the SDK, the registry key

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -40,8 +40,11 @@ groups:
           - If the user has provided a `service.instance.id`, via environment
             variable, configuration or custom resource detection, this will
             always be used and honored over generated IDs.
-          - When the `container.id` resource attribute is provided, it should be used as the input
-            for generating a UUID v5.
+          - When any of the below combinations of resource attribute are provided, they should be used as the input
+            for generating a UUID v5. The values within each combination should be separated with dots:
+            * `container.id`
+            * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`
+            * `host.id`
           - When the SDK can detect it's running on Kubernetes or derivatives, such as by checking the
             availability of a directory named `/var/run/secrets/kubernetes.io`, it should use
             the contents of the file `/var/run/secrets/kubernetes.io/serviceaccount/namespace`,

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -45,7 +45,7 @@ groups:
 
           Users running their services on platforms such as Kubernetes are encouraged to explicitly set the
           `service.instance.id` using their existing automation, or by setting a value that can be used for a
-          consistent value, such as `container.id`.
+          consistent value, such as `container.id`. Similarly, 
 
           SDKs are required to use the following algorithm when generating `service.instance.id`:
 
@@ -67,7 +67,7 @@ groups:
           - When no other source is available the SDK MUST generate a value using UUID v1 or v4.
             This would also typically be the case for service instances running on Kubernetes,
             given that the pod's name and namespace are not unique enough to determine a service
-            instance's identity and the container name cannot easily be infered: on pods with
+            instance's identity and the container name cannot easily be inferred: on pods with
             multiple containers, the `service.instance.id` would yield the same results for all
             containers, which is not desirable. And given that the services are ephemeral on
             Kubernetes, the `service.instance.id` would change on each restart, being therefore

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -30,37 +30,45 @@ groups:
           and stay the same for the lifetime of the service instance, however it is acceptable that
           the ID is ephemeral and changes during important lifetime events for the service
           (e.g. service instance restarts).
-          If the instance has no inherent unique ID that can be used as the value of this attribute
-          it is recommended to generate a random Version 1 or Version 4
-          [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. Services aiming for reproducible UUIDs may also
-          use Version 5. UUIDs are typically recommended, as we only need an opaque yet reproducible value for
+
+          If the instance has no inherent unique ID that can be used as the value of this attribute,
+          implementations MAY to generate a random Version 1 or Version 4
+          [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. When enough data is available, 
+          implementations SHOULD use Version 5 and MUST use the following UUID as the namespace: 
+          `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
+
+          UUIDs are typically recommended, as we only need an opaque yet reproducible value for
           the purposes of identifying a service instance. Similar to what can be seen in the man page for the
-          [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file, the underlying data, such as pod name and namespace should be treated as
+          [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file, 
+          the underlying data, such as pod name and namespace should be treated as
           confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
 
-          When a UUID v5 is generated, the UUID's namespace MUST be set to:
-          `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`, so that the same service yields the
-          same ID if the same value (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
-          yield different results for different services on the same host.
+          When a UUID v5 is generated, the input MUST be prefixed with
+          `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the 
+          the workload identifier, which should tentatively stable. This means that the same service yields the
+          same UUID if the same identifier (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
+          yield different results for different services on the same host or namespace. When no namespaces or equivalent fields
+          are available, the prefix MUST then be `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`.
 
           Users running their services on platforms such as Kubernetes are encouraged to explicitly set the
           `service.instance.id` using their existing automation, or by setting a value that can be used for a
           consistent value, such as `container.id`. Similarly, users of application servers such as `unicorn`
           are encouraged to set the `service.instance.id` on a per-worker basis.
 
-          SDKs are required to use the following algorithm when generating `service.instance.id`:
+          SDKs MUST use the following algorithm when generating `service.instance.id`:
 
           - If the user has provided a `service.instance.id`, via environment
             variable, configuration or custom resource detection, this will
             always be used and honored over generated IDs.
-          - When any of the below combinations of resource attribute are provided, they should be used as the input
-            for generating a UUID v5. The values within each combination should be separated with dots:
-            * `container.id`
-            * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`
-            * `host.id`
+          - When any of the below combinations of resource attribute are provided, they MUST be used as the input
+            for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
+            * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`
+            * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`
+            * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`
           - When the SDK is running in an environment where a `/etc/machine-id`
             (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
-            is available, the machine-id should be used as the input for generating a UUID v5.
+            is available, the machine-id should be used in the input for generating a UUID v5: 
+            `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${machine.id}`
           - When the SDK is running on a Windows environment and there's a reasonable way to read
             registry keys for the SDK, the registry key
             `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid` can be used in a
@@ -73,4 +81,43 @@ groups:
             containers, which is not desirable. And given that the services are ephemeral on
             Kubernetes, the `service.instance.id` would change on each restart, being therefore
             no different than a completely new UUID per process.
+
+          Examples in Go, using the package "github.com/google/uuid" to generate the UUIDs:
+          ```go
+          package main
+
+          import (
+            "fmt"
+
+            "github.com/google/uuid"
+          )
+
+          func main() {
+            // fixed namespace for the purposes of this OTEP
+            ns := uuid.MustParse("4d63009a-8d0f-11ee-aad7-4c796ed8e320")
+
+            // prefix when no namespace is available
+            prefix := "${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}"
+
+            // prefix when a namespace is available
+            prefix = "${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}"
+
+            // actual prefix for the OTel Go SDK, for a service named "customers"
+            prefix = "opentelemetry.go.customers"
+
+            // the generated service.instance.id where a host.id is used
+            host := "graviola"
+            id := uuid.NewSHA1(ns, []byte(fmt.Sprintf("%s.%s", prefix, host))) // 17ffc8fd-6ed7-5069-a5fb-2fed78f5455f
+            fmt.Printf("v5 host id: %v\n", id)
+
+            // the generated service.instance.id where a typical kubernetes values are available
+            namespace := "accounting"
+            name := "vendors" // typically, the deployment name
+            pod := "vendors-pqr-jh7d2"
+            container := "some-sidecar"
+            input := fmt.Sprintf("opentelemetry.go.%s.%s.%s.%s", namespace, name, pod, container)
+            id = uuid.NewSHA1(ns, []byte(input)) // f3a5f61b-9fff-5707-8d41-d3a9d2423b7d
+            fmt.Printf("v5 id: %v\n", id)
+          }
+          ```
         examples: ["my-k8s-pod-deployment-1", "627cc493-f310-47de-96bd-71410b7dec09"]

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -37,25 +37,35 @@ groups:
           implementations SHOULD use Version 5 and MUST use the following UUID as the namespace:
           `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
 
-          UUIDs are typically recommended, as we only need an opaque yet reproducible value for
-          the purposes of identifying a service instance. Similar to what can be seen in the man page for the
+          UUIDs are typically recommended, as only an opaque yet reproducible value for
+          the purposes of identifying a service instance is needed. Similar to what can be seen in the man page for the
           [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file,
           the underlying data, such as pod name and namespace should be treated as
           confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
 
           When a UUID v5 is generated, the input MUST be prefixed with
           `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the
-          the workload identifier, which should tentatively stable. This means that the same service yields the
+          the workload identifier, which should tentatively stable. The workload identifier is the final piece of
+          information making the source of telemetry to be uniquely idenfiable. For instance, it might be the `container.id`
+          or `container.name` in containerized or Kubernetes environments. This means that the same service yields the
           same UUID if the same identifier (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
           yield different results for different services on the same host or namespace. When no namespaces or equivalent fields
           are available, the prefix MUST then be `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`.
 
-          Users running their services on platforms such as Kubernetes are encouraged to explicitly set the
-          `service.instance.id` using their existing automation, or by setting a value that can be used for a
-          consistent value, such as `container.id`. Similarly, users of application servers such as `unicorn`
-          are encouraged to set the `service.instance.id` on a per-worker basis.
+          Users are encouraged to explicitly set the `service.instance.id` themselves, given they are in the best position
+          to determine what's a service instance. For instance, in some cases, all containers in a given pod might be part
+          of the same service, while in other cases, each container would independently generate their own telemetry. When
+          it's not possible or desirable to explicitly generate a `service.instance.id`, users are encouraged to set set
+          enough information via their workload automation, such as Helm. In that case, SDKs would have enough information to
+          generate a `service.instance.id`. Future versions of the OpenTelemetry Operator might also have the ability to
+          generate the `service.instance.id` and set container-specific labels, given it is in a position to know all that
+          metadata. When SDKs don't have sufficient information to generate a stable UUID, a random one is generated.
 
-          SDKs MUST use the following algorithm when generating `service.instance.id`:
+          In more concrete terms: users running their services on platforms such as Kubernetes are encouraged to explicitly
+          set the `service.instance.id` using their existing automation, or set a value that can be used for a
+          consistent value, such as `container.id`. Similarly, users of application servers such as `unicorn`
+          are encouraged to set the `service.instance.id` on a per-worker basis. SDKs MUST use the following algorithm when
+          generating `service.instance.id`:
 
           - If the user has provided a `service.instance.id`, via environment
             variable, configuration or custom resource detection, this MUST take priority over generated IDs.

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -22,7 +22,7 @@ groups:
         type: string
         brief: >
           The string ID of the service instance.
-        note: >
+        note: |
           MUST be unique for each instance of the same `service.namespace,service.name` pair
           (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique).
           The ID helps to distinguish instances of the same service that exist at the same time
@@ -53,7 +53,7 @@ groups:
             * `container.id`
             * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`
             * `host.id`
-          - When the SDK is running in an environment where a `/etc/machine-id` 
+          - When the SDK is running in an environment where a `/etc/machine-id`
             (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
             is available, the machine-id should be used as the input for generating a UUID v5.
           - When the SDK is running on a Windows environment and there's a reasonable way to read

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -23,108 +23,30 @@ groups:
         brief: >
           The string ID of the service instance.
         note: |
-          MUST be unique for each instance of the same `service.namespace,service.name` pair
-          (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique).
-          The ID helps to distinguish instances of the same service that exist at the same time
-          (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent
-          and stay the same for the lifetime of the service instance, however it is acceptable that
-          the ID is ephemeral and changes during important lifetime events for the service
-          (e.g. service instance restarts).
+          MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words
+          `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to
+          distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled
+          service).
 
-          If the instance has no inherent unique ID that can be used as the value of this attribute,
-          implementations MAY generate a random Version 1 or Version 4
-          [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. When enough data is available,
-          implementations SHOULD use Version 5 and SHOULD use the following UUID as the namespace:
-          `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
+          Implementations are recommended to generate a random Version 1 or Version 4 [RFC
+          4122](https://www.ietf.org/rfc/rfc4122.txt) UUID, but are free to use an inherent unique ID as the source of
+          this value if stability is desirable. In that case, the ID SHOULD be used as source of a UUID Version 5 and
+          SHOULD use the following UUID as the namespace: `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
 
-          UUIDs are typically recommended, as only an opaque yet reproducible value for
-          the purposes of identifying a service instance is needed. Similar to what can be seen in the man page for the
-          [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file,
-          the underlying data, such as pod name and namespace should be treated as
-          confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
+          UUIDs are typically recommended, as only an opaque value for the purposes of identifying a service instance is
+          needed. Similar to what can be seen in the man page for the
+          [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file, the underlying
+          data, such as pod name and namespace should be treated as confidential, being the user's choice to expose it
+          or not via another resource attribute.
 
-          When a UUID v5 is generated, the input SHOULD be prefixed with
-          `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the
-          the workload identifier, which should tentatively be stable. The workload identifier is the final piece of
-          information making the source of telemetry to be uniquely idenfiable. For instance, it might be the `container.name`
-          in containerized or Kubernetes environments. This means that the same service yields the
-          same UUID if the same identifier (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
-          yield different results for different services on the same host or namespace. When no namespaces or equivalent fields
-          are available, the prefix MUST then be `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`.
+          For applications running behind an application server, such as unicorn, a stable identifier is not desirable,
+          as each worker thread typically is seen as a different instance. For those cases, a UUID v1/v4 is always
+          recommended.
 
-          For applications running behind an application server, such as unicorn, a stable identifier is not desirable, as
-          each worker thread typically is seen as a different instance.
-
-          SDKs SHOULD use the following algorithm when generating `service.instance.id`:
-
-          - If the user has provided a `service.instance.id`, via environment
-            variable, configuration or custom resource detection, this MUST take priority over generated IDs. The special value `uuidv4` means
-            that a UUID v4 should be generated.
-          - When the language, framework, or platform has a native mechanism allowing workloads to be uniquely idenfiable, this mechanism MAY be used,
-            either directly or as an input when generating UUID v5. A generated UUID v5 is preferable if the provided identifier isn't opaque and can
-            leak unwanted information about the workload (like a node name). An example of such native mechanism is Erlang's `erlang:node()`.
-          - When any of the below combinations of resource attribute are provided, they MUST be used as the input
-            for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
-            * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input
-            `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`. In this case,
-            the namespace MUST be used.
-            * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`,
-            possibly without the `${service.namespace}`.
-            * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`,
-            possibly without `${service.namespace}`.
-          - When the SDK is running in an environment where a `/etc/machine-id`
-            (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
-            is available, the machine-id SHOULD be used in the input for generating a UUID v5 (possibly without the namespace):
-            `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${machine.id}`
-          - When the SDK is running on a Windows environment and there's a reasonable way to read
-            registry keys for the SDK, the registry key
-            `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid` can be used in a
-            similar way to Linux' machine-id above.
-          - When no other source is available the SDK MUST generate a value using UUID v1 or v4.
-            For service instances running on Kubernetes, this is typically the case where a pod's name +
-            namespace are not unique enough to determine a service instance's identity and the container name
-            cannot easily be inferred. If we created a UUID without `container.name`, on pods with multiple
-            containers, the `service.instance.id` would yield the same results for all containers, which is undesirable.
-            Given that services are ephemeral on Kubernetes, the `service.instance.id` would change on each
-            restart, therefore being no different than a completely new UUID per process.
-
-          Examples in Go, using the package "github.com/google/uuid" to generate the UUIDs:
-
-          ```go
-          package main
-
-          import (
-            "fmt"
-
-            "github.com/google/uuid"
-          )
-
-          func main() {
-            // fixed namespace for the purposes of this OTEP
-            ns := uuid.MustParse("4d63009a-8d0f-11ee-aad7-4c796ed8e320")
-
-            // prefix when no namespace is available
-            prefix := "${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}"
-
-            // prefix when a namespace is available
-            prefix = "${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}"
-
-            // actual prefix for the OTel Go SDK, for a service named "customers"
-            prefix = "opentelemetry.go.customers"
-
-            // the generated service.instance.id where a host.id is used
-            host := "graviola"
-            id := uuid.NewSHA1(ns, []byte(fmt.Sprintf("%s.%s", prefix, host))) // 17ffc8fd-6ed7-5069-a5fb-2fed78f5455f
-            fmt.Printf("v5 host id: %v\n", id)
-
-            // the generated service.instance.id where a typical kubernetes values are available
-            namespace := "accounting"
-            name := "vendors" // typically, the deployment name
-            pod := "vendors-pqr-jh7d2"
-            container := "some-sidecar"
-            input := fmt.Sprintf("opentelemetry.go.%s.%s.%s.%s", namespace, name, pod, container)
-            id = uuid.NewSHA1(ns, []byte(input)) // f3a5f61b-9fff-5707-8d41-d3a9d2423b7d
-            fmt.Printf("v5 id: %v\n", id)
-          }
-          ```
-        examples: ["my-k8s-pod-deployment-1", "627cc493-f310-47de-96bd-71410b7dec09"]
+          Collectors aren't recommended to set a `service.instance.id`: any identifying information that the Collector
+          can infer should be added as a regular resource attribute, and it's unlikely that the Collector will have all
+          the information to be certain from which instance of a service a data point originated. As an example, a
+          Kubernetes pod might have multiple containers, and a Collector may not be able to confidently infer from which
+          container the telemetry is coming from. However, if the Collector can confidently infer the source of
+          telemetry unambiguously, it MAY use the information at its disposal and generate a UUID Version 5 with it.
+        examples: ["627cc493-f310-47de-96bd-71410b7dec09"]

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -45,7 +45,7 @@ groups:
 
           It's not recommended for a Collector to set `service.instance.id` if it can't unambiguously determine the
           service instance that is generating that telemetry. For instance, creating an UUID based on `pod.name` will
-          likely be wrong, as the Collector likely doesn't know whether there are multiple containers within that pod.
+          likely be wrong, as the Collector might not know from which container within that pod the telemetry originated.
           However, Collectors can set the `service.instance.id` if they can unambiguously determine the service instance
           for that telemetry. This is typically the case for scraping receivers, as they know the target address and
           port.

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -34,7 +34,7 @@ groups:
           If the instance has no inherent unique ID that can be used as the value of this attribute,
           implementations MAY generate a random Version 1 or Version 4
           [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. When enough data is available,
-          implementations SHOULD use Version 5 and MUST use the following UUID as the namespace:
+          implementations SHOULD use Version 5 and SHOULD use the following UUID as the namespace:
           `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
 
           UUIDs are typically recommended, as only an opaque yet reproducible value for
@@ -43,41 +43,28 @@ groups:
           the underlying data, such as pod name and namespace should be treated as
           confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
 
-          When a UUID v5 is generated, the input MUST be prefixed with
+          When a UUID v5 is generated, the input SHOULD be prefixed with
           `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the
           the workload identifier, which should tentatively be stable. The workload identifier is the final piece of
-          information making the source of telemetry to be uniquely idenfiable. For instance, it might be the `container.id`
-          or `container.name` in containerized or Kubernetes environments. This means that the same service yields the
+          information making the source of telemetry to be uniquely idenfiable. For instance, it might be the `container.name`
+          in containerized or Kubernetes environments. This means that the same service yields the
           same UUID if the same identifier (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
           yield different results for different services on the same host or namespace. When no namespaces or equivalent fields
           are available, the prefix MUST then be `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`.
 
-          Users are encouraged to explicitly set the `service.instance.id` themselves, given they are in the best position
-          to determine what's a service instance. For instance, in some cases, all containers in a given pod might be part
-          of the same service, while in other cases, each container would independently generate their own telemetry. When
-          it's not possible or desirable to explicitly generate a `service.instance.id`, users are encouraged to set
-          enough information via their workload automation, such as Helm. In that case, SDKs would have enough data to
-          generate a `service.instance.id`. Future versions of the OpenTelemetry Operator might also have the ability to
-          generate the `service.instance.id` and set container-specific labels, given it is in a position to know all that
-          metadata. When SDKs don't have sufficient data to generate a stable UUID, a random one is generated.
-
-          In more concrete terms: users running their services on platforms such as Kubernetes are encouraged to explicitly
-          set the `service.instance.id` using their existing automation, or set a value that can be used for a
-          consistent value, such as `container.id`. Similarly, users of application servers such as `unicorn`
-          are encouraged to set the `service.instance.id` on a per-worker basis. SDKs MUST use the following algorithm when
-          generating `service.instance.id`:
+          SDKs MUST provide a `service.instance.id`. SDKs SHOULD use the following algorithm when generating `service.instance.id`:
 
           - If the user has provided a `service.instance.id`, via environment
             variable, configuration or custom resource detection, this MUST take priority over generated IDs.
           - When any of the below combinations of resource attribute are provided, they MUST be used as the input
             for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
-            * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`,
-            possibly without the namespace.
             * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input
             `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`. In this case,
             the namespace MUST be used.
-            * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`,
+            * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`,
             possibly without the namespace.
+            * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`,
+            possibly without `${service.namespace}`.
           - When the SDK is running in an environment where a `/etc/machine-id`
             (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
             is available, the machine-id SHOULD be used in the input for generating a UUID v5 (possibly without the namespace):
@@ -87,7 +74,7 @@ groups:
             `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid` can be used in a
             similar way to Linux' machine-id above.
           - When no other source is available the SDK MUST generate a value using UUID v1 or v4.
-            This would also typically be the case for service instances running on Kubernetes,
+            This would typically be the case for service instances running on Kubernetes,
             given that the pod's name and namespace are not unique enough to determine a service
             instance's identity and the container name cannot easily be inferred: on pods with
             multiple containers, the `service.instance.id` would yield the same results for all

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -45,7 +45,7 @@ groups:
           - When the SDK can detect it's running on Kubernetes or derivatives, such as by checking the
             availability of a directory named `/var/run/secrets/kubernetes.io`, it should use
             the contents of the file `/var/run/secrets/kubernetes.io/serviceaccount/namespace`,
-            along with the hostname and separated with a dot ("namespace.hostname") as the input
+            along with the hostname and process ID (PID) separated with a dot ("namespace.hostname.pid") as the input
             for generating a UUID v5.
           - When the SDK is running in an environment where a `/etc/machine-id` (see MACHINE-ID(5))
             is available, the machine-id should be used as the input for generating a UUID v5.

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -33,7 +33,10 @@ groups:
           If the service has no inherent unique ID that can be used as the value of this attribute
           it is recommended to generate a random Version 1 or Version 4
           [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. Services aiming for reproducible UUIDs may also
-          use Version 5.
+          use Version 5. UUIDs are typically recommended, as we only need an opaque yet reproducible value for
+          the purposes of identifying a service instance. Similar to what can be seen in the man page for the
+          `/etc/machine-id` file, the underlying data, such as pod name and namespace should be treated as
+          confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
 
           SDKs are required to follow the following algorithm when generating `service.instance.id`:
 
@@ -45,12 +48,8 @@ groups:
             * `container.id`
             * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`
             * `host.id`
-          - When the SDK can detect it's running on Kubernetes or derivatives, such as by checking the
-            availability of a directory named `/var/run/secrets/kubernetes.io`, it should use
-            the contents of the file `/var/run/secrets/kubernetes.io/serviceaccount/namespace`,
-            along with the hostname and process ID (PID) separated with a dot ("namespace.hostname.pid") as the input
-            for generating a UUID v5.
-          - When the SDK is running in an environment where a `/etc/machine-id` (see MACHINE-ID(5))
+          - When the SDK is running in an environment where a `/etc/machine-id` 
+            (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
             is available, the machine-id should be used as the input for generating a UUID v5 along with
             the `service.name`.
           - When the SDK is running on a Windows environment and there's a reasonable way to read
@@ -58,5 +57,10 @@ groups:
             `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid` can be used in a
             similar way to Linux' machine-id above.
           - When no other source is available the SDK MUST generate an ID. This
-            ID SHOULD follow version 1 or 4 of RFC 4122 UUIDs.
+            ID SHOULD follow version 1 or 4 of RFC 4122 UUIDs. This would also typically be the case for
+            service instances running on Kubernetes, given that the pod's name and namespace are not unique
+            enough to determine a service instance's identity: on pods with multiple containers, the
+            `service.instance.id` would yield the same results for all containers, which is not desirable.
+            And given that the services are ephemeral on Kubernetes, the `service.instance.id` would change
+            on each restart, being therefore no different than a completely new UUID per process.
         examples: ["my-k8s-pod-deployment-1", "627cc493-f310-47de-96bd-71410b7dec09"]

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -38,7 +38,12 @@ groups:
           `/etc/machine-id` file, the underlying data, such as pod name and namespace should be treated as
           confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
 
-          SDKs are required to follow the following algorithm when generating `service.instance.id`:
+          When a UUID v5 is generated, the UUID's namespace MUST be set to:
+          `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`, so that the same service yields the
+          same ID if the same value (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
+          yield different results for different services on the same host.
+
+          SDKs are required to use the following algorithm when generating `service.instance.id`:
 
           - If the user has provided a `service.instance.id`, via environment
             variable, configuration or custom resource detection, this will
@@ -50,17 +55,17 @@ groups:
             * `host.id`
           - When the SDK is running in an environment where a `/etc/machine-id` 
             (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
-            is available, the machine-id should be used as the input for generating a UUID v5 along with
-            the `service.name`.
+            is available, the machine-id should be used as the input for generating a UUID v5.
           - When the SDK is running on a Windows environment and there's a reasonable way to read
             registry keys for the SDK, the registry key
             `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid` can be used in a
             similar way to Linux' machine-id above.
-          - When no other source is available the SDK MUST generate an ID. This
-            ID SHOULD follow version 1 or 4 of RFC 4122 UUIDs. This would also typically be the case for
-            service instances running on Kubernetes, given that the pod's name and namespace are not unique
-            enough to determine a service instance's identity: on pods with multiple containers, the
-            `service.instance.id` would yield the same results for all containers, which is not desirable.
-            And given that the services are ephemeral on Kubernetes, the `service.instance.id` would change
-            on each restart, being therefore no different than a completely new UUID per process.
+          - When no other source is available the SDK MUST generate a value using UUID v1 or v4.
+            This would also typically be the case for service instances running on Kubernetes,
+            given that the pod's name and namespace are not unique enough to determine a service
+            instance's identity and the container name cannot easily be infered: on pods with
+            multiple containers, the `service.instance.id` would yield the same results for all
+            containers, which is not desirable. And given that the services are ephemeral on
+            Kubernetes, the `service.instance.id` would change on each restart, being therefore
+            no different than a completely new UUID per process.
         examples: ["my-k8s-pod-deployment-1", "627cc493-f310-47de-96bd-71410b7dec09"]

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -29,19 +29,23 @@ groups:
           (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent
           and stay the same for the lifetime of the service instance, however it is acceptable that
           the ID is ephemeral and changes during important lifetime events for the service
-          (e.g. service restarts).
-          If the service has no inherent unique ID that can be used as the value of this attribute
+          (e.g. service instance restarts).
+          If the instance has no inherent unique ID that can be used as the value of this attribute
           it is recommended to generate a random Version 1 or Version 4
           [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. Services aiming for reproducible UUIDs may also
           use Version 5. UUIDs are typically recommended, as we only need an opaque yet reproducible value for
           the purposes of identifying a service instance. Similar to what can be seen in the man page for the
-          `/etc/machine-id` file, the underlying data, such as pod name and namespace should be treated as
+          [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file, the underlying data, such as pod name and namespace should be treated as
           confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
 
           When a UUID v5 is generated, the UUID's namespace MUST be set to:
           `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`, so that the same service yields the
           same ID if the same value (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
           yield different results for different services on the same host.
+
+          Users running their services on platforms such as Kubernetes are encouraged to explicitly set the
+          `service.instance.id` using their existing automation, or by setting a value that can be used for a
+          consistent value, such as `container.id`.
 
           SDKs are required to use the following algorithm when generating `service.instance.id`:
 

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -58,8 +58,7 @@ groups:
           SDKs MUST use the following algorithm when generating `service.instance.id`:
 
           - If the user has provided a `service.instance.id`, via environment
-            variable, configuration or custom resource detection, this will
-            always be used and honored over generated IDs.
+            variable, configuration or custom resource detection, this MUST take priority over generated IDs.
           - When any of the below combinations of resource attribute are provided, they MUST be used as the input
             for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
             * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -60,7 +60,9 @@ groups:
           - If the user has provided a `service.instance.id`, via environment
             variable, configuration or custom resource detection, this MUST take priority over generated IDs. The special value `uuidv4` means
             that a UUID v4 should be generated.
-          - When the language, framework, or platform has a native mechanism allowing workloads to be uniquely idenfiable, this mechanism MAY be used.
+          - When the language, framework, or platform has a native mechanism allowing workloads to be uniquely idenfiable, this mechanism MAY be used,
+            either directly or as an input when generating UUID v5. A generated UUID v5 is preferable if the provided identifier isn't opaque and can
+            leak unwanted information about the workload (like a node name). An example of such native mechanism is Erlang's `erlang:node()`.
           - When any of the below combinations of resource attribute are provided, they MUST be used as the input
             for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
             * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -48,7 +48,8 @@ groups:
             along with the hostname and process ID (PID) separated with a dot ("namespace.hostname.pid") as the input
             for generating a UUID v5.
           - When the SDK is running in an environment where a `/etc/machine-id` (see MACHINE-ID(5))
-            is available, the machine-id should be used as the input for generating a UUID v5.
+            is available, the machine-id should be used as the input for generating a UUID v5 along with
+            the `service.name`.
           - When the SDK is running on a Windows environment and there's a reasonable way to read
             registry keys for the SDK, the registry key
             `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid` can be used in a

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -45,7 +45,8 @@ groups:
 
           Users running their services on platforms such as Kubernetes are encouraged to explicitly set the
           `service.instance.id` using their existing automation, or by setting a value that can be used for a
-          consistent value, such as `container.id`. Similarly, 
+          consistent value, such as `container.id`. Similarly, users of application servers such as `unicorn`
+          are encouraged to set the `service.instance.id` on a per-worker basis.
 
           SDKs are required to use the following algorithm when generating `service.instance.id`:
 

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -52,12 +52,15 @@ groups:
           yield different results for different services on the same host or namespace. When no namespaces or equivalent fields
           are available, the prefix MUST then be `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.name}`.
 
+          For applications running behind an application server, such as unicorn, a stable identifier is not desirable, as
+          each worker thread typically is seen as a different instance.
+
           SDKs SHOULD use the following algorithm when generating `service.instance.id`:
 
           - If the user has provided a `service.instance.id`, via environment
-            variable, configuration or custom resource detection, this MUST take priority over generated IDs.
-          - When the language, framework, or platform has a native mechanism allowing workloads to be uniquely idenfiable, like Erlang's
-            clustering identity, this mechanism MAY be used.
+            variable, configuration or custom resource detection, this MUST take priority over generated IDs. The special value `uuidv4` means
+            that a UUID v4 should be generated.
+          - When the language, framework, or platform has a native mechanism allowing workloads to be uniquely idenfiable, this mechanism MAY be used.
           - When any of the below combinations of resource attribute are provided, they MUST be used as the input
             for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
             * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -71,7 +71,7 @@ groups:
             variable, configuration or custom resource detection, this MUST take priority over generated IDs.
           - When any of the below combinations of resource attribute are provided, they MUST be used as the input
             for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
-            * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`, 
+            * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`,
             possibly without the namespace.
             * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input
             `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`. In this case,

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -31,7 +31,28 @@ groups:
           the ID is ephemeral and changes during important lifetime events for the service
           (e.g. service restarts).
           If the service has no inherent unique ID that can be used as the value of this attribute
-          it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID
-          (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122
-          for more recommendations).
+          it is recommended to generate a random Version 1 or Version 4
+          [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. Services aiming for reproducible UUIDs may also
+          use Version 5.
+
+          SDKs are required to follow the following algorithm when generating `service.instance.id`:
+
+          - If the user has provided a `service.instance.id`, via environment
+            variable, configuration or custom resource detection, this will
+            always be used and honored over generated IDs.
+          - When the `container.id` resource attribute is provided, it should be used as the input
+            for generating a UUID v5.
+          - When the SDK can detect it's running on Kubernetes or derivatives, such as by checking the
+            availability of a directory named `/var/run/secrets/kubernetes.io`, it should use
+            the contents of the file `/var/run/secrets/kubernetes.io/serviceaccount/namespace`,
+            along with the hostname and separated with a dot ("namespace.hostname") as the input
+            for generating a UUID v5.
+          - When the SDK is running in an environment where a `/etc/machine-id` (see MACHINE-ID(5))
+            is available, the machine-id should be used as the input for generating a UUID v5.
+          - When the SDK is running on a Windows environment and there's a reasonable way to read
+            registry keys for the SDK, the registry key
+            `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid` can be used in a
+            similar way to Linux' machine-id above.
+          - When no other source is available the SDK MUST generate an ID. This
+            ID SHOULD follow version 1 or 4 of RFC 4122 UUIDs.
         examples: ["my-k8s-pod-deployment-1", "627cc493-f310-47de-96bd-71410b7dec09"]

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -61,13 +61,16 @@ groups:
             variable, configuration or custom resource detection, this MUST take priority over generated IDs.
           - When any of the below combinations of resource attribute are provided, they MUST be used as the input
             for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
-            * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`
+            * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`, 
+            possibly without the namespace.
             * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input
-            `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`
-            * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`
+            `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`. In this case,
+            the namespace MUST be used.
+            * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`,
+            possibly without the namespace.
           - When the SDK is running in an environment where a `/etc/machine-id`
             (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
-            is available, the machine-id should be used in the input for generating a UUID v5:
+            is available, the machine-id should be used in the input for generating a UUID v5 (possibly without the namespace):
             `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${machine.id}`
           - When the SDK is running on a Windows environment and there's a reasonable way to read
             registry keys for the SDK, the registry key

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -33,18 +33,18 @@ groups:
 
           If the instance has no inherent unique ID that can be used as the value of this attribute,
           implementations MAY to generate a random Version 1 or Version 4
-          [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. When enough data is available, 
-          implementations SHOULD use Version 5 and MUST use the following UUID as the namespace: 
+          [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID. When enough data is available,
+          implementations SHOULD use Version 5 and MUST use the following UUID as the namespace:
           `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
 
           UUIDs are typically recommended, as we only need an opaque yet reproducible value for
           the purposes of identifying a service instance. Similar to what can be seen in the man page for the
-          [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file, 
+          [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file,
           the underlying data, such as pod name and namespace should be treated as
           confidential by this algorithm, being the user's choice to expose it or not via another resource attribute.
 
           When a UUID v5 is generated, the input MUST be prefixed with
-          `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the 
+          `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}`, followed by the
           the workload identifier, which should tentatively stable. This means that the same service yields the
           same UUID if the same identifier (`host.id`, `/etc/machine-id`, and so on) remains the same. It would still
           yield different results for different services on the same host or namespace. When no namespaces or equivalent fields
@@ -63,11 +63,12 @@ groups:
           - When any of the below combinations of resource attribute are provided, they MUST be used as the input
             for generating a UUID v5 following the prefix mentioned above. The values within each combination MUST be separated with dots:
             * `container.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${container.id}`
-            * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`
+            * `k8s.namespace.name`/`k8s.pod.name`/`k8s.container.name`, resulting in the input
+            `${telemetry.sdk.name}.${telemetry.sdk.language}.${k8s.namespace.name}.${service.name}.${k8s.pod.name}.${k8s.container.name}`
             * `host.id`, resulting in the input `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${host.id}`
           - When the SDK is running in an environment where a `/etc/machine-id`
             (see [MACHINE-ID(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html))
-            is available, the machine-id should be used in the input for generating a UUID v5: 
+            is available, the machine-id should be used in the input for generating a UUID v5:
             `${telemetry.sdk.name}.${telemetry.sdk.language}.${service.namespace}.${service.name}.${machine.id}`
           - When the SDK is running on a Windows environment and there's a reasonable way to read
             registry keys for the SDK, the registry key

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -84,6 +84,7 @@ groups:
             no different than a completely new UUID per process.
 
           Examples in Go, using the package "github.com/google/uuid" to generate the UUIDs:
+
           ```go
           package main
 


### PR DESCRIPTION
Related to #311, built on top of https://github.com/open-telemetry/opentelemetry-specification/pull/3222 by @jsuereth.

## Changes

Enhances the existing `service.instance.id` convention with a common algorithm for SDKs to use when generating that value.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
