### PR TITLE
Add semconv-mobile-approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,4 +41,8 @@
 /docs/resource/host.md    @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
 /model/resource/host.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
 
+# Mobile semantic conventions approvers
+/docs/mobile/        @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-mobile-approvers
+/model/logs/mobile*  @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-mobile-approvers
+
 # TODO - Add semconv area experts


### PR DESCRIPTION
This adds two paths for the newly minted `@open-telemetry/semconv-mobile-approvers` group:

* `/docs/mobile/` - Where mobile specific conventions will be captured
* `/model/logs/mobile*` - For definitions of mobile events via yaml

Relates to #67, #343, and #348. 