### PR TITLE
Remove `network.type` from HTTP semconv (changing it from recommended to opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release.
 
 - BREAKING: Rename http.resend_count to http.request.resend_count.
   ([#374](https://github.com/open-telemetry/semantic-conventions/pull/374))
+- BREAKING: Change `network.type` from recommended to opt-in in HTTP semconv.
+  ([#410](https://github.com/open-telemetry/semantic-conventions/pull/410))
 
 ### Features
 

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -126,7 +126,6 @@ sections below.
 | [`network.protocol.name`](../general/attributes.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [6] | `http`; `spdy` | Recommended: if not default (`http`). |
 | [`network.protocol.version`](../general/attributes.md) | string | Version of the protocol specified in `network.protocol.name`. [7] | `1.0`; `1.1`; `2`; `3` | Recommended |
 | [`network.transport`](../general/attributes.md) | string | [OSI transport layer](https://osi-model.com/transport-layer/) or [inter-process communication method](https://en.wikipedia.org/wiki/Inter-process_communication). [8] | `tcp`; `udp` | Conditionally Required: [9] |
-| [`network.type`](../general/attributes.md) | string | [OSI network layer](https://osi-model.com/network-layer/) or non-OSI equivalent. [10] | `ipv4`; `ipv6` | Recommended |
 | `user_agent.original` | string | Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | Recommended |
 
 **[1]:** If the request fails with an error before response status code was sent or received,
@@ -183,8 +182,6 @@ different processes could be listening on TCP port 12345 and UDP port 12345.
 
 **[9]:** If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
 
-**[10]:** The value SHOULD be normalized to lowercase.
-
 Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
 
 * [`http.request.method`](../attributes-registry/http.md)
@@ -218,13 +215,6 @@ Following attributes MUST be provided **at span creation time** (when provided a
 | `udp` | UDP |
 | `pipe` | Named or anonymous pipe. See note below. |
 | `unix` | Unix domain socket |
-
-`network.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `ipv4` | IPv4 |
-| `ipv6` | IPv6 |
 <!-- endsemconv -->
 
 ## HTTP client

--- a/model/trace/http.yaml
+++ b/model/trace/http.yaml
@@ -22,7 +22,6 @@ groups:
       - ref: network.transport
         requirement_level:
           conditionally_required: If not default (`tcp` for `HTTP/1.1` and `HTTP/2`, `udp` for `HTTP/3`).
-      - ref: network.type
       - ref: user_agent.original
 
   - id: trace.http.client


### PR DESCRIPTION
Knowing `ipv4` vs `ipv6` does not seem to be a useful enough piece of data in the scope of HTTP semconv to capture it by default on all HTTP telemetry.

Since there isn't anything to override (brief or note) on `network.type`, this attribute is simply removed from http semconv (unlike in #398 and #402 where the attribute is explicitly included as opt-in).

Fixes #403

## Changes

Changes `network.type` from recommended to opt-in in the HTTP semconv.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~
