### PR TITLE
Fix lint warning

### DIFF
--- a/model/registry/http.yaml
+++ b/model/registry/http.yaml
@@ -11,7 +11,7 @@ groups:
           is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)
           header. For requests using transport encoding, this should be the compressed size.
         examples: 3495
-        stability: experimental # this should not be marked stable with other HTTP attributes
+        stability: experimental  # this should not be marked stable with other HTTP attributes
       - id: request.header
         type: template[string[]]
         brief: >
@@ -98,7 +98,7 @@ groups:
           is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length)
           header. For requests using transport encoding, this should be the compressed size.
         examples: 3495
-        stability: experimental # this should not be marked stable with other HTTP attributes
+        stability: experimental  # this should not be marked stable with other HTTP attributes
       - id: response.header
         type: template[string[]]
         brief: >


### PR DESCRIPTION
Fixes lint warning.

See https://github.com/open-telemetry/semantic-conventions/pull/472#pullrequestreview-1704658579

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* ~[CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.~
* ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~
