### PR TITLE
Moved `messaging.*` attributes to the registry

### DIFF
--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -1,0 +1,89 @@
+<!--- Hugo front matter used to generate the website version of this page:
+--->
+
+# Messaging
+
+## Messaging Attributes
+
+<!-- semconv registry.messaging(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  |
+|---|---|---|---|
+| `messaging.batch.message_count` | int | The number of messages sent, received, or processed in the scope of the batching operation. [1] | `0`; `1`; `2` |
+| `messaging.client_id` | string | A unique identifier for the client that consumes or produces a message. | `client-5`; `myhost@8742@s8083jm` |
+| `messaging.destination.anonymous` | boolean | A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name). |  |
+| `messaging.destination.name` | string | The message destination name [2] | `MyQueue`; `MyTopic` |
+| `messaging.destination.template` | string | Low cardinality representation of the messaging destination name [3] | `/customers/{customerId}` |
+| `messaging.destination.temporary` | boolean | A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed. |  |
+| `messaging.destination_publish.anonymous` | boolean | A boolean that is true if the publish message destination is anonymous (could be unnamed or have auto-generated name). |  |
+| `messaging.destination_publish.name` | string | The name of the original destination the message was published to [4] | `MyQueue`; `MyTopic` |
+| `messaging.kafka.consumer.group` | string | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. | `my-group` |
+| `messaging.kafka.destination.partition` | int | Partition the message is sent to. | `2` |
+| `messaging.kafka.message.key` | string | Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message.id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set. [5] | `myKey` |
+| `messaging.kafka.message.offset` | int | The offset of a record in the corresponding Kafka partition. | `42` |
+| `messaging.kafka.message.tombstone` | boolean | A boolean that is true if the message is a tombstone. |  |
+| `messaging.message.body.size` | int | The size of the message body in bytes. [6] | `1439` |
+| `messaging.message.conversation_id` | string | The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". [7] | `MyConversationId` |
+| `messaging.message.envelope.size` | int | The size of the message body and metadata in bytes. [8] | `2738` |
+| `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` |
+| `messaging.operation` | string | A string identifying the kind of messaging operation. [9] | `publish` |
+| `messaging.rabbitmq.destination.routing_key` | string | RabbitMQ message routing key. | `myKey` |
+| `messaging.rocketmq.client_group` | string | Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind. | `myConsumerGroup` |
+| `messaging.rocketmq.consumption_model` | string | Model of message consumption. This only applies to consumer spans. | `clustering` |
+| `messaging.rocketmq.message.delay_time_level` | int | The delay time level for delay message, which determines the message delay time. | `3` |
+| `messaging.rocketmq.message.delivery_timestamp` | int | The timestamp in milliseconds that the delay message is expected to be delivered to consumer. | `1665987217045` |
+| `messaging.rocketmq.message.group` | string | It is essential for FIFO message. Messages that belong to the same message group are always processed one by one within the same consumer group. | `myMessageGroup` |
+| `messaging.rocketmq.message.keys` | string[] | Key(s) of message, another way to mark message besides message id. | `[keyA, keyB]` |
+| `messaging.rocketmq.message.tag` | string | The secondary classifier of message besides topic. | `tagA` |
+| `messaging.rocketmq.message.type` | string | Type of message. | `normal` |
+| `messaging.rocketmq.namespace` | string | Namespace of RocketMQ resources, resources in different namespaces are individual. | `myNamespace` |
+| `messaging.system` | string | A string identifying the messaging system. | `kafka`; `rabbitmq`; `rocketmq`; `activemq`; `AmazonSQS` |
+
+**[1]:** Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
+
+**[2]:** Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
+the broker doesn't have such notion, the destination name SHOULD uniquely identify the broker.
+
+**[3]:** Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
+
+**[4]:** The name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
+the broker doesn't have such notion, the original destination name SHOULD uniquely identify the broker.
+
+**[5]:** If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.
+
+**[6]:** This can refer to both the compressed or uncompressed body size. If both sizes are known, the uncompressed
+body size should be used.
+
+**[7]:** In some messaging systems, a message can receive one or more reply messages that answers a particular other message that was sent earlier.
+All messages that are grouped together by such a reply-relationship are called a *conversation*.
+The grouping usually happens through some sort of "In-Reply-To:" meta information or an explicit *conversation ID* (sometimes called *correlation ID*).
+Sometimes a conversation can span multiple message destinations (e.g. initiated via a topic, continued on a temporary one-to-one queue).
+
+**[8]:** This can refer to both the compressed or uncompressed size. If both sizes are known, the uncompressed
+size should be used.
+
+**[9]:** If a custom value is used, it MUST be of low cardinality.
+
+`messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `publish` | A message is sent to a destination by a message producer/client. |
+| `receive` | A message is received from a destination by a message consumer/server. |
+| `process` | A message that was previously received from a destination is processed by a message consumer/server. |
+
+`messaging.rocketmq.consumption_model` MUST be one of the following:
+
+| Value  | Description |
+|---|---|
+| `clustering` | Clustering consumption model |
+| `broadcasting` | Broadcasting consumption model |
+
+`messaging.rocketmq.message.type` MUST be one of the following:
+
+| Value  | Description |
+|---|---|
+| `normal` | Normal message |
+| `fifo` | FIFO message |
+| `delay` | Delay message |
+| `transaction` | Transaction message |
+<!-- endsemconv -->

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -22,10 +22,10 @@
 | `messaging.kafka.message.offset` | int | The offset of a record in the corresponding Kafka partition. | `42` |
 | `messaging.kafka.message.tombstone` | boolean | A boolean that is true if the message is a tombstone. |  |
 | `messaging.message.body.size` | int | The size of the message body in bytes. [6] | `1439` |
-| `messaging.message.conversation_id` | string | The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". [7] | `MyConversationId` |
-| `messaging.message.envelope.size` | int | The size of the message body and metadata in bytes. [8] | `2738` |
+| `messaging.message.conversation_id` | string | The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` |
+| `messaging.message.envelope.size` | int | The size of the message body and metadata in bytes. [7] | `2738` |
 | `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` |
