### PR TITLE
Change sampling relevant from MUST to SHOULD (and update build-tools version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ release.
   ([#478](https://github.com/open-telemetry/semantic-conventions/pull/478))
 - Remove outdated `http.request.header.host` guidance
   ([#479](https://github.com/open-telemetry/semantic-conventions/pull/479))
+- Change sampling relevant from `MUST` to `SHOULD`
+  ([#486](https://github.com/open-telemetry/semantic-conventions/pull/486))
 
 ### Features
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MISSPELL = $(TOOLS_DIR)/$(MISSPELL_BINARY)
 
 # see https://github.com/open-telemetry/build-tools/releases for semconvgen updates
 # Keep links in model/README.md and .vscode/settings.json in sync!
-SEMCONVGEN_VERSION=0.22.0
+SEMCONVGEN_VERSION=0.23.0
 
 # TODO: add `yamllint` step to `all` after making sure it works on Mac.
 .PHONY: all

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -180,7 +180,7 @@ The attribute value MUST consist of either multiple header values as an array of
 
 **[9]:** Generally `tcp` for `HTTP/1.0`, `HTTP/1.1`, and `HTTP/2`. Generally `udp` for `HTTP/3`. Other obscure implementations are possible.
 
-Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
+The following attributes can be important for making sampling decisions and SHOULD be provided **at span creation time** (if provided at all):
 
 * [`http.request.method`](../attributes-registry/http.md)
 
@@ -249,7 +249,7 @@ For an HTTP client span, `SpanKind` MUST be `Client`.
 `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password SHOULD be redacted and attribute's value SHOULD be `https://REDACTED:REDACTED@www.example.com/`.
 `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
 
-Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
+The following attributes can be important for making sampling decisions and SHOULD be provided **at span creation time** (if provided at all):
 
 * [`server.address`](../general/attributes.md)
 * [`server.port`](../general/attributes.md)
@@ -366,7 +366,7 @@ SHOULD include the [application root](/docs/http/http-spans.md#http-server-defin
 
 **[7]:** The scheme of the original client request, if known (e.g. from [Forwarded#proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/Forwarded#proto), [X-Forwarded-Proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Forwarded-Proto), or a similar header). Otherwise, the scheme of the immediate peer request.
 
-Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
+The following attributes can be important for making sampling decisions and SHOULD be provided **at span creation time** (if provided at all):
 
 * [`client.address`](../general/attributes.md)
 * [`server.address`](../general/attributes.md)

--- a/internal/tools/schema_check.sh
+++ b/internal/tools/schema_check.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-BUILD_TOOL_SCHEMAS_VERSION=0.22.0
+BUILD_TOOL_SCHEMAS_VERSION=0.23.0
 
 # List of versions that do not require or have a schema.
 declare -a skip_versions=("1.0.0" "1.0.1" "1.1.0" "1.2.0" "1.3.0" "1.6.0")

--- a/model/README.md
+++ b/model/README.md
@@ -14,12 +14,12 @@ Semantic conventions for the spec MUST adhere to the
 [attribute requirement level](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/common/attribute-requirement-level.md),
 and [metric requirement level](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/metrics/metric-requirement-level.md) conventions.
 
-Refer to the [syntax](https://github.com/open-telemetry/build-tools/tree/v0.22.0/semantic-conventions/syntax.md)
+Refer to the [syntax](https://github.com/open-telemetry/build-tools/tree/v0.23.0/semantic-conventions/syntax.md)
 for how to write the YAML files for semantic conventions and what the YAML properties mean.
 
 A schema file for VS code is configured in the `/.vscode/settings.json` of this
 repository, enabling auto-completion and additional checks. Refer to
-[the generator README](https://github.com/open-telemetry/build-tools/tree/v0.22.0/semantic-conventions/README.md) for what extension you need.
+[the generator README](https://github.com/open-telemetry/build-tools/tree/v0.23.0/semantic-conventions/README.md) for what extension you need.
 
 ## Generating markdown
 
@@ -30,7 +30,7 @@ formatted Markdown tables for all semantic conventions in the specification. Run
 make table-generation
 ```
 
-For more information, see the [semantic convention generator](https://github.com/open-telemetry/build-tools/tree/v0.22.0/semantic-conventions)
+For more information, see the [semantic convention generator](https://github.com/open-telemetry/build-tools/tree/v0.23.0/semantic-conventions)
 in the OpenTelemetry build tools repository.
 Using this build tool, it is also possible to generate code for use in OpenTelemetry
 language projects.


### PR DESCRIPTION
Follow-up to https://github.com/open-telemetry/build-tools/pull/230

Fixes #422

## Changes

Change sampling relevant from `MUST` to `SHOULD`.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~
