### PR TITLE
Staging the 1.23.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ release.
 
 ### Breaking
 
+### Features
+
+### Fixes
+
+## v1.23.0 (2023-11-03)
+
+This release marks the first where the core of HTTP semantic conventions have
+stabilized.
+
+### Breaking
+
 - BREAKING: Rename http.resend_count to http.request.resend_count.
   ([#374](https://github.com/open-telemetry/semantic-conventions/pull/374))
 - BREAKING: Change `network.protocol.name` from recommended to opt-in in HTTP semconv.

--- a/schemas/1.23.0
+++ b/schemas/1.23.0
@@ -1,5 +1,5 @@
 file_format: 1.1.0
-schema_url: https://opentelemetry.io/schemas/next
+schema_url: https://opentelemetry.io/schemas/1.23.0
 versions:
   1.23.0:
     metrics:

--- a/schemas/1.23.0
+++ b/schemas/1.23.0
@@ -1,7 +1,6 @@
 file_format: 1.1.0
 schema_url: https://opentelemetry.io/schemas/next
 versions:
-  next:
   1.23.0:
     metrics:
       changes:


### PR DESCRIPTION
This marks the stability release for HTTP.

Post-this-PR we will not allow "breaking" changes to HTTP attributes marked stable, as they are no longer covered by the transition.