### PR TITLE
Require two approvals from different companies before merging the PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,23 @@ To quickly fix typos, use
 make misspell-correction
 ```
 
+### How to get your PR merged
+
+A PR (pull request) is considered to be **ready to merge** when:
+
+* It has received more than two approvals from the [code
+  owners](./.github/CODEOWNERS) (if approvals are from only one company, they
+  won't count).
+* There is no `request changes` from the [code owners](./.github/CODEOWNERS).
+* It has been at least two working days since the last modification (except for
+  the trivial updates, such like typo, cosmetic, rebase, etc.). This gives
+  people reasonable time to review.
+* Trivial changes (typos, cosmetic changes, CI improvements, etc.) don't have to
+  wait for two days.
+
+Any [maintainer](./README.md#contributing) can merge the PR once it is **ready
+to merge**.
+
 ## Updating the referenced specification version
 
 1. Open the `./internal/tools/update_specification_version.sh` script.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ make misspell-correction
 
 A PR (pull request) is considered to be **ready to merge** when:
 
-* It has received more than two approvals from the [code
+* It has received at least two approvals from the [code
   owners](./.github/CODEOWNERS) (if approvals are from only one company, they
   won't count).
 * There is no `request changes` from the [code owners](./.github/CODEOWNERS).


### PR DESCRIPTION
Borrowing from the specification repo https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#how-to-get-your-pr-merged.