### PR TITLE
Add `enduser.anon_id` to general attributes

### DIFF
--- a/docs/general/attributes.md
+++ b/docs/general/attributes.md
@@ -306,12 +306,13 @@ Examples of `peer.service` that users may specify:
 
 ## General identity attributes
 
-These attributes may be used for any operation with an authenticated and/or authorized enduser.
+These attributes may be used for any operation with an authenticated or anonymous enduser.
 
 <!-- semconv identity -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `enduser.id` | string | Username or client_id extracted from the access token or [Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) header in the inbound request from outside the system. | `username` | Recommended |
+| `enduser.anon_id` | string | Randomly generated id of an anonymous user that is persisted throughout the lifetime of the visits. | `V1StGXR8_Z5jdHi6B-myT` | Recommended |
 | `enduser.role` | string | Actual/assumed role the client is making the request under extracted from token or application security context. | `admin` | Recommended |
 | `enduser.scope` | string | Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an [OAuth 2.0 Access Token](https://tools.ietf.org/html/rfc6749#section-3.3) or an attribute value in a [SAML 2.0 Assertion](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html). | `read:message, write:files` | Recommended |
 <!-- endsemconv -->

--- a/docs/general/attributes.md
+++ b/docs/general/attributes.md
@@ -311,8 +311,8 @@ These attributes may be used for any operation with an authenticated or anonymou
 <!-- semconv identity -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `enduser.id` | string | Username or client_id extracted from the access token or [Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) header in the inbound request from outside the system. | `username` | Recommended |
 | `enduser.anon_id` | string | Randomly generated id of an anonymous user that is persisted throughout the lifetime of the visits. | `V1StGXR8_Z5jdHi6B-myT` | Recommended |
+| `enduser.id` | string | Username or client_id extracted from the access token or [Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) header in the inbound request from outside the system. | `username` | Recommended |
 | `enduser.role` | string | Actual/assumed role the client is making the request under extracted from token or application security context. | `admin` | Recommended |
 | `enduser.scope` | string | Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an [OAuth 2.0 Access Token](https://tools.ietf.org/html/rfc6749#section-3.3) or an attribute value in a [SAML 2.0 Assertion](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html). | `read:message, write:files` | Recommended |
 <!-- endsemconv -->

--- a/model/general.yaml
+++ b/model/general.yaml
@@ -43,7 +43,7 @@ groups:
     prefix: enduser
     type: span
     brief: >
-      These attributes may be used for any operation with an authenticated and/or authorized enduser.
+      These attributes may be used for any operation with an authenticated or anonymous enduser.
     attributes:
       - id: id
         type: string
@@ -52,6 +52,11 @@ groups:
           [Authorization](https://tools.ietf.org/html/rfc7235#section-4.2)
           header in the inbound request from outside the system.
         examples: 'username'
+      - id: anon_id
+        type: string
+        brief: >
+          Randomly generated id of an anonymous user that is persisted throughout the lifetime of the visits.
+        examples: 'V1StGXR8_Z5jdHi6B-myT'
       - id: role
         type: string
         brief: 'Actual/assumed role the client is making the request under extracted from token or application security context.'


### PR DESCRIPTION
## Changes

Adding enduser.anon_id to handle case of enduser which is not authorized/authenticated but we want a way to track their visits throughout the lifetime

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