-| `messaging.operation` | string | A string identifying the kind of messaging operation. [9] | `publish` |
+| `messaging.operation` | string | A string identifying the kind of messaging operation. [8] | `publish` |
 | `messaging.rabbitmq.destination.routing_key` | string | RabbitMQ message routing key. | `myKey` |
 | `messaging.rocketmq.client_group` | string | Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind. | `myConsumerGroup` |
 | `messaging.rocketmq.consumption_model` | string | Model of message consumption. This only applies to consumer spans. | `clustering` |
@@ -53,23 +53,19 @@ the broker doesn't have such notion, the original destination name SHOULD unique
 **[6]:** This can refer to both the compressed or uncompressed body size. If both sizes are known, the uncompressed
 body size should be used.
 
-**[7]:** In some messaging systems, a message can receive one or more reply messages that answers a particular other message that was sent earlier.
-All messages that are grouped together by such a reply-relationship are called a *conversation*.
-The grouping usually happens through some sort of "In-Reply-To:" meta information or an explicit *conversation ID* (sometimes called *correlation ID*).
-Sometimes a conversation can span multiple message destinations (e.g. initiated via a topic, continued on a temporary one-to-one queue).
-
-**[8]:** This can refer to both the compressed or uncompressed size. If both sizes are known, the uncompressed
+**[7]:** This can refer to both the compressed or uncompressed size. If both sizes are known, the uncompressed
 size should be used.
 
