### PR TITLE
Rename `cloud.platform` to `cloud.service.name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ release.
 ## Unreleased
 
 - Adds `session.id` and session.md to general docs and model
-([#215](https://github.com/open-telemetry/semantic-conventions/pull/215))
+  ([#215](https://github.com/open-telemetry/semantic-conventions/pull/215))
 - Add `cluster.name` and `node.name` attributes to Elasticsearch semantic conventions.
   ([#285](https://github.com/open-telemetry/semantic-conventions/pull/285))
 - Fix the unit of metric.process.runtime.jvm.system.cpu.load_1m to be {run_queue_item}
@@ -116,6 +116,7 @@ release.
   ([#328](https://github.com/open-telemetry/semantic-conventions/pull/328))
 - Added `os.build_id` resource attribute.
   ([#293](https://github.com/open-telemetry/semantic-conventions/pull/293))
+- BREAKING: Rename `cloud.platform` to `cloud.service.name`. 
 
 ## v1.21.0 (2023-07-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,8 @@ release.
   ([#328](https://github.com/open-telemetry/semantic-conventions/pull/328))
 - Added `os.build_id` resource attribute.
   ([#293](https://github.com/open-telemetry/semantic-conventions/pull/293))
-- BREAKING: Rename `cloud.platform` to `cloud.service.name`. 
+- BREAKING: Rename `cloud.platform` to `cloud.service.name`.
+  ([#344](https://github.com/open-telemetry/semantic-conventions/pull/344))
 
 ## v1.21.0 (2023-07-13)
 

--- a/docs/resource/cloud.md
+++ b/docs/resource/cloud.md
@@ -11,10 +11,11 @@
 |---|---|---|---|---|
 | `cloud.provider` | string | Name of the cloud provider. | `alibaba_cloud` | Recommended |
 | `cloud.account.id` | string | The cloud account ID the resource is assigned to. | `111111111111`; `opentelemetry` | Recommended |
+| `cloud.account.name` | string | The cloud account name or alias the resource is assigned to. | `dev-env`; `prod-env` | Recommended |
 | `cloud.region` | string | The geographical region the resource is running. [1] | `us-central1`; `us-east-1` | Recommended |
 | `cloud.resource_id` | string | Cloud provider-specific native identifier of the monitored cloud resource (e.g. an [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) on AWS, a [fully qualified resource ID](https://learn.microsoft.com/en-us/rest/api/resources/resources/get-by-id) on Azure, a [full resource name](https://cloud.google.com/apis/design/resource_names#full_resource_name) on GCP) [2] | `arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function`; `//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID`; `/subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>` | Recommended |
 | `cloud.availability_zone` | string | Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running. [3] | `us-east-1c` | Recommended |
-| `cloud.service.name` | string | The cloud platform in use. [4] | `alibaba_cloud_ecs` | Recommended |
+| `cloud.service.name` | string | The cloud service name in use. [4] | `alibaba_cloud_ecs` | Recommended |
 
 **[1]:** Refer to your provider's docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), [Google Cloud regions](https://cloud.google.com/about/locations), or [Tencent Cloud regions](https://www.tencentcloud.com/document/product/213/6091).
 

--- a/docs/resource/cloud.md
+++ b/docs/resource/cloud.md
@@ -14,7 +14,7 @@
 | `cloud.region` | string | The geographical region the resource is running. [1] | `us-central1`; `us-east-1` | Recommended |
 | `cloud.resource_id` | string | Cloud provider-specific native identifier of the monitored cloud resource (e.g. an [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) on AWS, a [fully qualified resource ID](https://learn.microsoft.com/en-us/rest/api/resources/resources/get-by-id) on Azure, a [full resource name](https://cloud.google.com/apis/design/resource_names#full_resource_name) on GCP) [2] | `arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function`; `//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID`; `/subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>` | Recommended |
 | `cloud.availability_zone` | string | Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running. [3] | `us-east-1c` | Recommended |
-| `cloud.platform` | string | The cloud platform in use. [4] | `alibaba_cloud_ecs` | Recommended |
+| `cloud.service.name` | string | The cloud platform in use. [4] | `alibaba_cloud_ecs` | Recommended |
 
 **[1]:** Refer to your provider's docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), [Google Cloud regions](https://cloud.google.com/about/locations), or [Tencent Cloud regions](https://www.tencentcloud.com/document/product/213/6091).
 
@@ -52,7 +52,7 @@ The following well-known definitions MUST be used if you set this attribute and 
 | `ibm_cloud` | IBM Cloud |
 | `tencent_cloud` | Tencent Cloud |
 
-`cloud.platform` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`cloud.service.name` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|

--- a/model/resource/cloud.yaml
+++ b/model/resource/cloud.yaml
@@ -38,6 +38,11 @@ groups:
         brief: >
           The cloud account ID the resource is assigned to.
         examples: ['111111111111', 'opentelemetry']
+      - id: account.name
+        type: string
+        brief: >
+          The cloud account name or alias the resource is assigned to.
+        examples: [ 'dev-env', 'prod-env' ]
       - id: region
         type: string
         brief: >
@@ -174,6 +179,6 @@ groups:
               value: 'tencent_cloud_scf'
               brief: Tencent Cloud Serverless Cloud Function (SCF)
         brief: >
-          The cloud platform in use.
+          The cloud service name in use.
         note: >
           The prefix of the service SHOULD match the one specified in `cloud.provider`.

--- a/model/resource/cloud.yaml
+++ b/model/resource/cloud.yaml
@@ -88,7 +88,7 @@ groups:
         note: >
           Availability zones are called "zones" on Alibaba Cloud and Google Cloud.
         examples: ['us-east-1c']
-      - id: platform
+      - id: service.name
         type:
           allow_custom_values: true
           members:


### PR DESCRIPTION
## Changes

This PR is to rename `cloud.platform` field name to `cloud.service.name` which is from ECS: https://www.elastic.co/guide/en/ecs/current/ecs-cloud.html#field-cloud-service-name. These two fields represent the same thing but `cloud.service.name` is more readable IMHO.

cc @AlexanderWert @ChrsMark 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
