### PR TITLE
Fix System metrics yaml warning

### DIFF
--- a/model/metrics/system-metrics.yaml
+++ b/model/metrics/system-metrics.yaml
@@ -452,7 +452,7 @@ groups:
       - ref: system.network.state
       - ref: network.transport
 
-    # system.processes.* metrics and attribute group
+  # system.processes.* metrics and attribute group
   - id: attributes.system.processes
     prefix: system.processes
     type: attribute_group


### PR DESCRIPTION
I noticed a warning in PRs related to the recently merged #89  yaml model for system metrics. I left a misaligned comment and GitHub UI complains about it:

![image](https://github.com/open-telemetry/semantic-conventions/assets/5938087/56c86289-c832-469a-b66e-108bae58c518)