-**[9]:** If a custom value is used, it MUST be of low cardinality.
+**[8]:** If a custom value is used, it MUST be of low cardinality.
 
 `messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|
-| `publish` | A message is sent to a destination by a message producer/client. |
-| `receive` | A message is received from a destination by a message consumer/server. |
-| `process` | A message that was previously received from a destination is processed by a message consumer/server. |
+| `publish` | One or more messages are provided for publishing to an intermediary. If a single message is published, the context of the "Publish" span can be used as the creation context and no "Create" span needs to be created. |
+| `create` | A message is created. "Create" spans always refer to a single message and are used to provide a unique creation context for messages in batch publishing scenarios. |
+| `receive` | One or more messages are requested by a consumer. This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages. |
+| `deliver` | One or more messages are passed to a consumer. This operation refers to push-based scenarios, where consumer register callbacks which get called by messaging SDKs. |
 
 `messaging.rocketmq.consumption_model` MUST be one of the following:
 

--- a/docs/messaging/kafka.md
+++ b/docs/messaging/kafka.md
@@ -24,14 +24,14 @@ described on this page.
 
 For Apache Kafka, the following additional attributes are defined:
 
-<!-- semconv messaging.kafka -->
+<!-- semconv messaging.kafka(full,tag=tech-specific-kafka) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `messaging.kafka.consumer.group` | string | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. | `my-group` | Recommended |
-| `messaging.kafka.destination.partition` | int | Partition the message is sent to. | `2` | Recommended |
-| `messaging.kafka.message.key` | string | Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message.id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set. [1] | `myKey` | Recommended |
-| `messaging.kafka.message.offset` | int | The offset of a record in the corresponding Kafka partition. | `42` | Recommended |
-| `messaging.kafka.message.tombstone` | boolean | A boolean that is true if the message is a tombstone. |  | Conditionally Required: [2] |
+| [`messaging.kafka.consumer.group`](../attributes-registry/messaging.md) | string | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. | `my-group` | Recommended |
+| [`messaging.kafka.destination.partition`](../attributes-registry/messaging.md) | int | Partition the message is sent to. | `2` | Recommended |
+| [`messaging.kafka.message.key`](../attributes-registry/messaging.md) | string | Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message.id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set. [1] | `myKey` | Recommended |
+| [`messaging.kafka.message.offset`](../attributes-registry/messaging.md) | int | The offset of a record in the corresponding Kafka partition. | `42` | Recommended |
+| [`messaging.kafka.message.tombstone`](../attributes-registry/messaging.md) | boolean | A boolean that is true if the message is a tombstone. |  | Conditionally Required: [2] |
 
 **[1]:** If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.
 

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -13,7 +13,6 @@
   * [Intermediary](#intermediary)
   * [Destinations](#destinations)
   * [Message consumption](#message-consumption)
-  * [Conversations](#conversations)
   * [Temporary and anonymous destinations](#temporary-and-anonymous-destinations)
 - [Conventions](#conventions)
   * [Context propagation](#context-propagation)
@@ -124,12 +123,6 @@ First, the lower-level receiving of a message at a consumer, and then the logica
 Often, the waiting for a message is not particularly interesting and hidden away in a framework that only invokes some handler function to process a message once one is received
 (in the same way that the listening on a TCP port for an incoming HTTP message is not particularly interesting).
 
-### Conversations
-
-In some messaging systems, a message can receive one or more reply messages that answers a particular other message that was sent earlier. All messages that are grouped together by such a reply-relationship are called a *conversation*.
-The grouping usually happens through some sort of "In-Reply-To:" meta information or an explicit *conversation ID* (sometimes called *correlation ID*).
-Sometimes a conversation can span multiple message destinations (e.g. initiated via a topic, continued on a temporary one-to-one queue).
-
 ### Temporary and anonymous destinations
 
 Some messaging systems support the concept of *temporary destination* (often only temporary queues) that are established just for a particular set of communication partners (often one to one) or conversation.
@@ -182,10 +175,10 @@ The span name SHOULD be set to the message destination name and the operation be
 The destination name SHOULD only be used for the span name if it is known to be of low cardinality (cf. [general span name guidelines](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/trace/api.md#span)).
 This can be assumed if it is statically derived from application code or configuration.
 Wherever possible, the real destination names after resolving logical or aliased names SHOULD be used.
-If the destination name is dynamic, such as a [conversation ID](#conversations) or a value obtained from a `Reply-To` header, it SHOULD NOT be used for the span name.
+If the destination name is dynamic, such as a [conversation ID](../attributes-registry/messaging.md) or a value obtained from a `Reply-To` header, it SHOULD NOT be used for the span name.
 In these cases, an artificial destination name that best expresses the destination, or a generic, static fallback like `"(anonymous)"` for [anonymous destinations](#temporary-and-anonymous-destinations) SHOULD be used instead.
 
-The values allowed for `<operation name>` are defined in the section [Operation names](#operation-names) below.
+The values allowed for `<operation name>` are defined in the well-known values section for the [`messaging.operation`](../attributes-registry/messaging.md) attribute.
 If the format above is used, the operation name MUST match the `messaging.operation` attribute defined for message consumer spans below.
 
 Examples:
@@ -273,28 +266,28 @@ messages were received). For each message it accounts for, the "Deliver" or
 
 ## Messaging attributes
 
-<!-- semconv messaging -->
+<!-- semconv messaging(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `messaging.batch.message_count` | int | The number of messages sent, received, or processed in the scope of the batching operation. [1] | `0`; `1`; `2` | Conditionally Required: [2] |
-| `messaging.client_id` | string | A unique identifier for the client that consumes or produces a message. | `client-5`; `myhost@8742@s8083jm` | Recommended: If a client id is available |
-| `messaging.destination.anonymous` | boolean | A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name). |  | Conditionally Required: [3] |
-| `messaging.destination.name` | string | The message destination name [4] | `MyQueue`; `MyTopic` | Conditionally Required: [5] |
-| `messaging.destination.template` | string | Low cardinality representation of the messaging destination name [6] | `/customers/{customerId}` | Conditionally Required: [7] |
-| `messaging.destination.temporary` | boolean | A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed. |  | Conditionally Required: [8] |
-| `messaging.message.body.size` | int | The size of the message body in bytes. [9] | `1439` | Recommended: [10] |
-| `messaging.message.conversation_id` | string | The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` | Recommended: [11] |
-| `messaging.message.envelope.size` | int | The size of the message body and metadata in bytes. [12] | `2738` | Recommended: [13] |
-| `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | Recommended: [14] |
-| `messaging.operation` | string | A string identifying the kind of messaging operation as defined in the [Operation names](#operation-names) section above. [15] | `publish` | Required |
-| `messaging.system` | string | A string identifying the messaging system. | `kafka`; `rabbitmq`; `rocketmq`; `activemq`; `AmazonSQS` | Required |
+| [`messaging.batch.message_count`](../attributes-registry/messaging.md) | int | The number of messages sent, received, or processed in the scope of the batching operation. [1] | `0`; `1`; `2` | Conditionally Required: [2] |
+| [`messaging.client_id`](../attributes-registry/messaging.md) | string | A unique identifier for the client that consumes or produces a message. | `client-5`; `myhost@8742@s8083jm` | Recommended: If a client id is available |
+| [`messaging.destination.anonymous`](../attributes-registry/messaging.md) | boolean | A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name). |  | Conditionally Required: [3] |
+| [`messaging.destination.name`](../attributes-registry/messaging.md) | string | The message destination name [4] | `MyQueue`; `MyTopic` | Conditionally Required: [5] |
+| [`messaging.destination.template`](../attributes-registry/messaging.md) | string | Low cardinality representation of the messaging destination name [6] | `/customers/{customerId}` | Conditionally Required: [7] |
+| [`messaging.destination.temporary`](../attributes-registry/messaging.md) | boolean | A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed. |  | Conditionally Required: [8] |
+| [`messaging.message.body.size`](../attributes-registry/messaging.md) | int | The size of the message body in bytes. [9] | `1439` | Recommended: [10] |
+| [`messaging.message.conversation_id`](../attributes-registry/messaging.md) | string | The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". [11] | `MyConversationId` | Recommended: [12] |
+| [`messaging.message.envelope.size`](../attributes-registry/messaging.md) | int | The size of the message body and metadata in bytes. [13] | `2738` | Recommended: [14] |
+| [`messaging.message.id`](../attributes-registry/messaging.md) | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | Recommended: [15] |
+| [`messaging.operation`](../attributes-registry/messaging.md) | string | A string identifying the kind of messaging operation. [16] | `publish` | Required |
+| [`messaging.system`](../attributes-registry/messaging.md) | string | A string identifying the messaging system. | `kafka`; `rabbitmq`; `rocketmq`; `activemq`; `AmazonSQS` | Required |
 | [`network.peer.address`](../attributes-registry/network.md) | string | Peer address of the network connection - IP address or Unix domain socket name. | `10.1.2.80`; `/tmp/my.sock` | Recommended |
 | [`network.peer.port`](../attributes-registry/network.md) | int | Peer port number of the network connection. | `65123` | Recommended: If `network.peer.address` is set. |
-| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [16] | `amqp`; `mqtt` | Recommended |
-| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [17] | `3.1.1` | Recommended |
-| [`network.transport`](../attributes-registry/network.md) | string | [OSI transport layer](https://osi-model.com/transport-layer/) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication). [18] | `tcp`; `udp` | Recommended |
-| [`network.type`](../attributes-registry/network.md) | string | [OSI network layer](https://osi-model.com/network-layer/) or non-OSI equivalent. [19] | `ipv4`; `ipv6` | Recommended |
-| [`server.address`](../general/attributes.md) | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [20] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Conditionally Required: If available. |
+| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [17] | `amqp`; `mqtt` | Recommended |
+| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [18] | `3.1.1` | Recommended |
+| [`network.transport`](../attributes-registry/network.md) | string | [OSI transport layer](https://osi-model.com/transport-layer/) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication). [19] | `tcp`; `udp` | Recommended |
+| [`network.type`](../attributes-registry/network.md) | string | [OSI network layer](https://osi-model.com/network-layer/) or non-OSI equivalent. [20] | `ipv4`; `ipv6` | Recommended |
+| [`server.address`](../general/attributes.md) | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [21] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Conditionally Required: If available. |
 
 **[1]:** Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
 
@@ -318,38 +311,59 @@ body size should be used.
 
 **[10]:** Only if span represents operation on a single message.
 
-**[11]:** Only if span represents operation on a single message.
+**[11]:** In some messaging systems, a message can receive one or more reply messages that answers a particular other message that was sent earlier.
+All messages that are grouped together by such a reply-relationship are called a *conversation*.
+The grouping usually happens through some sort of "In-Reply-To:" meta information or an explicit *conversation ID* (sometimes called *correlation ID*).
+Sometimes a conversation can span multiple message destinations (e.g. initiated via a topic, continued on a temporary one-to-one queue).
 
-**[12]:** This can refer to both the compressed or uncompressed size. If both sizes are known, the uncompressed
+**[12]:** Only if span represents operation on a single message.
+
+**[13]:** This can refer to both the compressed or uncompressed size. If both sizes are known, the uncompressed
 size should be used.
 
-**[13]:** Only if span represents operation on a single message.
+**[14]:** Only if span represents operation on a single message.
 
-**[14]:** Only for spans that represent an operation on a single message.
+**[15]:** Only for spans that represent an operation on a single message.
 
-**[15]:** If a custom value is used, it MUST be of low cardinality.
+**[16]:** If a custom value is used, it MUST be of low cardinality.
 
-**[16]:** The value SHOULD be normalized to lowercase.
+**[17]:** The value SHOULD be normalized to lowercase.
 
-**[17]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[18]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
-**[18]:** The value SHOULD be normalized to lowercase.
+**[19]:** The value SHOULD be normalized to lowercase.
 
 Consider always setting the transport when setting a port number, since
 a port number is ambiguous without knowing the transport. For example
 different processes could be listening on TCP port 12345 and UDP port 12345.
 
-**[19]:** The value SHOULD be normalized to lowercase.
+**[20]:** The value SHOULD be normalized to lowercase.
 
-**[20]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
+**[21]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
 
 `messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|
