### PR TITLE
Factor in `X-Forwarded-Host` / `Forwarded` when capturing `server.address` and `server.port`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release.
 
 - BREAKING: Rename http.resend_count to http.request.resend_count.
   ([#374](https://github.com/open-telemetry/semantic-conventions/pull/374))
+- BREAKING: Consider `X-Forwarded-Host` / `Forwarded` when capturing `server.address` and `server.port`.
+  ([#411](https://github.com/open-telemetry/semantic-conventions/pull/411))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ release.
   ([#376](https://github.com/open-telemetry/semantic-conventions/pull/376))
 - BREAKING: Change `network.transport` from recommended to opt-in in HTTP semconv.
   ([#402](https://github.com/open-telemetry/semantic-conventions/pull/402))
-- BREAKING: Consider `X-Forwarded-Host` / `Forwarded` when capturing `server.address` and `server.port`.
+- BREAKING: Factor in `X-Forwarded-Host` / `Forwarded` when capturing `server.address` and `server.port`.
   ([#411](https://github.com/open-telemetry/semantic-conventions/pull/411))
 
 ### Features

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -138,7 +138,7 @@ MUST NOT include the port identifier.
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
-Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+Warning: since this attribute may be based on HTTP headers, opting in to it may allow an attacker
 to trigger cardinality limits, degrading the usefulness of the metric.
 
 **[7]:** Determined by using the first of the following that applies
@@ -150,7 +150,7 @@ to trigger cardinality limits, degrading the usefulness of the metric.
   [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Port identifier of the `Host` header
 
-Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+Warning: since this attribute may be based on HTTP headers, opting in to it may allow an attacker
 to trigger cardinality limits, degrading the usefulness of the metric.
 
 **[8]:** The scheme of the original client request, if known (e.g. from [Forwarded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded), [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto), or a similar header). Otherwise, the scheme of the immediate peer request.
@@ -335,7 +335,7 @@ MUST NOT include the port identifier.
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
-Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+Warning: since this attribute may be based on HTTP headers, opting in to it may allow an attacker
 to trigger cardinality limits, degrading the usefulness of the metric.
 
 **[7]:** Determined by using the first of the following that applies
@@ -347,7 +347,7 @@ to trigger cardinality limits, degrading the usefulness of the metric.
   [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Port identifier of the `Host` header
 
-Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+Warning: since this attribute may be based on HTTP headers, opting in to it may allow an attacker
 to trigger cardinality limits, degrading the usefulness of the metric.
 
 **[8]:** The scheme of the original client request, if known (e.g. from [Forwarded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded), [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto), or a similar header). Otherwise, the scheme of the immediate peer request.
@@ -453,7 +453,7 @@ MUST NOT include the port identifier.
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
-Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+Warning: since this attribute may be based on HTTP headers, opting in to it may allow an attacker
 to trigger cardinality limits, degrading the usefulness of the metric.
 
 **[7]:** Determined by using the first of the following that applies
@@ -465,7 +465,7 @@ to trigger cardinality limits, degrading the usefulness of the metric.
   [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Port identifier of the `Host` header
 
-Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+Warning: since this attribute may be based on HTTP headers, opting in to it may allow an attacker
 to trigger cardinality limits, degrading the usefulness of the metric.
 
 **[8]:** The scheme of the original client request, if known (e.g. from [Forwarded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded), [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto), or a similar header). Otherwise, the scheme of the immediate peer request.

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -127,11 +127,14 @@ SHOULD include the [application root](/docs/http/http-spans.md#http-server-defin
 
 **[6]:** Determined by using the first of the following that applies
 
-- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
-  include host identifier.
+- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
+- Host identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+  [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Host identifier of the `Host` header
+
+MUST NOT include the port identifier.
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
@@ -140,6 +143,8 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
+- Port identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+  [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Port identifier of the `Host` header
 
 `error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
@@ -201,15 +206,18 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 
 **[2]:** Determined by using the first of the following that applies
 
-- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
-  include host identifier.
+- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
+- Host identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+  [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Host identifier of the `Host` header
+
+MUST NOT include the port identifier.
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
-Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+Warning: since this attribute may be based on HTTP headers, opting in to it may allow an attacker
 to trigger cardinality limits, degrading the usefulness of the metric.
 
 **[3]:** Determined by using the first of the following that applies
@@ -217,9 +225,11 @@ to trigger cardinality limits, degrading the usefulness of the metric.
 - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
+- Port identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+  [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Port identifier of the `Host` header
 
-Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+Warning: since this attribute may be based on HTTP headers, opting in to it may allow an attacker
 to trigger cardinality limits, degrading the usefulness of the metric.
 
 `http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
@@ -306,11 +316,14 @@ SHOULD include the [application root](/docs/http/http-spans.md#http-server-defin
 
 **[6]:** Determined by using the first of the following that applies
 
-- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
-  include host identifier.
+- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
+- Host identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+  [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Host identifier of the `Host` header
+
+MUST NOT include the port identifier.
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
@@ -319,6 +332,8 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
+- Port identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+  [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Port identifier of the `Host` header
 
 `error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
@@ -411,11 +426,14 @@ SHOULD include the [application root](/docs/http/http-spans.md#http-server-defin
 
 **[6]:** Determined by using the first of the following that applies
 
-- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
-  include host identifier.
+- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
+- Host identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+  [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Host identifier of the `Host` header
+
+MUST NOT include the port identifier.
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
@@ -424,6 +442,8 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
+- Port identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+  [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Port identifier of the `Host` header
 
 `error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -389,11 +389,14 @@ SHOULD include the [application root](/docs/http/http-spans.md#http-server-defin
 
 **[4]:** Determined by using the first of the following that applies
 
-- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
-  include host identifier.
+- The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
+- Host identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+  [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Host identifier of the `Host` header
+
+MUST NOT include the port identifier.
 
 SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
@@ -402,6 +405,8 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
+- Port identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+  [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
 - Port identifier of the `Host` header
 
 **[6]:** If not default (`80` for `http` scheme, `443` for `https`).

--- a/model/http-common.yaml
+++ b/model/http-common.yaml
@@ -77,11 +77,14 @@ groups:
         note: |
           Determined by using the first of the following that applies
 
-          - The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
-            include host identifier.
+          - The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
           - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
+          - Host identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+            [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
           - Host identifier of the `Host` header
+
+          MUST NOT include the port identifier.
 
           SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
@@ -94,6 +97,8 @@ groups:
           - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
           - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
+          - Port identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+            [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
           - Port identifier of the `Host` header
         requirement_level:
           conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -44,15 +44,18 @@ groups:
         note: |
           Determined by using the first of the following that applies
 
-          - The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
-            include host identifier.
+          - The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
           - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
+          - Host identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+            [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
           - Host identifier of the `Host` header
+
+          MUST NOT include the port identifier.
 
           SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
-          Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+          Warning: since this attribute may be based on HTTP headers, opting in to it may allow an attacker
           to trigger cardinality limits, degrading the usefulness of the metric.
 
       - ref: server.port
@@ -65,9 +68,11 @@ groups:
           - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
           - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
+          - Port identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+            [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
           - Port identifier of the `Host` header
 
-          Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+          Warning: since this attribute may be based on HTTP headers, opting in to it may allow an attacker
           to trigger cardinality limits, degrading the usefulness of the metric.
 
   - id: metric.http.server.request.body.size

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -9,15 +9,18 @@ groups:
         note: |
           Determined by using the first of the following that applies
 
-          - The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host. MUST only
-            include host identifier.
+          - The [primary server name](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
           - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
+          - Host identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+            [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
           - Host identifier of the `Host` header
+
+          MUST NOT include the port identifier.
 
           SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
 
-          Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+          Warning: since this attribute may be based on HTTP headers, opting in to it may allow an attacker
           to trigger cardinality limits, degrading the usefulness of the metric.
 
       - ref: server.port
@@ -28,9 +31,11 @@ groups:
           - Port identifier of the [primary server host](/docs/http/http-spans.md#http-server-definitions) of the matched virtual host.
           - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
+          - Port identifier of [Forwarded#host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#host),
+            [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host), or a similar header.
           - Port identifier of the `Host` header
 
-          Warning: since this attribute may be based on the `Host` header, opting in to it may allow an attacker
+          Warning: since this attribute may be based on HTTP headers, opting in to it may allow an attacker
           to trigger cardinality limits, degrading the usefulness of the metric.
 
   - id: metric_attributes.http.client


### PR DESCRIPTION
Fixes #408

## Changes

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~
