### PR TITLE
Change the precedence between `:authority` and `Host` headers when populating `server.address` and `server.port` attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ release.
   ([#413](https://github.com/open-telemetry/semantic-conventions/pull/413))
 - Clarify HTTP server definitions and `server.address|port` notes.
   ([#423](https://github.com/open-telemetry/semantic-conventions/pull/423))
+- Change pthe recedence between `:authority` and `Host` headers when populating
+  `server.address` and `server.port` attributes.
+  ([#455](https://github.com/open-telemetry/semantic-conventions/pull/455))
 
 ## v1.22.0 (2023-10-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ release.
   ([#413](https://github.com/open-telemetry/semantic-conventions/pull/413))
 - Clarify HTTP server definitions and `server.address|port` notes.
   ([#423](https://github.com/open-telemetry/semantic-conventions/pull/423))
-- Change pthe recedence between `:authority` and `Host` headers when populating
+- Change the precedence between `:authority` and `Host` headers when populating
   `server.address` and `server.port` attributes.
   ([#455](https://github.com/open-telemetry/semantic-conventions/pull/455))
 

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -312,8 +312,8 @@ In the context of HTTP server, `server.address` and `server.port` attributes cap
 HTTP server instrumentations SHOULD do the best effort when populating `server.address` and `server.port` attributes and SHOULD determine them by using the first of the following that applies:
 
 * The original host which may be passed by the reverse proxy in the [`Forwarded#host`][Forwarded], [`X-Forwarded-Host`][X-Forwarded-Host], or a similar header.
-* The [`Host`][Host header] header.
 * The [`:authority`][HTTP/2 authority] pseudo-header in case of HTTP/2 or HTTP/3
+* The [`Host`][Host header] header.
 
 > **Note**: The `Host` and `:authority` headers contain host and port number of the server. The same applies to the `host` identifier of `Forwarded` header or the `X-Forwarded-Host` header. Instrumentations SHOULD populate both `server.address` and `server.port` attributes by parsing the value of corresponding header.
 


### PR DESCRIPTION
Fixes #451

## Changes

Changes the precedence between `:authority` and `Host` headers when populating `server.address` and `server.port` attributes.

Included in change log under "Fixes" instead of "Breaking" because we don't expect this to have any difference in practice, see https://github.com/open-telemetry/semantic-conventions/issues/451#issuecomment-1781371555.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~
