### PR TITLE
Increase markdown-link-check timeout

### DIFF
--- a/.markdown_link_check_config.json
+++ b/.markdown_link_check_config.json
@@ -15,5 +15,6 @@
     }
   ],
   "retryOn429": true,
+  "timeout": "30s",
   "aliveStatusCodes": [200, 403]
 }


### PR DESCRIPTION
Currently the markdown link check if failing on all PRs because of https://web.archive.org/web/20180321091318/http://www.onlamp.com/pub/a/linux/2000/11/16/LinuxAdmin.html. 

The link is not dead but it's really unreliable and takes long to load most of the times. As a first quick fix, we can try increasing the tool timeout. Went with `30s` which may be quite long, but I assume the rest of pages load fast, meaning I think it won't affect the total task duration.
