### PR TITLE
Add cardinality warning about two opt-in HTTP metric attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ release.
 
 ### Fixes
 
+- Add cardinality warning about two opt-in HTTP metric attributes
+  ([#401](https://github.com/open-telemetry/semantic-conventions/pull/401))
+
 ## v1.22.0 (2023-10-12)
 
 - Remove experimental Kafka metrics ([#338](https://github.com/open-telemetry/semantic-conventions/pull/338))

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -208,12 +208,18 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
+Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+to trigger cardinality limits, degrading the usefulness of the metric.
+
 **[3]:** Determined by using the first of the following that applies
 
 - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
+
+Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+to trigger cardinality limits, degrading the usefulness of the metric.
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -52,6 +52,9 @@ groups:
 
           SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
+          Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+          to trigger cardinality limits, degrading the usefulness of the metric.
+
       - ref: server.port
         requirement_level: opt_in
         brief: >
@@ -63,6 +66,9 @@ groups:
           - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
           - Port identifier of the `Host` header
+
+          Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+          to trigger cardinality limits, degrading the usefulness of the metric.
 
   - id: metric.http.server.request.body.size
     type: metric


### PR DESCRIPTION
## Changes

Adds cardinality warning about two opt-in HTTP metric attributes.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~
