### PR TITLE
Align networking conventions with ECS' `server.ip` and `client.ip`

### DIFF
--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -69,28 +69,22 @@ Some database systems may allow a connection to switch to a different `db.user`,
 | `db.user` | string | Username for accessing the database. | `readonly_user`; `reporting_user` | Recommended |
 | [`network.transport`](../general/attributes.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Recommended |
 | [`network.type`](../general/attributes.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Name of the database host. [1] | `example.com` | Conditionally Required: See alternative attributes below. |
-| [`server.port`](../general/attributes.md) | int | Server port number [2] | `80`; `8080`; `443` | Conditionally Required: [3] |
-| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [4] | `10.5.3.2` | See below |
-| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [5] | `16456` | Recommended: If different than `server.port`. |
+| `proxy.address` | string | Proxy address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. | `proxy.example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
+| `proxy.ip` | string | Proxy IP address. | `10.1.2.80` | Recommended: If different than `proxy.address`. |
+| `proxy.port` | int | Proxy port number. | `65123` | Recommended |
+| [`server.address`](../general/attributes.md) | string | Name of the database host. [1] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Conditionally Required: See alternative attributes below. |
+| [`server.ip`](../general/attributes.md) | string | Server IP address. [2] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.port`](../general/attributes.md) | int | Server port number [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
 
 **[1]:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent
 the server address behind any intermediaries (e.g. proxies) if it's available.
 
-**[2]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
+**[2]:** When observed from the client side, and when communicating through an intermediary, `server.ip` SHOULD represent the server IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the server side, this SHOULD represent the physical server IP address.
 
-**[3]:** If using a port other than the default port for this DBMS and if `server.address` is set.
+**[3]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
 
-**[4]:** When observed from the client side, this SHOULD represent the immediate server peer address.
-When observed from the server side, this SHOULD represent the physical server address.
-
-**[5]:** When observed from the client side, this SHOULD represent the immediate server peer port.
-When observed from the server side, this SHOULD represent the physical server port.
-
-**Additional attribute requirements:** At least one of the following sets of attributes is required:
-
-* [`server.address`](../general/attributes.md)
-* [`server.socket.address`](../general/attributes.md)
+**[4]:** If using a port other than the default port for this DBMS and if `server.address` is set.
 
 `db.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/database/elasticsearch.md
+++ b/docs/database/elasticsearch.md
@@ -44,7 +44,7 @@ in order to map the path part values to their names.
 | [`db.operation`](database-spans.md) | string | The endpoint identifier for the request. [3] | `search`; `ml.close_job`; `cat.aliases` | Required |
 | [`db.statement`](database-spans.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. | `"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"` | Recommended: [4] |
 | `http.request.method` | string | HTTP request method. [5] | `GET`; `POST`; `HEAD` | Required |
-| [`server.address`](../general/attributes.md) | string | Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [6] | `example.com` | See below |
+| [`server.address`](../general/attributes.md) | string | Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [6] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
 | [`server.port`](../general/attributes.md) | int | Server port number [7] | `80`; `8080`; `443` | Recommended |
 | [`url.full`](../url/url.md) | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [8] | `https://localhost:9200/index/_search?q=user.id:kimchy` | Required |
 

--- a/docs/database/mongodb.md
+++ b/docs/database/mongodb.md
@@ -22,14 +22,14 @@ described on this page.
 
 ## Example
 
-| Key | Value |
-| :---------------------- | :----------------------------------------------------------- |
+| Key                     | Value |
+|:------------------------| :----------------------------------------------------------- |
 | Span name               | `"products.findAndModify"` |
 | `db.system`             | `"mongodb"` |
 | `db.connection_string`  | not set |
 | `db.user`               | `"the_user"` |
 | `server.address`        | `"mongodb0.example.com"` |
-| `server.socket.address` | `"192.0.2.14"` |
+| `server.ip`             | `"192.0.2.14"` |
 | `server.port`           | `27017` |
 | `network.transport`     | `"IP.TCP"` |
 | `db.name`               | `"shopDb"` |

--- a/docs/database/redis.md
+++ b/docs/database/redis.md
@@ -36,7 +36,7 @@ Furthermore, `db.name` is not specified as there is no database name in Redis an
 | `db.system`               | `"redis"` |
 | `db.connection_string`    | not set |
 | `db.user`                 | not set |
-| `server.socket.address`   | `"/tmp/redis.sock"` |
+| `server.address`          | `"/tmp/redis.sock"` |
 | `network.transport`       | `"Unix"` |
 | `db.name`                 | not set |
 | `db.statement`            | `"HMSET myhash field1 'Hello' field2 'World"` |

--- a/docs/database/sql.md
+++ b/docs/database/sql.md
@@ -24,19 +24,19 @@ described on this page.
 
 This is an example of attributes for a MySQL database span:
 
-| Key                     | Value |
-|:------------------------| :----------------------------------------------------------- |
-| Span name               | `"SELECT ShopDb.orders"` |
-| `db.system`             | `"mysql"` |
-| `db.connection_string`  | `"Server=shopdb.example.com;Database=ShopDb;Uid=billing_user;TableCache=true;UseCompression=True;MinimumPoolSize=10;MaximumPoolSize=50;"` |
-| `db.user`               | `"billing_user"` |
-| `server.address`        | `"shopdb.example.com"` |
-| `server.socket.address` | `"192.0.2.12"` |
-| `server.port`           | `3306` |
-| `network.transport`     | `"IP.TCP"` |
-| `db.name`               | `"ShopDb"` |
-| `db.statement`          | `"SELECT * FROM orders WHERE order_id = 'o4711'"` |
-| `db.operation`          | `"SELECT"` |
-| `db.sql.table`          | `"orders"` |
+| Key                    | Value |
+|:-----------------------| :----------------------------------------------------------- |
+| Span name              | `"SELECT ShopDb.orders"` |
+| `db.system`            | `"mysql"` |
+| `db.connection_string` | `"Server=shopdb.example.com;Database=ShopDb;Uid=billing_user;TableCache=true;UseCompression=True;MinimumPoolSize=10;MaximumPoolSize=50;"` |
+| `db.user`              | `"billing_user"` |
+| `server.address`       | `"shopdb.example.com"` |
+| `server.ip`            | `"192.0.2.12"` |
+| `server.port`          | `3306` |
+| `network.transport`    | `"IP.TCP"` |
+| `db.name`              | `"ShopDb"` |
+| `db.statement`         | `"SELECT * FROM orders WHERE order_id = 'o4711'"` |
+| `db.operation`         | `"SELECT"` |
+| `db.sql.table`         | `"orders"` |
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.22.0/specification/document-status.md

--- a/docs/general/attributes.md
+++ b/docs/general/attributes.md
@@ -55,24 +55,17 @@ if they do not cause breaking changes to HTTP semantic conventions.
 <!-- semconv server -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `server.address` | string | Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [1] | `example.com` | Recommended |
+| `server.address` | string | Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [1] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
 | `server.port` | int | Server port number [2] | `80`; `8080`; `443` | Recommended |
-| `server.socket.domain` | string | Immediate server peer's domain name if available without reverse DNS lookup [3] | `proxy.example.com` | Recommended: If different than `server.address`. |
-| `server.socket.address` | string | Server address of the socket connection - IP address or Unix domain socket name. [4] | `10.5.3.2` | Recommended: If different than `server.address`. |
-| `server.socket.port` | int | Server port number of the socket connection. [5] | `16456` | Recommended: If different than `server.port`. |
+| `server.ip` | string | Server IP address. [3] | `10.5.3.2` | Recommended: If different than `server.address`. |
 
 **[1]:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent
 the server address behind any intermediaries (e.g. proxies) if it's available.
 
 **[2]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
 
-**[3]:** Typically observed from the client side, and represents a proxy or other intermediary domain name.
-
-**[4]:** When observed from the client side, this SHOULD represent the immediate server peer address.
-When observed from the server side, this SHOULD represent the physical server address.
-
-**[5]:** When observed from the client side, this SHOULD represent the immediate server peer port.
-When observed from the server side, this SHOULD represent the physical server port.
+**[3]:** When observed from the client side, and when communicating through an intermediary, `server.ip` SHOULD represent the server IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the server side, this SHOULD represent the physical server IP address.
 <!-- endsemconv -->
 
 `server.address` and `server.port` represent logical server name and port. Semantic conventions that refer to these attributes SHOULD
@@ -128,20 +121,16 @@ if they do not cause breaking changes to HTTP semantic conventions.
 <!-- semconv client -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `client.address` | string | Client address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [1] | `/tmp/my.sock`; `10.1.2.80` | Recommended |
+| `client.address` | string | Client address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [1] | `client.example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
 | `client.port` | int | Client port number. [2] | `65123` | Recommended |
-| `client.socket.address` | string | Client address of the socket connection - IP address or Unix domain socket name. [3] | `/tmp/my.sock`; `127.0.0.1` | Recommended: If different than `client.address`. |
-| `client.socket.port` | int | Client port number of the socket connection. [4] | `35555` | Recommended: If different than `client.port`. |
+| `client.ip` | string | Client IP address. [3] | `127.0.0.1` | Recommended: If different than `client.address`. |
 
 **[1]:** When observed from the server side, and when communicating through an intermediary, `client.address` SHOULD represent the client address behind any intermediaries (e.g. proxies) if it's available.
 
 **[2]:** When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent the client port behind any intermediaries (e.g. proxies) if it's available.
 
-**[3]:** When observed from the server side, this SHOULD represent the immediate client peer address.
-When observed from the client side, this SHOULD represent the physical client address.
-
-**[4]:** When observed from the server side, this SHOULD represent the immediate client peer port.
-When observed from the client side, this SHOULD represent the physical client port.
+**[3]:** When observed from the server side, and when communicating through an intermediary, `client.ip` SHOULD represent the client IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the client side, this SHOULD represent the physical client IP address.
 <!-- endsemconv -->
 
 `client.socket.address` and `client.socket.port` represent physical client name and port.

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -82,7 +82,7 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [4] | `3.1.1` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [5] | `example.com` | Opt-In |
+| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [5] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Opt-In |
 | [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [6] | `80`; `8080`; `443` | Opt-In |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
@@ -177,7 +177,7 @@ This metric is optional.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.request.method` | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
-| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [2] | `example.com` | Opt-In |
+| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [2] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Opt-In |
 | [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [3] | `80`; `8080`; `443` | Opt-In |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
@@ -252,7 +252,7 @@ This metric is optional.
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [4] | `3.1.1` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [5] | `example.com` | Opt-In |
+| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [5] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Opt-In |
 | [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [6] | `80`; `8080`; `443` | Opt-In |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
@@ -354,7 +354,7 @@ This metric is optional.
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [4] | `3.1.1` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [5] | `example.com` | Opt-In |
+| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [5] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Opt-In |
 | [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [6] | `80`; `8080`; `443` | Opt-In |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
@@ -461,9 +461,9 @@ of `[ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `example.com` | Required |
-| [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [5] | `80`; `8080`; `443` | Conditionally Required: [6] |
-| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [7] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
+| [`server.ip`](../general/attributes.md) | string | Server IP address. [5] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [6] | `80`; `8080`; `443` | Conditionally Required: [7] |
 
 **[1]:** If the request fails with an error before response status code was sent or received,
 `error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
@@ -506,12 +506,12 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 
 SHOULD NOT be set if capturing it would require an extra DNS lookup.
 
-**[5]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
+**[5]:** When observed from the client side, and when communicating through an intermediary, `server.ip` SHOULD represent the server IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the server side, this SHOULD represent the physical server IP address.
 
-**[6]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[6]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
-**[7]:** When observed from the client side, this SHOULD represent the immediate server peer address.
-When observed from the server side, this SHOULD represent the physical server address.
+**[7]:** If not default (`80` for `http` scheme, `443` for `https`).
 
 `error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -557,9 +557,9 @@ This metric is optional.
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `example.com` | Required |
-| [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [5] | `80`; `8080`; `443` | Conditionally Required: [6] |
-| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [7] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
+| [`server.ip`](../general/attributes.md) | string | Server IP address. [5] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [6] | `80`; `8080`; `443` | Conditionally Required: [7] |
 
 **[1]:** If the request fails with an error before response status code was sent or received,
 `error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
@@ -602,12 +602,12 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 
 SHOULD NOT be set if capturing it would require an extra DNS lookup.
 
-**[5]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
+**[5]:** When observed from the client side, and when communicating through an intermediary, `server.ip` SHOULD represent the server IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the server side, this SHOULD represent the physical server IP address.
 
-**[6]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[6]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
-**[7]:** When observed from the client side, this SHOULD represent the immediate server peer address.
-When observed from the server side, this SHOULD represent the physical server address.
+**[7]:** If not default (`80` for `http` scheme, `443` for `https`).
 
 `error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -653,9 +653,9 @@ This metric is optional.
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | Recommended |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [3] | `3.1.1` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `example.com` | Required |
-| [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [5] | `80`; `8080`; `443` | Conditionally Required: [6] |
-| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [7] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
+| [`server.ip`](../general/attributes.md) | string | Server IP address. [5] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [6] | `80`; `8080`; `443` | Conditionally Required: [7] |
 
 **[1]:** If the request fails with an error before response status code was sent or received,
 `error.type` SHOULD be set to exception type or a component-specific low cardinality error code.
@@ -698,12 +698,12 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 
 SHOULD NOT be set if capturing it would require an extra DNS lookup.
 
-**[5]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
+**[5]:** When observed from the client side, and when communicating through an intermediary, `server.ip` SHOULD represent the server IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the server side, this SHOULD represent the physical server IP address.
 
-**[6]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[6]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
-**[7]:** When observed from the client side, this SHOULD represent the immediate server peer address.
-When observed from the server side, this SHOULD represent the physical server address.
+**[7]:** If not default (`80` for `http` scheme, `443` for `https`).
 
 `error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -442,34 +442,34 @@ As an example, if a browser request for `https://example.com:8080/webshop/articl
 
 Span name: `GET`
 
-|   Attribute name     |                                       Value             |
-| :------------------- | :-------------------------------------------------------|
-| `http.request.method`| `"GET"`                                                 |
-| `network.protocol.version` | `"1.1"`                                           |
-| `url.full`           | `"https://example.com:8080/webshop/articles/4?s=1"`     |
-| `server.address`     | `example.com`                                           |
-| `server.port`        | 8080                                                    |
-| `server.socket.address` | `"192.0.2.5"`                                        |
+| Attribute name              |                                       Value             |
+|:----------------------------| :-------------------------------------------------------|
+| `http.request.method`       | `"GET"`                                                 |
+| `network.protocol.version`  | `"1.1"`                                           |
+| `url.full`                  | `"https://example.com:8080/webshop/articles/4?s=1"`     |
+| `server.address`            | `example.com`                                           |
+| `server.port`               | 8080                                                    |
+| `server.ip`                 | `"192.0.2.5"`                                        |
 | `http.response.status_code` | `200`                                            |
 
 The corresponding server Span may look like this:
 
 Span name: `GET /webshop/articles/:article_id`.
 
-|   Attribute name     |                      Value                      |
-| :------------------- | :---------------------------------------------- |
-| `http.request.method`| `"GET"`                                         |
-| `network.protocol.version` | `"1.1"`                                   |
-| `url.path`           | `"/webshop/articles/4"`                         |
-| `url.query`          | `"?s=1"`                                        |
-| `server.address`     | `"example.com"`                                 |
-| `server.port`        | `8080`                                          |
-| `url.scheme`         | `"https"`                                       |
-| `http.route`         | `"/webshop/articles/:article_id"`               |
-| `http.response.status_code` | `200`                                    |
-| `client.address`     | `"192.0.2.4"`                                   |
-| `client.socket.address` | `"192.0.2.5"` (the client goes through a proxy) |
-| `user_agent.original` | `"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0"` |
+| Attribute name              | Value                                                                              |
+|:----------------------------|:-----------------------------------------------------------------------------------|
+| `http.request.method`       | `"GET"`                                                                            |
+| `network.protocol.version`  | `"1.1"`                                                                            |
+| `url.path`                  | `"/webshop/articles/4"`                                                            |
+| `url.query`                 | `"?s=1"`                                                                           |
+| `server.address`            | `"example.com"`                                                                    |
+| `server.port`               | `8080`                                                                             |
+| `url.scheme`                | `"https"`                                                                          |
+| `http.route`                | `"/webshop/articles/:article_id"`                                                  |
+| `http.response.status_code` | `200`                                                                              |
+| `client.address`            | `"192.0.2.4"`                                                                      |
+| `proxy.address`             | `"192.0.2.5"` (the request goes through a proxy)                                   |
+| `user_agent.original`       | `"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0"` |
 
 ### HTTP client retries examples
 

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -240,12 +240,13 @@ For an HTTP client span, `SpanKind` MUST be `Client`.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.resend_count` | int | The ordinal number of request resending attempt (for any reason, including redirects). [1] | `3` | Recommended: if and only if request was retried. |
-| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `example.com` | Required |
-| [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
-| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [5] | `10.5.3.2` | Recommended: If different than `server.address`. |
-| [`server.socket.domain`](../general/attributes.md) | string | Immediate server peer's domain name if available without reverse DNS lookup [6] | `proxy.example.com` | Recommended: If different than `server.address`. |
-| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [7] | `16456` | Recommended: If different than `server.port`. |
-| [`url.full`](../url/url.md) | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [8] | `https://www.foo.bar/search?q=OpenTelemetry#SemConv`; `//localhost` | Required |
+| `proxy.address` | string | Proxy address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. | `proxy.example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
+| `proxy.ip` | string | Proxy IP address. | `10.1.2.80` | Recommended: If different than `proxy.address`. |
+| `proxy.port` | int | Proxy port number. | `65123` | Recommended |
+| [`server.address`](../general/attributes.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
+| [`server.ip`](../general/attributes.md) | string | Server IP address. [3] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.port`](../general/attributes.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
+| [`url.full`](../url/url.md) | string | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) [6] | `https://www.foo.bar/search?q=OpenTelemetry#SemConv`; `//localhost` | Required |
 
 **[1]:** The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues, or any other).
 
@@ -258,19 +259,14 @@ For an HTTP client span, `SpanKind` MUST be `Client`.
 If an HTTP client request is explicitly made to an IP address, e.g. `http://x.x.x.x:8080`, then
 `server.address` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
 
-**[3]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
+**[3]:** When observed from the client side, and when communicating through an intermediary, `server.ip` SHOULD represent the server IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the server side, this SHOULD represent the physical server IP address.
 
-**[4]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[4]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
 
-**[5]:** When observed from the client side, this SHOULD represent the immediate server peer address.
-When observed from the server side, this SHOULD represent the physical server address.
+**[5]:** If not default (`80` for `http` scheme, `443` for `https`).
 
-**[6]:** Typically observed from the client side, and represents a proxy or other intermediary domain name.
-
-**[7]:** When observed from the client side, this SHOULD represent the immediate server peer port.
-When observed from the server side, this SHOULD represent the physical server port.
-
-**[8]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
+**[6]:** For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
 `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password should be redacted and attribute's value should be `https://REDACTED:REDACTED@www.example.com/`.
 `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
 
@@ -377,15 +373,16 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
 | [`client.address`](../general/attributes.md) | string | Client address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [2] | `83.164.160.102` | Recommended |
-| [`client.port`](../general/attributes.md) | int | The port of the original client behind all proxies, if known (e.g. from [Forwarded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded) or a similar header). Otherwise, the immediate client peer port. [3] | `65123` | Recommended |
-| [`client.socket.address`](../general/attributes.md) | string | Client address of the socket connection - IP address or Unix domain socket name. [4] | `/tmp/my.sock`; `127.0.0.1` | Recommended: If different than `client.address`. |
-| [`client.socket.port`](../general/attributes.md) | int | Client port number of the socket connection. [5] | `35555` | Recommended: If different than `client.port`. |
-| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [6] | `example.com` | Recommended |
+| [`client.ip`](../general/attributes.md) | string | Client IP address. [3] | `127.0.0.1` | Recommended: If different than `client.address`. |
+| [`client.port`](../general/attributes.md) | int | The port of the original client behind all proxies, if known (e.g. from [Forwarded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded) or a similar header). Otherwise, the immediate client peer port. [4] | `65123` | Recommended |
+| `proxy.address` | string | Proxy address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. | `proxy.example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
+| `proxy.ip` | string | Proxy IP address. | `10.1.2.80` | Recommended: If different than `proxy.address`. |
+| `proxy.port` | int | Proxy port number. | `65123` | Recommended |
+| [`server.address`](../general/attributes.md) | string | Name of the local HTTP server that received the request. [5] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
+| [`server.ip`](../general/attributes.md) | string | Local socket IP address. Useful in case of a multi-IP host. [6] | `10.5.3.2` | Opt-In |
 | [`server.port`](../general/attributes.md) | int | Port of the local HTTP server that received the request. [7] | `80`; `8080`; `443` | Recommended: [8] |
-| [`server.socket.address`](../general/attributes.md) | string | Local socket address. Useful in case of a multi-IP host. [9] | `10.5.3.2` | Opt-In |
-| [`server.socket.port`](../general/attributes.md) | int | Local socket port. Useful in case of a multi-port host. [10] | `16456` | Opt-In |
-| [`url.path`](../url/url.md) | string | The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component [11] | `/search` | Required |
-| [`url.query`](../url/url.md) | string | The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component [12] | `q=OpenTelemetry` | Conditionally Required: If and only if one was received/sent. |
+| [`url.path`](../url/url.md) | string | The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component [9] | `/search` | Required |
+| [`url.query`](../url/url.md) | string | The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component [10] | `q=OpenTelemetry` | Conditionally Required: If and only if one was received/sent. |
 | [`url.scheme`](../url/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Required |
 
 **[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
@@ -393,15 +390,12 @@ SHOULD include the [application root](/docs/http/http-spans.md#http-server-defin
 
 **[2]:** The IP address of the original client behind all proxies, if known (e.g. from [Forwarded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded), [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For), or a similar header). Otherwise, the immediate client peer address.
 
-**[3]:** When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent the client port behind any intermediaries (e.g. proxies) if it's available.
+**[3]:** When observed from the server side, and when communicating through an intermediary, `client.ip` SHOULD represent the client IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the client side, this SHOULD represent the physical client IP address.
 
-**[4]:** When observed from the server side, this SHOULD represent the immediate client peer address.
-When observed from the client side, this SHOULD represent the physical client address.
+**[4]:** When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent the client port behind any intermediaries (e.g. proxies) if it's available.
 
-**[5]:** When observed from the server side, this SHOULD represent the immediate client peer port.
-When observed from the client side, this SHOULD represent the physical client port.
-
-**[6]:** Determined by using the first of the following that applies
+**[5]:** Determined by using the first of the following that applies
 
 - The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
   include host identifier.
@@ -410,6 +404,9 @@ When observed from the client side, this SHOULD represent the physical client po
 - Host identifier of the `Host` header
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
+
+**[6]:** When observed from the client side, and when communicating through an intermediary, `server.ip` SHOULD represent the server IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the server side, this SHOULD represent the physical server IP address.
 
 **[7]:** Determined by using the first of the following that applies
 
@@ -420,15 +417,9 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 
 **[8]:** If not default (`80` for `http` scheme, `443` for `https`).
 
-**[9]:** When observed from the client side, this SHOULD represent the immediate server peer address.
-When observed from the server side, this SHOULD represent the physical server address.
+**[9]:** When missing, the value is assumed to be `/`
 
-**[10]:** When observed from the client side, this SHOULD represent the immediate server peer port.
-When observed from the server side, this SHOULD represent the physical server port.
-
-**[11]:** When missing, the value is assumed to be `/`
-
-**[12]:** Sensitive content provided in query string SHOULD be scrubbed when instrumentations can identify it.
+**[10]:** Sensitive content provided in query string SHOULD be scrubbed when instrumentations can identify it.
 
 Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
 

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -233,10 +233,11 @@ The following operations related to messages are defined for these semantic conv
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the application layer protocol used. See note below. [14] | `3.1.1` | Recommended |
 | [`network.transport`](../general/attributes.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Recommended |
 | [`network.type`](../general/attributes.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [15] | `example.com` | Conditionally Required: If available. |
-| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [16] | `10.5.3.2` | Recommended: If different than `server.address`. |
-| [`server.socket.domain`](../general/attributes.md) | string | Immediate server peer's domain name if available without reverse DNS lookup [17] | `proxy.example.com` | Recommended: [18] |
-| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [19] | `16456` | Recommended: If different than `server.port`. |
+| `proxy.address` | string | Proxy address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. | `proxy.example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
+| `proxy.ip` | string | Proxy IP address. | `10.1.2.80` | Recommended: If different than `proxy.address`. |
+| `proxy.port` | int | Proxy port number. | `65123` | Recommended |
+| [`server.address`](../general/attributes.md) | string | Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [15] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Conditionally Required: If available. |
+| [`server.ip`](../general/attributes.md) | string | Server IP address. [16] | `10.5.3.2` | Recommended: If different than `server.address`. |
 
 **[1]:** If a custom value is used, it MUST be of low cardinality.
 
@@ -269,15 +270,8 @@ the broker does not have such notion, the destination name SHOULD uniquely ident
 
 **[15]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
 
-**[16]:** When observed from the client side, this SHOULD represent the immediate server peer address.
-When observed from the server side, this SHOULD represent the physical server address.
-
-**[17]:** Typically observed from the client side, and represents a proxy or other intermediary domain name.
-
-**[18]:** If different than `server.address` and if `server.socket.address` is set.
-
-**[19]:** When observed from the client side, this SHOULD represent the immediate server peer port.
-When observed from the server side, this SHOULD represent the physical server port.
+**[16]:** When observed from the client side, and when communicating through an intermediary, `server.ip` SHOULD represent the server IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the server side, this SHOULD represent the physical server IP address.
 
 `messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/rpc/rpc-metrics.md
+++ b/docs/rpc/rpc-metrics.md
@@ -225,10 +225,12 @@ measurements.
 | [`rpc.method`](rpc-spans.md) | string | The name of the (logical) method being called, must be equal to the $method part in the span name. [2] | `exampleMethod` | Recommended |
 | [`network.transport`](../general/attributes.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Recommended |
 | [`network.type`](../general/attributes.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
-| [`server.address`](../general/attributes.md) | string | RPC server [host name](https://grpc.github.io/grpc/core/md_doc_naming.html). [3] | `example.com` | Required |
-| [`server.port`](../general/attributes.md) | int | Server port number [4] | `80`; `8080`; `443` | Conditionally Required: See below |
-| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [5] | `10.5.3.2` | See below |
-| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [6] | `16456` | Recommended: [7] |
+| `proxy.address` | string | Proxy address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. | `proxy.example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
+| `proxy.ip` | string | Proxy IP address. | `10.1.2.80` | Recommended: If different than `proxy.address`. |
+| `proxy.port` | int | Proxy port number. | `65123` | Recommended |
+| [`server.address`](../general/attributes.md) | string | RPC server [host name](https://grpc.github.io/grpc/core/md_doc_naming.html). [3] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
+| [`server.ip`](../general/attributes.md) | string | Server IP address. [4] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.port`](../general/attributes.md) | int | Server port number [5] | `80`; `8080`; `443` | Conditionally Required: See below |
 
 **[1]:** This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
 
@@ -236,20 +238,10 @@ measurements.
 
 **[3]:** May contain server IP address, DNS name, or local socket name. When host component is an IP address, instrumentations SHOULD NOT do a reverse proxy lookup to obtain DNS name and SHOULD set `server.address` to the IP address provided in the host component.
 
-**[4]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
+**[4]:** When observed from the client side, and when communicating through an intermediary, `server.ip` SHOULD represent the server IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the server side, this SHOULD represent the physical server IP address.
 
-**[5]:** When observed from the client side, this SHOULD represent the immediate server peer address.
-When observed from the server side, this SHOULD represent the physical server address.
-
-**[6]:** When observed from the client side, this SHOULD represent the immediate server peer port.
-When observed from the server side, this SHOULD represent the physical server port.
-
-**[7]:** If different than `server.port` and if `server.socket.address` is set.
-
-**Additional attribute requirements:** At least one of the following sets of attributes is required:
-
-* [`server.socket.address`](../general/attributes.md)
-* [`server.address`](../general/attributes.md)
+**[5]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
 
 `rpc.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/rpc/rpc-metrics.md
+++ b/docs/rpc/rpc-metrics.md
@@ -254,13 +254,6 @@ When observed from the server side, this SHOULD represent the physical server IP
 | `connect_rpc` | Connect RPC |
 <!-- endsemconv -->
 
-To avoid high cardinality, implementations should prefer the most stable of `server.address` or
-`server.socket.address`, depending on expected deployment profile.  For many cloud applications, this is likely
-`server.address` as names can be recycled even across re-instantiation of a server with a different `ip`.
-
-For client-side metrics `server.port` is required if the connection is IP-based and the port is available (it describes the server port they are connecting to).
-For server-side spans `server.port` is optional (it describes the port the client is connecting from).
-
 ### Service name
 
 On the server process receiving and handling the remote procedure call, the service name provided in `rpc.service` does not necessarily have to match the [`service.name`][] resource attribute.

--- a/docs/rpc/rpc-spans.md
+++ b/docs/rpc/rpc-spans.md
@@ -90,10 +90,12 @@ Examples of span names:
 | `rpc.method` | string | The name of the (logical) method being called, must be equal to the $method part in the span name. [2] | `exampleMethod` | Recommended |
 | [`network.transport`](../general/attributes.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Recommended |
 | [`network.type`](../general/attributes.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
-| [`server.address`](../general/attributes.md) | string | RPC server [host name](https://grpc.github.io/grpc/core/md_doc_naming.html). [3] | `example.com` | Required |
-| [`server.port`](../general/attributes.md) | int | Server port number [4] | `80`; `8080`; `443` | Conditionally Required: See below |
-| [`server.socket.address`](../general/attributes.md) | string | Server address of the socket connection - IP address or Unix domain socket name. [5] | `10.5.3.2` | See below |
-| [`server.socket.port`](../general/attributes.md) | int | Server port number of the socket connection. [6] | `16456` | Recommended: [7] |
+| `proxy.address` | string | Proxy address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. | `proxy.example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
+| `proxy.ip` | string | Proxy IP address. | `10.1.2.80` | Recommended: If different than `proxy.address`. |
+| `proxy.port` | int | Proxy port number. | `65123` | Recommended |
+| [`server.address`](../general/attributes.md) | string | RPC server [host name](https://grpc.github.io/grpc/core/md_doc_naming.html). [3] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
+| [`server.ip`](../general/attributes.md) | string | Server IP address. [4] | `10.5.3.2` | Recommended: If different than `server.address`. |
+| [`server.port`](../general/attributes.md) | int | Server port number [5] | `80`; `8080`; `443` | Conditionally Required: See below |
 
 **[1]:** This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
 
@@ -101,20 +103,10 @@ Examples of span names:
 
 **[3]:** May contain server IP address, DNS name, or local socket name. When host component is an IP address, instrumentations SHOULD NOT do a reverse proxy lookup to obtain DNS name and SHOULD set `server.address` to the IP address provided in the host component.
 
-**[4]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
+**[4]:** When observed from the client side, and when communicating through an intermediary, `server.ip` SHOULD represent the server IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the server side, this SHOULD represent the physical server IP address.
 
-**[5]:** When observed from the client side, this SHOULD represent the immediate server peer address.
-When observed from the server side, this SHOULD represent the physical server address.
-
-**[6]:** When observed from the client side, this SHOULD represent the immediate server peer port.
-When observed from the server side, this SHOULD represent the physical server port.
-
-**[7]:** If different than `server.port` and if `server.socket.address` is set.
-
-**Additional attribute requirements:** At least one of the following sets of attributes is required:
-
-* [`server.socket.address`](../general/attributes.md)
-* [`server.address`](../general/attributes.md)
+**[5]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries (e.g. proxies) if it's available.
 
 `rpc.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -147,13 +139,6 @@ Generally, a user SHOULD NOT set `peer.service` to a fully qualified RPC service
 ### Client attributes
 
 <!-- semconv rpc.client -->
-| Attribute  | Type | Description  | Examples  | Requirement Level |
-|---|---|---|---|---|
-| [`server.socket.domain`](../general/attributes.md) | string | Immediate server peer's domain name if available without reverse DNS lookup [1] | `proxy.example.com` | Recommended: [2] |
-
-**[1]:** Typically observed from the client side, and represents a proxy or other intermediary domain name.
-
-**[2]:** If different than `server.address` and if `server.socket.address` is set.
 <!-- endsemconv -->
 
 ### Server attributes
@@ -161,22 +146,18 @@ Generally, a user SHOULD NOT set `peer.service` to a fully qualified RPC service
 <!-- semconv rpc.server -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`client.address`](../general/attributes.md) | string | Client address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [1] | `/tmp/my.sock`; `10.1.2.80` | Recommended |
-| [`client.port`](../general/attributes.md) | int | Client port number. [2] | `65123` | Recommended |
-| [`client.socket.address`](../general/attributes.md) | string | Client address of the socket connection - IP address or Unix domain socket name. [3] | `/tmp/my.sock`; `127.0.0.1` | Recommended: If different than `client.address`. |
-| [`client.socket.port`](../general/attributes.md) | int | Client port number of the socket connection. [4] | `35555` | Recommended: If different than `client.port`. |
+| [`client.address`](../general/attributes.md) | string | Client address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name. [1] | `client.example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
+| [`client.ip`](../general/attributes.md) | string | Client IP address. [2] | `127.0.0.1` | Recommended: If different than `client.address`. |
+| [`client.port`](../general/attributes.md) | int | Client port number. [3] | `65123` | Recommended |
 | [`network.transport`](../general/attributes.md) | string | [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase. | `tcp`; `udp` | Recommended |
 | [`network.type`](../general/attributes.md) | string | [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase. | `ipv4`; `ipv6` | Recommended |
 
 **[1]:** When observed from the server side, and when communicating through an intermediary, `client.address` SHOULD represent the client address behind any intermediaries (e.g. proxies) if it's available.
 
-**[2]:** When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent the client port behind any intermediaries (e.g. proxies) if it's available.
+**[2]:** When observed from the server side, and when communicating through an intermediary, `client.ip` SHOULD represent the client IP address behind any intermediaries (e.g. proxies) if it's available.
+When observed from the client side, this SHOULD represent the physical client IP address.
 
-**[3]:** When observed from the server side, this SHOULD represent the immediate client peer address.
-When observed from the client side, this SHOULD represent the physical client address.
-
-**[4]:** When observed from the server side, this SHOULD represent the immediate client peer port.
-When observed from the client side, this SHOULD represent the physical client port.
+**[3]:** When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent the client port behind any intermediaries (e.g. proxies) if it's available.
 <!-- endsemconv -->
 
 ### Events

--- a/model/client.yaml
+++ b/model/client.yaml
@@ -16,7 +16,7 @@ groups:
         note: >
           When observed from the server side, and when communicating through an intermediary, `client.address` SHOULD represent
           the client address behind any intermediaries (e.g. proxies) if it's available.
-        examples: ['/tmp/my.sock', '10.1.2.80']
+        examples: ['client.example.com', '10.1.2.80', '/tmp/my.sock']
       - id: port
         type: int
         brief: Client port number.
@@ -24,23 +24,14 @@ groups:
         note: >
           When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent
           the client port behind any intermediaries (e.g. proxies) if it's available.
-      - id: socket.address
+      - id: ip
         type: string
-        brief: Client address of the socket connection - IP address or Unix domain socket name.
+        brief: Client IP address.
         note: >
-          When observed from the server side, this SHOULD represent the immediate client peer address.
+          When observed from the server side, and when communicating through an intermediary, `client.ip` SHOULD represent
+          the client IP address behind any intermediaries (e.g. proxies) if it's available.
 
-          When observed from the client side, this SHOULD represent the physical client address.
-        examples: ['/tmp/my.sock', '127.0.0.1']
+          When observed from the client side, this SHOULD represent the physical client IP address.
+        examples: ['127.0.0.1']
         requirement_level:
           recommended: If different than `client.address`.
-      - id: socket.port
-        type: int
-        brief: Client port number of the socket connection.
-        note: >
-          When observed from the server side, this SHOULD represent the immediate client peer port.
-
-          When observed from the client side, this SHOULD represent the physical client port.
-        examples: [35555]
-        requirement_level:
-          recommended: If different than `client.port`.

--- a/model/deprecated/network.yaml
+++ b/model/deprecated/network.yaml
@@ -8,19 +8,20 @@ groups:
       - id: sock.peer.name
         type: string
         stability: deprecated
-        brief: Deprecated, use `server.socket.domain` on client spans.
+        brief: Deprecated, since this was intended to be used for proxies on client spans, use `proxy.address`.
         examples: ['/var/my.sock']
       - id: sock.peer.addr
         type: string
         stability: deprecated
         brief: >
-          Deprecated, use `server.socket.address` on client spans and `client.socket.address` on server spans.
+          Deprecated, if this doesn't represent a proxy address, use `server.ip` on client spans and `client.ip` on server spans.
+          If this represents a proxy address, use `proxy.address`.
         examples: ['192.168.0.1']
       - id: sock.peer.port
         type: int
         stability: deprecated
         examples: [65531]
-        brief: Deprecated, use `server.socket.port` on client spans and `client.socket.port` on server spans.
+        brief: Deprecated, since this was intended to be used for proxies, use `proxy.port`.
       - id: peer.name
         type: string
         stability: deprecated
@@ -44,12 +45,12 @@ groups:
       - id: sock.host.addr
         type: string
         stability: deprecated
-        brief: Deprecated, use `server.socket.address`.
+        brief: Deprecated, use `server.ip`.
         examples: ['/var/my.sock']
       - id: sock.host.port
         type: int
         stability: deprecated
-        brief: Deprecated, use `server.socket.port`.
+        brief: Deprecated, use `server.port`.
         examples: [8080]
       - id: transport
         type:

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -66,7 +66,7 @@ groups:
       - ref: http.response.status_code
       - ref: network.protocol.name
       - ref: network.protocol.version
-      - ref: server.socket.address
+      - ref: server.ip
       - ref: error.type
         requirement_level:
           conditionally_required: If request has ended with an error.

--- a/model/metrics/rpc-metrics.yaml
+++ b/model/metrics/rpc-metrics.yaml
@@ -13,8 +13,7 @@ groups:
       - ref: network.type
       - ref: server.address
       - ref: server.port
-      - ref: server.socket.address
-      - ref: server.socket.port
+      - ref: server.ip
 
   # RPC Server metrics
   - id: metric.rpc.server.duration

--- a/model/metrics/system-metrics.yaml
+++ b/model/metrics/system-metrics.yaml
@@ -452,7 +452,7 @@ groups:
       - ref: system.network.state
       - ref: network.transport
 
-    # system.processes.* metrics and attribute group
+  # system.processes.* metrics and attribute group
   - id: attributes.system.processes
     prefix: system.processes
     type: attribute_group

--- a/model/proxy.yaml
+++ b/model/proxy.yaml
@@ -2,7 +2,7 @@ groups:
   - id: proxy
     prefix: proxy
     type: attribute_group
-    brief: These attributes may be used to describe a proxy (or other intermediary) in a connection-based network interaction.
+    brief: These attributes may be used to describe a known proxy (or other intermediary) in a connection-based network interaction.
     attributes:
       - id: address
         type: string

--- a/model/proxy.yaml
+++ b/model/proxy.yaml
@@ -1,0 +1,20 @@
+groups:
+  - id: proxy
+    prefix: proxy
+    type: attribute_group
+    brief: These attributes may be used to describe a proxy (or other intermediary) in a connection-based network interaction.
+    attributes:
+      - id: address
+        type: string
+        brief: Proxy address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name.
+        examples: ['proxy.example.com', '10.1.2.80', '/tmp/my.sock']
+      - id: port
+        type: int
+        brief: Proxy port number.
+        examples: [65123]
+      - id: ip
+        type: string
+        brief: Proxy IP address.
+        examples: ['10.1.2.80']
+        requirement_level:
+          recommended: If different than `proxy.address`.

--- a/model/server.yaml
+++ b/model/server.yaml
@@ -16,7 +16,7 @@ groups:
         note: |
           When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent
           the server address behind any intermediaries (e.g. proxies) if it's available.
-        examples: ['example.com']
+        examples: ['example.com', '10.1.2.80', '/tmp/my.sock']
       - id: port
         type: int
         brief: Server port number
@@ -24,30 +24,14 @@ groups:
           When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent
           the server port behind any intermediaries (e.g. proxies) if it's available.
         examples: [80, 8080, 443]
-      - id: socket.domain
+      - id: ip
         type: string
-        brief: Immediate server peer's domain name if available without reverse DNS lookup
-        examples: ['proxy.example.com']
-        note: Typically observed from the client side, and represents a proxy or other intermediary domain name.
-        requirement_level:
-          recommended: If different than `server.address`.
-      - id: socket.address
-        type: string
-        brief: Server address of the socket connection - IP address or Unix domain socket name.
+        brief: Server IP address.
         note: >
-          When observed from the client side, this SHOULD represent the immediate server peer address.
+          When observed from the client side, and when communicating through an intermediary, `server.ip` SHOULD represent
+          the server IP address behind any intermediaries (e.g. proxies) if it's available.
 
-          When observed from the server side, this SHOULD represent the physical server address.
+          When observed from the server side, this SHOULD represent the physical server IP address.
         examples: ['10.5.3.2']
         requirement_level:
           recommended: If different than `server.address`.
-      - id: socket.port
-        type: int
-        brief: Server port number of the socket connection.
-        note: >
-          When observed from the client side, this SHOULD represent the immediate server peer port.
-
-          When observed from the server side, this SHOULD represent the physical server port.
-        examples: [16456]
-        requirement_level:
-          recommended: If different than `server.port`.

--- a/model/trace/database.yaml
+++ b/model/trace/database.yaml
@@ -238,21 +238,18 @@ groups:
         tag: connection-level
         requirement_level:
           conditionally_required: If using a port other than the default port for this DBMS and if `server.address` is set.
-      - ref: server.socket.address
-        tag: connection-level
-      - ref: server.socket.port
+      - ref: server.ip
         tag: connection-level
       - ref: network.transport
         tag: connection-level
       - ref: network.type
         tag: connection-level
-      - ref: server.socket.domain
-        requirement_level:
-          recommended: If different than `server.address` and if `server.socket.address` is set.
-    constraints:
-      - any_of:
-          - 'server.address'
-          - 'server.socket.address'
+      - ref: proxy.address
+        tag: connection-level
+      - ref: proxy.port
+        tag: connection-level
+      - ref: proxy.ip
+        tag: connection-level
 
   - id: db.mssql
     prefix: db.mssql

--- a/model/trace/http.yaml
+++ b/model/trace/http.yaml
@@ -77,9 +77,10 @@ groups:
         note: >
           When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `server.port` MUST match
           URI port identifier, otherwise it MUST match `Host` header port identifier.
-      - ref: server.socket.domain
-      - ref: server.socket.address
-      - ref: server.socket.port
+      - ref: server.ip
+      - ref: proxy.address
+      - ref: proxy.port
+      - ref: proxy.ip
       - ref: url.full
         sampling_relevant: true
         requirement_level: required
@@ -120,12 +121,9 @@ groups:
           - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
           - Port identifier of the `Host` header
-      - ref: server.socket.address
+      - ref: server.ip
         requirement_level: opt_in
-        brief: Local socket address. Useful in case of a multi-IP host.
-      - ref: server.socket.port
-        requirement_level: opt_in
-        brief: Local socket port. Useful in case of a multi-port host.
+        brief: Local socket IP address. Useful in case of a multi-IP host.
       - ref: client.address
         note: >
             The IP address of the original client behind all proxies, if
@@ -138,8 +136,10 @@ groups:
             The port of the original client behind all proxies, if
             known (e.g. from [Forwarded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded) or a similar header).
             Otherwise, the immediate client peer port.
-      - ref: client.socket.address
-      - ref: client.socket.port
+      - ref: client.ip
+      - ref: proxy.address
+      - ref: proxy.port
+      - ref: proxy.ip
       - ref: url.path
         requirement_level: required
         sampling_relevant: true

--- a/model/trace/messaging.yaml
+++ b/model/trace/messaging.yaml
@@ -167,18 +167,18 @@ groups:
           This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
         requirement_level:
           conditionally_required: If available.
-      - ref: server.socket.address
-        tag: connection-level
-      - ref: server.socket.port
+      - ref: server.ip
         tag: connection-level
       - ref: network.transport
         tag: connection-level
       - ref: network.type
         tag: connection-level
-      - ref: server.socket.domain
+      - ref: proxy.address
         tag: connection-level
-        requirement_level:
-          recommended: If different than `server.address` and if `server.socket.address` is set.
+      - ref: proxy.port
+        tag: connection-level
+      - ref: proxy.ip
+        tag: connection-level
       - ref: network.protocol.name
         examples: ['amqp', 'mqtt']
       - ref: network.protocol.version

--- a/model/trace/rpc.yaml
+++ b/model/trace/rpc.yaml
@@ -49,10 +49,6 @@ groups:
           (e.g., method actually executing the call on the server side,
           RPC client stub method on the client side).
         examples: "exampleMethod"
-      - ref: server.socket.address
-      - ref: server.socket.port
-        requirement_level:
-          recommended: If different than `server.port` and if `server.socket.address` is set.
       - ref: network.transport
       - ref: network.type
       - ref: server.address
@@ -66,19 +62,15 @@ groups:
       - ref: server.port
         requirement_level:
           conditionally_required: See below
-    constraints:
-      - any_of:
-          - server.socket.address
-          - server.address
+      - ref: server.ip
+      - ref: proxy.address
+      - ref: proxy.port
+      - ref: proxy.ip
 
   - id: rpc.client
     type: span
     brief: 'This document defines semantic conventions for remote procedure call client spans.'
     extends: rpc
-    attributes:
-      - ref: server.socket.domain
-        requirement_level:
-          recommended: If different than `server.address` and if `server.socket.address` is set.
 
   - id: rpc.server
     prefix: rpc
@@ -89,8 +81,7 @@ groups:
     attributes:
       - ref: client.address
       - ref: client.port
-      - ref: client.socket.address
-      - ref: client.socket.port
+      - ref: client.ip
       - ref: network.transport
       - ref: network.type
 


### PR DESCRIPTION
Fixes #320

## Changes

Aligns networking conventions with ECS' `server.ip` and `client.ip`.

Removes confusion about `client.socket.*` and `server.socket.*` namespaces.

Introduces dedicated `proxy.*` namespace to make modeling proxies (and other intermediaries) much clearer.

NOTE: still need to update [`attributes.md`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attributes.md#server-and-client-attributes), using the images below as explanation.