### PR TITLE
docs: explain deployment.environment impact on service identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ release.
 
 ## Unreleased
 
- - Explain `deployment.environment` impact on service identity. ([#481](https://github.com/open-telemetry/semantic-conventions/pull/481))
-
 ### Breaking
 
 - BREAKING: Rename http.resend_count to http.request.resend_count.
@@ -82,6 +80,7 @@ release.
 - Change the precedence between `:authority` and `Host` headers when populating
   `server.address` and `server.port` attributes.
   ([#455](https://github.com/open-telemetry/semantic-conventions/pull/455))
+- Explain `deployment.environment` impact on service identity. ([#481](https://github.com/open-telemetry/semantic-conventions/pull/481))
 
 ## v1.22.0 (2023-10-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ release.
 
 ## Unreleased
 
+ - Explain `deployment.environment` impact on service identity. ([#481](https://github.com/open-telemetry/semantic-conventions/pull/481))
+
 ### Breaking
 
 - BREAKING: Rename http.resend_count to http.request.resend_count.

--- a/docs/resource/deployment-environment.md
+++ b/docs/resource/deployment-environment.md
@@ -9,7 +9,15 @@
 <!-- semconv deployment -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `deployment.environment` | string | Name of the [deployment environment](https://wikipedia.org/wiki/Deployment_environment) (aka deployment tier). | `staging`; `production` | Recommended |
+| `deployment.environment` | string | Name of the [deployment environment](https://wikipedia.org/wiki/Deployment_environment) (aka deployment tier). [1] | `staging`; `production` | Recommended |
+
+**[1]:** `deployment.environment` does not affect the uniqueness constraints defined through
+the `service.namespace`, `service.name` and `service.instance.id` resource attributes.
+This implies that resources carrying the following attribute combinations MUST be
+considered to be identifying the same service:
+
+* `service.name=frontend`, `deployment.environment=production`
+* `service.name=frontend`, `deployment.environment=staging`.
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/model/resource/deployment_environment.yaml
+++ b/model/resource/deployment_environment.yaml
@@ -10,12 +10,12 @@ groups:
         brief: >
           Name of the [deployment environment](https://wikipedia.org/wiki/Deployment_environment)
           (aka deployment tier).
-        note: >
+        note: |
           `deployment.environment` does not affect the uniqueness constraints defined through
           the `service.namespace`, `service.name` and `service.instance.id` resource attributes.
           This implies that resources carrying the following attribute combinations MUST be
           considered to be identifying the same service:
-          
-           - `service.name=frontend`, `deployment.environment=production`
-           - `service.name=frontend`, `deployment.environment=staging`.
+
+          * `service.name=frontend`, `deployment.environment=production`
+          * `service.name=frontend`, `deployment.environment=staging`.
         examples: ['staging', 'production']

--- a/model/resource/deployment_environment.yaml
+++ b/model/resource/deployment_environment.yaml
@@ -10,4 +10,12 @@ groups:
         brief: >
           Name of the [deployment environment](https://wikipedia.org/wiki/Deployment_environment)
           (aka deployment tier).
+        note: >
+          `deployment.environment` does not affect the uniqueness constraints defined through
+          the `service.namespace`, `service.name` and `service.instance.id` resource attributes.
+          This implies that resources carrying the following attribute combinations MUST be
+          considered to be identifying the same service:
+          
+           - `service.name=frontend`, `deployment.environment=production`
+           - `service.name=frontend`, `deployment.environment=staging`.
         examples: ['staging', 'production']


### PR DESCRIPTION
# Why

To clarify a likely misconception about service identity in the case of multiple environments.

# What

Explain that `deployment.environment` does not impact service identity.

# References

Fixes https://github.com/open-telemetry/semantic-conventions/issues/119

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
