### PR TITLE
Move Alexander Wert from approver to maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 Approvers ([@open-telemetry/specs-semconv-approvers](https://github.com/orgs/open-telemetry/teams/specs-semconv-approvers)):
 
-- [Alexander Wert](https://github.com/AlexanderWert), Elastic
 - [Christian Neumüller](https://github.com/Oberon00), Dynatrace
 - [James Moessis](https://github.com/jamesmoessis), Atlassian
 - [Johannes Tax](https://github.com/pyohannes), Grafana Labs
@@ -29,6 +28,7 @@ _Find more about the approver role in [community repository](https://github.com/
 
 Maintainers ([@open-telemetry/specs-semconv-maintainers](https://github.com/orgs/open-telemetry/teams/specs-semconv-maintainers)):
 
+- [Alexander Wert](https://github.com/AlexanderWert), Elastic
 - [Armin Ruech](https://github.com/arminru), Dynatrace
 - [Joao Grassi](https://github.com/joaopgrassi), Dynatrace
 - [Josh Suereth](https://github.com/jsuereth), Google


### PR DESCRIPTION
@AlexanderWert has been [actively contributing to the semantic-conventions](https://github.com/open-telemetry/semantic-conventions/pulls?q=+is%3Apr+author%3AAlexanderWert), based on the offline discussions with the current maintainers, we would like to invite Alex as a maintainer of this project.

@arminru @joaopgrassi @jsuereth

FYI @open-telemetry/specs-semconv-approvers and @tigrannajaryan.