### PR TITLE
Update http-spans.md

### DIFF
--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -74,7 +74,7 @@ If there is no (low-cardinality) `http.route` available, HTTP server span names
 SHOULD be [`{method}`](#method-placeholder).
 
 HTTP client spans have no `http.route` attribute since client-side instrumentation
-is not generally aware of the "route", and therefore HTTP client spans SHOULD be
+is not generally aware of the "route", and therefore HTTP client span names SHOULD be
 [`{method}`](#method-placeholder).
 <!-- markdown-link-check-enable -->
 


### PR DESCRIPTION
## Changes

Please provide a brief description of the changes here.

A small improvement to docs, removed ambiguity for ppl like me (who're reading docs for the first time)

An earlier paragraph for server spans uses `span names` explicitly, so I figured to make it more obvious, the client paragraph could use the same wording:
 
>HTTP server span names SHOULD be [`{method}`](#method-placeholder).

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
