### PR TITLE
Remove outdated section in rpc-metrics.md that no longer applies

### DIFF
--- a/docs/rpc/rpc-metrics.md
+++ b/docs/rpc/rpc-metrics.md
@@ -271,10 +271,6 @@ different processes could be listening on TCP port 12345 and UDP port 12345.
 | `connect_rpc` | Connect RPC |
 <!-- endsemconv -->
 
-To avoid high cardinality, implementations should prefer the most stable of `server.address` or
-`server.socket.address`, depending on expected deployment profile.  For many cloud applications, this is likely
-`server.address` as names can be recycled even across re-instantiation of a server with a different `ip`.
-
 For client-side metrics `server.port` is required if the connection is IP-based and the port is available (it describes the server port they are connecting to).
 For server-side spans `server.port` is optional (it describes the port the client is connecting from).
 


### PR DESCRIPTION
## Changes

Removes outdated section in rpc-metrics.md that no longer applies.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* ~[CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.~
* ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~
