### PR TITLE
Change `network.transport` from recommended to opt-in in the HTTP semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ release.
 
 ## Unreleased
 
+- Remove `network.protocol.name` from HTTP semconv.
+  ([#402](https://github.com/open-telemetry/semantic-conventions/pull/402))
+
 ### Breaking
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ release.
 
 - BREAKING: Rename http.resend_count to http.request.resend_count.
   ([#374](https://github.com/open-telemetry/semantic-conventions/pull/374))
-- BREAKING: Change `network.transport` from recommended to opt-in in the HTTP semconv.
+- BREAKING: Change `network.transport` from recommended to opt-in in HTTP semconv.
   ([#402](https://github.com/open-telemetry/semantic-conventions/pull/402))
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ release.
 
 ## Unreleased
 
-- Remove `network.protocol.name` from HTTP semconv.
-  ([#402](https://github.com/open-telemetry/semantic-conventions/pull/402))
-
 ### Breaking
 
 ### Features
 
 ### Fixes
+
+- Change `network.transport` from recommended to opt-in in the HTTP semconv.
+  ([#402](https://github.com/open-telemetry/semantic-conventions/pull/402))
 
 ## v1.22.0 (2023-10-12)
 

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -125,7 +125,8 @@ sections below.
 | [`http.response.status_code`](../attributes-registry/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [6] | `http`; `spdy` | Recommended: if not default (`http`). |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the protocol specified in `network.protocol.name`. [7] | `1.0`; `1.1`; `2`; `3` | Recommended |
-| [`network.type`](../general/attributes.md) | string | [OSI network layer](https://osi-model.com/network-layer/) or non-OSI equivalent. [8] | `ipv4`; `ipv6` | Recommended |
+| [`network.transport`](../general/attributes.md) | string | [OSI transport layer](https://osi-model.com/transport-layer/) or [inter-process communication method](https://en.wikipedia.org/wiki/Inter-process_communication). [8] | `tcp`; `udp` | Opt-In |
+| [`network.type`](../general/attributes.md) | string | [OSI network layer](https://osi-model.com/network-layer/) or non-OSI equivalent. [9] | `ipv4`; `ipv6` | Recommended |
 | `user_agent.original` | string | Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | Recommended |
 
 **[1]:** If the request fails with an error before response status code was sent or received,
@@ -173,7 +174,9 @@ The attribute value MUST consist of either multiple header values as an array of
 
 **[7]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
-**[8]:** The value SHOULD be normalized to lowercase.
+**[8]:** Generally `tcp` for `HTTP/1.0`, `HTTP/1.1`, and `HTTP/2`. Generally `udp` for `HTTP/3`. More obscure implementations are possible.
+
+**[9]:** The value SHOULD be normalized to lowercase.
 
 Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
 
@@ -199,6 +202,15 @@ Following attributes MUST be provided **at span creation time** (when provided a
 | `PUT` | PUT method. |
 | `TRACE` | TRACE method. |
 | `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. |
+
+`network.transport` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `tcp` | TCP |
+| `udp` | UDP |
+| `pipe` | Named or anonymous pipe. See note below. |
+| `unix` | Unix domain socket |
 
 `network.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -174,7 +174,7 @@ The attribute value MUST consist of either multiple header values as an array of
 
 **[7]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
-**[8]:** Generally `tcp` for `HTTP/1.0`, `HTTP/1.1`, and `HTTP/2`. Generally `udp` for `HTTP/3`. More obscure implementations are possible.
+**[8]:** Generally `tcp` for `HTTP/1.0`, `HTTP/1.1`, and `HTTP/2`. Generally `udp` for `HTTP/3`. Other obscure implementations are possible.
 
 **[9]:** The value SHOULD be normalized to lowercase.
 

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -125,8 +125,7 @@ sections below.
 | [`http.response.status_code`](../attributes-registry/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [6] | `http`; `spdy` | Recommended: if not default (`http`). |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the protocol specified in `network.protocol.name`. [7] | `1.0`; `1.1`; `2`; `3` | Recommended |
-| [`network.transport`](../general/attributes.md) | string | [OSI transport layer](https://osi-model.com/transport-layer/) or [inter-process communication method](https://en.wikipedia.org/wiki/Inter-process_communication). [8] | `tcp`; `udp` | Conditionally Required: [9] |
-| [`network.type`](../general/attributes.md) | string | [OSI network layer](https://osi-model.com/network-layer/) or non-OSI equivalent. [10] | `ipv4`; `ipv6` | Recommended |
+| [`network.type`](../general/attributes.md) | string | [OSI network layer](https://osi-model.com/network-layer/) or non-OSI equivalent. [8] | `ipv4`; `ipv6` | Recommended |
 | `user_agent.original` | string | Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | Recommended |
 
 **[1]:** If the request fails with an error before response status code was sent or received,
@@ -176,14 +175,6 @@ The attribute value MUST consist of either multiple header values as an array of
 
 **[8]:** The value SHOULD be normalized to lowercase.
 
-Consider always setting the transport when setting a port number, since
-a port number is ambiguous without knowing the transport, for example
-different processes could be listening on TCP port 12345 and UDP port 12345.
-
-**[9]:** If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
-
-**[10]:** The value SHOULD be normalized to lowercase.
-
 Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
 
 * [`http.request.method`](../attributes-registry/http.md)
@@ -208,15 +199,6 @@ Following attributes MUST be provided **at span creation time** (when provided a
 | `PUT` | PUT method. |
 | `TRACE` | TRACE method. |
 | `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. |
-
-`network.transport` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `tcp` | TCP |
-| `udp` | UDP |
-| `pipe` | Named or anonymous pipe. See note below. |
-| `unix` | Unix domain socket |
 
 `network.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/model/trace/http.yaml
+++ b/model/trace/http.yaml
@@ -23,7 +23,7 @@ groups:
         requirement_level: opt_in
         note: >
           Generally `tcp` for `HTTP/1.0`, `HTTP/1.1`, and `HTTP/2`. Generally `udp` for `HTTP/3`.
-          More obscure implementations are possible.
+          Other obscure implementations are possible.
       - ref: network.type
       - ref: user_agent.original
 

--- a/model/trace/http.yaml
+++ b/model/trace/http.yaml
@@ -19,9 +19,6 @@ groups:
       - ref: http.request.method
         sampling_relevant: true
         requirement_level: required
-      - ref: network.transport
-        requirement_level:
-          conditionally_required: If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
       - ref: network.type
       - ref: user_agent.original
 

--- a/model/trace/http.yaml
+++ b/model/trace/http.yaml
@@ -19,6 +19,11 @@ groups:
       - ref: http.request.method
         sampling_relevant: true
         requirement_level: required
+      - ref: network.transport
+        requirement_level: opt_in
+        note: >
+          Generally `tcp` for `HTTP/1.0`, `HTTP/1.1`, and `HTTP/2`. Generally `udp` for `HTTP/3`.
+          More obscure implementations are possible.
       - ref: network.type
       - ref: user_agent.original
 


### PR DESCRIPTION
Fixes #389

`network.transport` is typically derivable from `network.protocol.version`:
* HTTP 1.0, 1.1, 2 --> `tcp`
* HTTP 3 --> `udp`

so it doesn't provide much value to capture in HTTP semconv.

## Changes

Change `network.transport` from recommended to opt-in in the HTTP semconv.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~
