### PR TITLE
feat: Add MySQL instance address attribute

### DIFF
--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -23,6 +23,7 @@
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
 | `db.connection_string` | string | The connection string used to connect to the database. It is recommended to remove embedded credentials. | `Server=(localdb)\v11.0;Integrated Security=true;` |
+| `db.instance.id` | string | An identifier (address, unique name, or any other identifier) of the database instance that is executing queries or mutations on the current connection. This is useful in cases where the database is running in a clustered environment and the instrumentation is able to record the node executing the query. The client may obtain this value in databases like MySQL using queries like `select @@hostname`. | `mysql-e26b99z.example.com` |
 | `db.name` | string | This attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`; `main` |
 | `db.operation` | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`, or the SQL keyword. [2] | `findAndModify`; `HMSET`; `SELECT` |
 | `db.statement` | string | The database statement being executed. | `SELECT * FROM wuser_table`; `SET mykey "WuValue"` |

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -65,6 +65,7 @@ Some database systems may allow a connection to switch to a different `db.user`,
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.connection_string`](../attributes-registry/db.md) | string | The connection string used to connect to the database. It is recommended to remove embedded credentials. | `Server=(localdb)\v11.0;Integrated Security=true;` | Recommended |
+| [`db.instance.id`](../attributes-registry/db.md) | string | An identifier (address, unique name, or any other identifier) of the database instance that is executing queries or mutations on the current connection. This is useful in cases where the database is running in a clustered environment and the instrumentation is able to record the node executing the query. The client may obtain this value in databases like MySQL using queries like `select @@hostname`. | `mysql-e26b99z.example.com` | Recommended: If different from the `server.address` |
 | [`db.system`](../attributes-registry/db.md) | string | An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers. | `other_sql` | Required |
 | [`db.user`](../attributes-registry/db.md) | string | Username for accessing the database. | `readonly_user`; `reporting_user` | Recommended |
 | [`network.peer.address`](../attributes-registry/network.md) | string | Peer address of the network connection - IP address or Unix domain socket name. | `10.1.2.80`; `/tmp/my.sock` | Recommended |

--- a/model/registry/db.yaml
+++ b/model/registry/db.yaml
@@ -422,3 +422,11 @@ groups:
           Username for accessing the database.
         examples: ['readonly_user', 'reporting_user']
         tag: db-generic
+      - id: instance.id
+        tag: db-generic
+        type: string
+        brief: >
+          An identifier (address, unique name, or any other identifier) of the database instance that is executing queries or mutations on the current connection.
+          This is useful in cases where the database is running in a clustered environment and the instrumentation is able to record the node executing the query.
+          The client may obtain this value in databases like MySQL using queries like `select @@hostname`.
+        examples: 'mysql-e26b99z.example.com'

--- a/model/trace/database.yaml
+++ b/model/trace/database.yaml
@@ -46,6 +46,10 @@ groups:
         tag: connection-level
       - ref: network.type
         tag: connection-level
+      - ref: db.instance.id
+        tag: connection-level
+        requirement_level:
+          recommended: If different from the `server.address`
 
   - id: db.mssql
     type: span


### PR DESCRIPTION
Fixes # N/A

## Changes

<!--
Please provide a brief description of the changes here.


Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.
-->

At GitHub we run MySQL in multi-node clusters and are often interested in knowing the hostname of a node that is executing a query or command.

In order to acheive this we added an attribute to the Trilogy instrumentation named `db.mysql.instance.address` which is populated with the hostname of the node:

<https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/487>

This change adds the attribute to the database model as a MySQL specific connection attribute.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
