### PR TITLE
change Erlang managed thread attribute to be the Erlang process

### DIFF
--- a/docs/general/attributes.md
+++ b/docs/general/attributes.md
@@ -364,14 +364,14 @@ a thread that started a span.
 
 Examples of where `thread.id` and `thread.name` can be extracted from:
 
-| Language or platform | `thread.id`                            | `thread.name`                      |
-|-----------------------|----------------------------------------|------------------------------------|
-| JVM                   | `Thread.currentThread().getId()`       | `Thread.currentThread().getName()` |
-| .NET                  | `Thread.CurrentThread.ManagedThreadId` | `Thread.CurrentThread.Name`        |
-| Python                | `threading.current_thread().ident`     | `threading.current_thread().name`  |
-| Ruby                  | `Thread.current.object_id`             | `Thread.current.name`              |
-| C++                   | `std::this_thread::get_id()`             |                                    |
-| Erlang               | `erlang:system_info(scheduler_id)` |                                  |
+| Language or platform  | `thread.id`                            | `thread.name`                                  |
+|-----------------------|----------------------------------------|------------------------------------------------|
+| JVM                   | `Thread.currentThread().getId()`       | `Thread.currentThread().getName()`             |
+| .NET                  | `Thread.CurrentThread.ManagedThreadId` | `Thread.CurrentThread.Name`                    |
+| Python                | `threading.current_thread().ident`     | `threading.current_thread().name`              |
+| Ruby                  | `Thread.current.object_id`             | `Thread.current.name`                          |
+| C++                   | `std::this_thread::get_id()`           |                                                |
+| Erlang                | `erlang:self()`                        | `erlang:process_info(self(), registered_name)` |
 
 ## Source Code Attributes
 


### PR DESCRIPTION
When a PR to add these attributes to otel Erlang/Elixir was opened it was pointed out the example is wrong and to match the other examples of what a "managed" thread is this should be the Erlang process id and not the scheduler id which is an OS thread.

## Changes

Since this is just an example change I haven't added it to the changelog. Happy to add one.

## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