-| `publish` | publish |
-| `receive` | receive |
-| `process` | process |
+| `publish` | A message is sent to a destination by a message producer/client. |
+| `receive` | A message is received from a destination by a message consumer/server. |
+| `process` | A message that was previously received from a destination is processed by a message consumer/server. |
+
+`network.transport` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `tcp` | TCP |
+| `udp` | UDP |
+| `pipe` | Named or anonymous pipe. |
+| `unix` | Unix domain socket |
+
+`network.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `ipv4` | IPv4 |
+| `ipv6` | IPv6 |
 <!-- endsemconv -->
 
 Additionally `server.port` from the [network attributes][] is recommended.
@@ -387,8 +401,8 @@ under the namespace `messaging.destination_publish.*`
 <!-- semconv messaging.destination_publish -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `messaging.destination_publish.anonymous` | boolean | A boolean that is true if the publish message destination is anonymous (could be unnamed or have auto-generated name). |  | Recommended |
-| `messaging.destination_publish.name` | string | The name of the original destination the message was published to [1] | `MyQueue`; `MyTopic` | Recommended |
+| [`messaging.destination_publish.anonymous`](../attributes-registry/messaging.md) | boolean | A boolean that is true if the publish message destination is anonymous (could be unnamed or have auto-generated name). |  | Recommended |
+| [`messaging.destination_publish.name`](../attributes-registry/messaging.md) | string | The name of the original destination the message was published to [1] | `MyQueue`; `MyTopic` | Recommended |
 
 **[1]:** The name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
 the broker doesn't have such notion, the original destination name SHOULD uniquely identify the broker.

--- a/docs/messaging/rabbitmq.md
+++ b/docs/messaging/rabbitmq.md
@@ -17,10 +17,10 @@ described on this page.
 In RabbitMQ, the destination is defined by an *exchange* and a *routing key*.
 `messaging.destination.name` MUST be set to the name of the exchange. This will be an empty string if the default exchange is used.
 
-<!-- semconv messaging.rabbitmq -->
+<!-- semconv messaging.rabbitmq(full,tag=tech-specific-rabbitmq) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `messaging.rabbitmq.destination.routing_key` | string | RabbitMQ message routing key. | `myKey` | Conditionally Required: If not empty. |
+| [`messaging.rabbitmq.destination.routing_key`](../attributes-registry/messaging.md) | string | RabbitMQ message routing key. | `myKey` | Conditionally Required: If not empty. |
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/docs/messaging/rocketmq.md
+++ b/docs/messaging/rocketmq.md
@@ -16,18 +16,18 @@ described on this page.
 
 Specific attributes for Apache RocketMQ are defined below.
 
-<!-- semconv messaging.rocketmq -->
+<!-- semconv messaging.rocketmq(full,tag=tech-specific-rocketmq) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `messaging.rocketmq.client_group` | string | Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind. | `myConsumerGroup` | Required |
-| `messaging.rocketmq.consumption_model` | string | Model of message consumption. This only applies to consumer spans. | `clustering` | Recommended |
-| `messaging.rocketmq.message.delay_time_level` | int | The delay time level for delay message, which determines the message delay time. | `3` | Conditionally Required: [1] |
-| `messaging.rocketmq.message.delivery_timestamp` | int | The timestamp in milliseconds that the delay message is expected to be delivered to consumer. | `1665987217045` | Conditionally Required: [2] |
-| `messaging.rocketmq.message.group` | string | It is essential for FIFO message. Messages that belong to the same message group are always processed one by one within the same consumer group. | `myMessageGroup` | Conditionally Required: If the message type is FIFO. |
-| `messaging.rocketmq.message.keys` | string[] | Key(s) of message, another way to mark message besides message id. | `[keyA, keyB]` | Recommended |
-| `messaging.rocketmq.message.tag` | string | The secondary classifier of message besides topic. | `tagA` | Recommended |
-| `messaging.rocketmq.message.type` | string | Type of message. | `normal` | Recommended |
-| `messaging.rocketmq.namespace` | string | Namespace of RocketMQ resources, resources in different namespaces are individual. | `myNamespace` | Required |
+| [`messaging.rocketmq.client_group`](../attributes-registry/messaging.md) | string | Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind. | `myConsumerGroup` | Required |
+| [`messaging.rocketmq.consumption_model`](../attributes-registry/messaging.md) | string | Model of message consumption. This only applies to consumer spans. | `clustering` | Recommended |
+| [`messaging.rocketmq.message.delay_time_level`](../attributes-registry/messaging.md) | int | The delay time level for delay message, which determines the message delay time. | `3` | Conditionally Required: [1] |
+| [`messaging.rocketmq.message.delivery_timestamp`](../attributes-registry/messaging.md) | int | The timestamp in milliseconds that the delay message is expected to be delivered to consumer. | `1665987217045` | Conditionally Required: [2] |
+| [`messaging.rocketmq.message.group`](../attributes-registry/messaging.md) | string | It is essential for FIFO message. Messages that belong to the same message group are always processed one by one within the same consumer group. | `myMessageGroup` | Conditionally Required: If the message type is FIFO. |
+| [`messaging.rocketmq.message.keys`](../attributes-registry/messaging.md) | string[] | Key(s) of message, another way to mark message besides message id. | `[keyA, keyB]` | Recommended |
+| [`messaging.rocketmq.message.tag`](../attributes-registry/messaging.md) | string | The secondary classifier of message besides topic. | `tagA` | Recommended |
+| [`messaging.rocketmq.message.type`](../attributes-registry/messaging.md) | string | Type of message. | `normal` | Recommended |
+| [`messaging.rocketmq.namespace`](../attributes-registry/messaging.md) | string | Namespace of RocketMQ resources, resources in different namespaces are individual. | `myNamespace` | Required |
 
 **[1]:** If the message type is delay and delivery timestamp is not specified.
 

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -1,0 +1,202 @@
+groups:
+  - id: registry.messaging
+    prefix: messaging
+    type: attribute_group
+    brief: 'Attributes describing telemetry around messaging systems and messaging activities.'
+    attributes:
+      - id: batch.message_count
+        type: int
+        brief: The number of messages sent, received, or processed in the scope of the batching operation.
+        note: >
+            Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message.
+            When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD
+            use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
+        examples: [0, 1, 2]
+      - id: client_id
+        type: string
+        brief: >
+          A unique identifier for the client that consumes or produces a message.
+        examples: ['client-5', 'myhost@8742@s8083jm']
+      - id: destination.name
+        type: string
+        brief: 'The message destination name'
+        note: |
+          Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
+          the broker doesn't have such notion, the destination name SHOULD uniquely identify the broker.
+        examples: ['MyQueue', 'MyTopic']
+      - id: destination.template
+        type: string
+        brief: Low cardinality representation of the messaging destination name
+        note: >
+          Destination names could be constructed from templates.
+          An example would be a destination name involving a user name or product id.
+          Although the destination name in this case is of high cardinality,
+          the underlying template is of low cardinality and can be effectively
+          used for grouping and aggregation.
+        examples: ['/customers/{customerId}']
+      - id: destination.anonymous
+        type: boolean
+        brief: 'A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).'
+      - id: destination.temporary
+        type: boolean
+        brief: 'A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed.'
+      - id: destination_publish.anonymous
+        type: boolean
+        brief: 'A boolean that is true if the publish message destination is anonymous (could be unnamed or have auto-generated name).'
+      - id: destination_publish.name
+        type: string
+        brief: 'The name of the original destination the message was published to'
+        note: |
+          The name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
+          the broker doesn't have such notion, the original destination name SHOULD uniquely identify the broker.
+        examples: ['MyQueue', 'MyTopic']
+      - id: kafka.consumer.group
+        type: string
+        brief: >
+          Name of the Kafka Consumer Group that is handling the message.
+          Only applies to consumers, not producers.
+        examples: 'my-group'
+      - id: kafka.destination.partition
+        type: int
+        brief: >
+          Partition the message is sent to.
+        examples: 2
+      - id: kafka.message.key
+        type: string
+        brief: >
+          Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition.
+          They differ from `messaging.message.id` in that they're not unique.
+          If the key is `null`, the attribute MUST NOT be set.
+        note: >
+          If the key type is not string, it's string representation has to be supplied for the attribute.
+          If the key has no unambiguous, canonical string form, don't include its value.
+        examples: 'myKey'
+      - id: kafka.message.offset
+        type: int
+        brief: >
+          The offset of a record in the corresponding Kafka partition.
+        examples: 42
+      - id: kafka.message.tombstone
+        type: boolean
+        brief: 'A boolean that is true if the message is a tombstone.'
+      - id: message.conversation_id
+        type: string
+        brief: >
+          The conversation ID identifying the conversation to which the message belongs,
+          represented as a string. Sometimes called "Correlation ID".
+        examples: 'MyConversationId'
+        note: |
+          In some messaging systems, a message can receive one or more reply messages that answers a particular other message that was sent earlier.
+          All messages that are grouped together by such a reply-relationship are called a *conversation*.
+          The grouping usually happens through some sort of "In-Reply-To:" meta information or an explicit *conversation ID* (sometimes called *correlation ID*).
+          Sometimes a conversation can span multiple message destinations (e.g. initiated via a topic, continued on a temporary one-to-one queue).
+      - id: message.envelope.size
+        type: int
+        brief: >
+          The size of the message body and metadata in bytes.
+        note: |
+          This can refer to both the compressed or uncompressed size. If both sizes are known, the uncompressed
+          size should be used.
+        examples: 2738
+      - id: message.id
+        type: string
+        brief: 'A value used by the messaging system as an identifier for the message, represented as a string.'
+        examples: '452a7c7c7c7048c2f887f61572b18fc2'
+      - id: message.body.size
+        type: int
+        brief: >
+          The size of the message body in bytes.
+        note: |
+          This can refer to both the compressed or uncompressed body size. If both sizes are known, the uncompressed
+          body size should be used.
+        examples: 1439
+      - id: operation
+        type:
+          allow_custom_values: true
+          members:
+            - id: publish
+              value: "publish"
+              brief: "A message is sent to a destination by a message producer/client."
+            - id: receive
+              value: "receive"
+              brief: "A message is received from a destination by a message consumer/server."
+            - id: process
+              value: "process"
+              brief: "A message that was previously received from a destination is processed by a message consumer/server."
+        brief: >
+          A string identifying the kind of messaging operation.
+        note: If a custom value is used, it MUST be of low cardinality.
+      - id: rabbitmq.destination.routing_key
+        type: string
+        brief: >
+          RabbitMQ message routing key.
+        examples: 'myKey'
+      - id: rocketmq.client_group
+        type: string
+        brief: >
+          Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind.
+        examples: 'myConsumerGroup'
+      - id: rocketmq.consumption_model
+        type:
+          allow_custom_values: false
+          members:
+            - id: clustering
+              value: 'clustering'
+              brief: 'Clustering consumption model'
+            - id: broadcasting
+              value: 'broadcasting'
+              brief: 'Broadcasting consumption model'
+        brief: >
+          Model of message consumption. This only applies to consumer spans.
+      - id: rocketmq.message.delay_time_level
+        type: int
+        brief: >
+          The delay time level for delay message, which determines the message delay time.
+        examples: 3
+      - id: rocketmq.message.delivery_timestamp
+        type: int
+        brief: >
+          The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
+        examples: 1665987217045
+      - id: rocketmq.message.group
+        type: string
+        brief: >
+          It is essential for FIFO message. Messages that belong to the same message group are always processed one by one within the same consumer group.
+        examples: 'myMessageGroup'
+      - id: rocketmq.message.keys
+        type: string[]
+        brief: >
+          Key(s) of message, another way to mark message besides message id.
+        examples: ['keyA', 'keyB']
+      - id: rocketmq.message.tag
+        type: string
+        brief: >
+          The secondary classifier of message besides topic.
+        examples: tagA
+      - id: rocketmq.message.type
+        type:
+          allow_custom_values: false
+          members:
+            - id: normal
+              value: 'normal'
+              brief: "Normal message"
+            - id: fifo
+              value: 'fifo'
+              brief: 'FIFO message'
+            - id: delay
+              value: 'delay'
+              brief: 'Delay message'
+            - id: transaction
+              value: 'transaction'
+              brief: 'Transaction message'
+        brief: >
+          Type of message.
+      - id: rocketmq.namespace
+        type: string
+        brief: >
+          Namespace of RocketMQ resources, resources in different namespaces are individual.
+        examples: 'myNamespace'
+      - id: system
+        type: string
+        brief: 'A string identifying the messaging system.'
+        examples: ['kafka', 'rabbitmq', 'rocketmq', 'activemq', 'AmazonSQS']

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -85,11 +85,6 @@ groups:
           The conversation ID identifying the conversation to which the message belongs,
           represented as a string. Sometimes called "Correlation ID".
         examples: 'MyConversationId'
-        note: |
-          In some messaging systems, a message can receive one or more reply messages that answers a particular other message that was sent earlier.
-          All messages that are grouped together by such a reply-relationship are called a *conversation*.
-          The grouping usually happens through some sort of "In-Reply-To:" meta information or an explicit *conversation ID* (sometimes called *correlation ID*).
-          Sometimes a conversation can span multiple message destinations (e.g. initiated via a topic, continued on a temporary one-to-one queue).
       - id: message.envelope.size
         type: int
         brief: >
@@ -116,13 +111,24 @@ groups:
           members:
             - id: publish
               value: "publish"
-              brief: "A message is sent to a destination by a message producer/client."
+              brief: >
+                One or more messages are provided for publishing to an intermediary.
+                If a single message is published, the context of the "Publish" span can be used as the creation context and no "Create" span needs to be created.
+            - id: create
+              value: "create"
+              brief: >
+                A message is created.
+                "Create" spans always refer to a single message and are used to provide a unique creation context for messages in batch publishing scenarios.
             - id: receive
               value: "receive"
-              brief: "A message is received from a destination by a message consumer/server."
-            - id: process
-              value: "process"
-              brief: "A message that was previously received from a destination is processed by a message consumer/server."
+              brief: >
+                One or more messages are requested by a consumer.
+                This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages.
+            - id: deliver
+              value: "deliver"
+              brief: >
+                One or more messages are passed to a consumer.
+                This operation refers to push-based scenarios, where consumer register callbacks which get called by messaging SDKs.
         brief: >
           A string identifying the kind of messaging operation.
         note: If a custom value is used, it MUST be of low cardinality.

--- a/model/trace/messaging.yaml
+++ b/model/trace/messaging.yaml
@@ -1,39 +1,15 @@
 groups:
   - id: messaging.message
-    prefix: messaging
     type: attribute_group
     brief: 'Semantic convention describing per-message attributes populated on messaging spans or links.'
     attributes:
       - ref: messaging.destination.name
-      - id: message.id
-        type: string
-        brief: 'A value used by the messaging system as an identifier for the message, represented as a string.'
-        examples: '452a7c7c7c7048c2f887f61572b18fc2'
-      - id: message.conversation_id
-        type: string
-        brief: >
-          The [conversation ID](#conversations) identifying the conversation to which the message belongs,
-          represented as a string. Sometimes called "Correlation ID".
-        examples: 'MyConversationId'
-      - id: message.envelope.size
-        type: int
-        brief: >
-          The size of the message body and metadata in bytes.
-        note: |
-          This can refer to both the compressed or uncompressed size. If both sizes are known, the uncompressed
-          size should be used.
-        examples: 2738
-      - id: message.body.size
-        type: int
-        brief: >
-          The size of the message body in bytes.
-        note: |
-          This can refer to both the compressed or uncompressed body size. If both sizes are known, the uncompressed
-          body size should be used.
-        examples: 1439
+      - ref: messaging.message.id
+      - ref: messaging.message.conversation_id
+      - ref: messaging.message.envelope.size
+      - ref: messaging.message.body.size
 
   - id: messaging.destination
-    prefix: messaging.destination
     type: attribute_group
     brief: 'Semantic convention for attributes that describe messaging destination on broker'
     note: |
@@ -46,29 +22,10 @@ groups:
       applies to all messages in the batch.
       In other cases, destination attributes may be set on links.
     attributes:
-      - id: name
-        type: string
-        brief: 'The message destination name'
-        note: |
-          Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
-          the broker doesn't have such notion, the destination name SHOULD uniquely identify the broker.
-        examples: ['MyQueue', 'MyTopic']
-      - id: template
-        type: string
-        brief: Low cardinality representation of the messaging destination name
-        note: >
-          Destination names could be constructed from templates.
-          An example would be a destination name involving a user name or product id.
-          Although the destination name in this case is of high cardinality,
-          the underlying template is of low cardinality and can be effectively
-          used for grouping and aggregation.
-        examples: ['/customers/{customerId}']
-      - id: temporary
-        type: boolean
-        brief: 'A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed.'
-      - id: anonymous
-        type: boolean
-        brief: 'A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).'
+      - ref: messaging.destination.name
+      - ref: messaging.destination.template
+      - ref: messaging.destination.temporary
+      - ref: messaging.destination.anonymous
 
   - id: messaging.destination_publish
     prefix: messaging.destination_publish
@@ -87,61 +44,25 @@ groups:
       applies to all messages in the batch.
       In other cases, destination attributes may be set on links.
     attributes:
-      - id: name
-        type: string
-        brief: 'The name of the original destination the message was published to'
-        note: |
-          The name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
-          the broker doesn't have such notion, the original destination name SHOULD uniquely identify the broker.
-        examples: ['MyQueue', 'MyTopic']
-      - id: anonymous
-        type: boolean
-        brief: 'A boolean that is true if the publish message destination is anonymous (could be unnamed or have auto-generated name).'
+      - ref: messaging.destination_publish.name
+      - ref: messaging.destination_publish.anonymous
 
   - id: messaging
-    prefix: messaging
     type: span
     brief: >
         This document defines general attributes used in
         messaging systems.
     attributes:
-      - id: system
-        type: string
+      - ref: messaging.system
         requirement_level: required
-        brief: 'A string identifying the messaging system.'
-        examples: ['kafka', 'rabbitmq', 'rocketmq', 'activemq', 'AmazonSQS']
-      - id: operation
-        type:
-          allow_custom_values: true
-          members:
-            - id: publish
-              value: "publish"
-            - id: receive
-              value: "receive"
-            - id: process
-              value: "process"
+      - ref: messaging.operation
         requirement_level: required
-        brief: >
-          A string identifying the kind of messaging operation as defined in the
-          [Operation names](#operation-names) section above.
-        note: If a custom value is used, it MUST be of low cardinality.
-      - id: batch.message_count
-        type: int
-        brief: The number of messages sent, received, or processed in the scope of the batching operation.
+      - ref: messaging.batch.message_count
         requirement_level:
           conditionally_required: If the span describes an operation on a batch of messages.
-        note: >
-            Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message.
-            When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD
-            use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
-        examples: [0, 1, 2]
-      - id: client_id
-        type: string
+      - ref: messaging.client_id
         requirement_level:
           recommended: If a client id is available
-        brief: >
-          A unique identifier for the client that consumes or produces a message.
-        examples: ['client-5', 'myhost@8742@s8083jm']
       - ref: messaging.destination.name
         requirement_level:
           conditionally_required: If span describes operation on a single message or if the value applies to all messages in the batch.
@@ -188,136 +109,64 @@ groups:
       - ref: network.protocol.version
 
   - id: messaging.rabbitmq
-    prefix: messaging.rabbitmq
     type: attribute_group
     extends: messaging
     brief: >
       Attributes for RabbitMQ
     attributes:
-      - id: destination.routing_key
-        type: string
+      - ref: messaging.rabbitmq.destination.routing_key
         requirement_level:
           conditionally_required: If not empty.
-        brief: >
-          RabbitMQ message routing key.
-        examples: 'myKey'
+        tag: tech-specific-rabbitmq
 
   - id: messaging.kafka
-    prefix: messaging.kafka
     type: attribute_group
     extends: messaging
     brief: >
       Attributes for Apache Kafka
     attributes:
-      - id: message.key
-        type: string
-        brief: >
-          Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition.
-          They differ from `messaging.message.id` in that they're not unique.
-          If the key is `null`, the attribute MUST NOT be set.
-        note: >
-          If the key type is not string, it's string representation has to be supplied for the attribute.
-          If the key has no unambiguous, canonical string form, don't include its value.
-        examples: 'myKey'
-      - id: consumer.group
-        type: string
-        brief: >
-          Name of the Kafka Consumer Group that is handling the message.
-          Only applies to consumers, not producers.
-        examples: 'my-group'
-      - id: destination.partition
-        type: int
-        brief: >
-          Partition the message is sent to.
-        examples: 2
-      - id: message.offset
-        type: int
-        brief: >
-          The offset of a record in the corresponding Kafka partition.
-        examples: 42
-      - id: message.tombstone
-        type: boolean
+      - ref: messaging.kafka.message.key
+        tag: tech-specific-kafka
+      - ref: messaging.kafka.consumer.group
+        tag: tech-specific-kafka
+      - ref: messaging.kafka.destination.partition
+        tag: tech-specific-kafka
+      - ref: messaging.kafka.message.offset
+        tag: tech-specific-kafka
+      - ref: messaging.kafka.message.tombstone
         requirement_level:
           conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
-        brief: 'A boolean that is true if the message is a tombstone.'
+        tag: tech-specific-kafka
 
   - id: messaging.rocketmq
-    prefix: messaging.rocketmq
     type: attribute_group
     extends: messaging
     brief: >
       Attributes for Apache RocketMQ
     attributes:
-      - id: namespace
-        type: string
+      - ref: messaging.rocketmq.namespace
         requirement_level: required
-        brief: >
-          Namespace of RocketMQ resources, resources in different namespaces are individual.
-        examples: 'myNamespace'
-      - id: client_group
-        type: string
+        tag: tech-specific-rocketmq
+      - ref: messaging.rocketmq.client_group
         requirement_level: required
-        brief: >
-          Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind.
-        examples: 'myConsumerGroup'
-      - id: message.delivery_timestamp
-        type: int
+        tag: tech-specific-rocketmq
+      - ref: messaging.rocketmq.message.delivery_timestamp
         requirement_level:
           conditionally_required: If the message type is delay and delay time level is not specified.
-        brief: >
-          The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
-        examples: 1665987217045
-      - id: message.delay_time_level
-        type: int
+        tag: tech-specific-rocketmq
+      - ref: messaging.rocketmq.message.delay_time_level
         requirement_level:
           conditionally_required: If the message type is delay and delivery timestamp is not specified.
-        brief: >
-          The delay time level for delay message, which determines the message delay time.
-        examples: 3
-      - id: message.group
-        type: string
+        tag: tech-specific-rocketmq
+      - ref: messaging.rocketmq.message.group
         requirement_level:
           conditionally_required: If the message type is FIFO.
-        brief: >
-          It is essential for FIFO message. Messages that belong to the same message group are always processed one by one within the same consumer group.
-        examples: 'myMessageGroup'
-      - id: message.type
-        type:
-          allow_custom_values: false
-          members:
-            - id: normal
-              value: 'normal'
-              brief: "Normal message"
-            - id: fifo
-              value: 'fifo'
-              brief: 'FIFO message'
-            - id: delay
-              value: 'delay'
-              brief: 'Delay message'
-            - id: transaction
-              value: 'transaction'
-              brief: 'Transaction message'
-        brief: >
-          Type of message.
-      - id: message.tag
-        type: string
-        brief: >
-          The secondary classifier of message besides topic.
-        examples: tagA
-      - id: message.keys
-        type: string[]
-        brief: >
-          Key(s) of message, another way to mark message besides message id.
-        examples: ['keyA', 'keyB']
-      - id: consumption_model
-        type:
-          allow_custom_values: false
-          members:
-            - id: clustering
-              value: 'clustering'
-              brief: 'Clustering consumption model'
-            - id: broadcasting
-              value: 'broadcasting'
-              brief: 'Broadcasting consumption model'
-        brief: >
-          Model of message consumption. This only applies to consumer spans.
+        tag: tech-specific-rocketmq
+      - ref: messaging.rocketmq.message.type
+        tag: tech-specific-rocketmq
+      - ref: messaging.rocketmq.message.tag
+        tag: tech-specific-rocketmq
+      - ref: messaging.rocketmq.message.keys
+        tag: tech-specific-rocketmq
+      - ref: messaging.rocketmq.consumption_model
+        tag: tech-specific-rocketmq


### PR DESCRIPTION
Refactoring: moves `messaging.*` attributes to the registry

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes. (N/A)
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions. (N/A)
