### PR TITLE
Revert to old `linkTitle` on runtime readme

### DIFF
--- a/docs/runtime/README.md
+++ b/docs/runtime/README.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: Semantic Conventions for Runtime Environment
+linkTitle: Runtime Environment
 --->
 
 # Semantic Conventions for Runtime Environment


### PR DESCRIPTION
As spotted by @chalin in https://github.com/open-telemetry/semantic-conventions/commit/559bf8bd66158dd402ae236141f139ef261b7b20#r130403152, I used the wrong `linkTitle` when I moved this page. Returning to the old one.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
