### PR TITLE
Rename `http.server.active_requests` metric to `http.server.current_requests`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ release.
   ([#409](https://github.com/open-telemetry/semantic-conventions/pull/409))
 - Remove `url.path` default value.
   ([#462](https://github.com/open-telemetry/semantic-conventions/pull/462))
+- Rename `http.server.active_requests` metric to `http.server.current_requests`.
+  ([#465](https://github.com/open-telemetry/semantic-conventions/pull/465))
 
 ### Features
 

--- a/docs/general/metrics.md
+++ b/docs/general/metrics.md
@@ -236,7 +236,7 @@ implementation detail. Both choices are compliant with this specification.
 When recording `UpDownCounter` metrics, the same attribute values used to record an increment SHOULD be used to record
 any associated decrement, otherwise those increments and decrements will end up as different timeseries.
 
-For example, if you are tracking `active_requests` with an `UpDownCounter`, and you are incrementing it each time a
+For example, if you are tracking `current_requests` with an `UpDownCounter`, and you are incrementing it each time a
 request starts and decrementing it each time a request ends, then any attributes which are not yet available when
 incrementing the counter at request start should not be used when decrementing the counter at request end.
 

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -16,7 +16,7 @@ operations. By adding HTTP attributes to metric events it allows for finely tune
 
 - [HTTP Server](#http-server)
   * [Metric: `http.server.request.duration`](#metric-httpserverrequestduration)
-  * [Metric: `http.server.active_requests`](#metric-httpserveractive_requests)
+  * [Metric: `http.server.current_requests`](#metric-httpservercurrent_requests)
   * [Metric: `http.server.request.body.size`](#metric-httpserverrequestbodysize)
   * [Metric: `http.server.response.body.size`](#metric-httpserverresponsebodysize)
 - [HTTP Client](#http-client)
@@ -159,19 +159,19 @@ SHOULD include the [application root](/docs/http/http-spans.md#http-server-defin
 | `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. |
 <!-- endsemconv -->
 
-### Metric: `http.server.active_requests`
+### Metric: `http.server.current_requests`
 
 **Status**: [Experimental][DocumentStatus]
 
 This metric is optional.
 
-<!-- semconv metric.http.server.active_requests(metric_table) -->
+<!-- semconv metric.http.server.current_requests(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `http.server.active_requests` | UpDownCounter | `{request}` | Number of active HTTP server requests. |
+| `http.server.current_requests` | UpDownCounter | `{request}` | Number of current HTTP server requests. |
 <!-- endsemconv -->
 
-<!-- semconv metric.http.server.active_requests(full) -->
+<!-- semconv metric.http.server.current_requests(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -35,10 +35,10 @@ groups:
     unit: "s"
     extends: metric_attributes.http.server
 
-  - id: metric.http.server.active_requests
+  - id: metric.http.server.current_requests
     type: metric
-    metric_name: http.server.active_requests
-    brief: "Number of active HTTP server requests."
+    metric_name: http.server.current_requests
+    brief: "Number of current HTTP server requests."
     instrument: updowncounter
     unit: "{request}"
     attributes:

--- a/schema-next.yaml
+++ b/schema-next.yaml
@@ -10,6 +10,9 @@ versions:
               thread.daemon: jvm.thread.daemon
             apply_to_metrics:
               - jvm.thread.count
+        # https://github.com/open-telemetry/semantic-conventions/pull/465
+        - rename_metrics:
+            http.server.active_requests: http.server.current_requests
   1.22.0:
     spans:
       changes:


### PR DESCRIPTION
Fixes #202

~Note: this metric is not (currently) in our initial stability plan, but I'm wondering now if it should be, so that this breaking change can be covered by the `OTEL_SEMCONV_STABILITY_OPT_IN` flag.~

EDIT: Nevermind, closing this PR, I think the naming convention here is still unclear. It would be good to have consistency across:

* `jvm.thread.count`
* `jvm.class.count`
* `http.server.current_requests`

which ties into #211 and https://github.com/open-telemetry/semantic-conventions/issues/260#issuecomment-1682527312.

## Changes

Renames `http.server.active_requests` metric to `http.server.current_requests`.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
