### PR TITLE
Move OS attributes to the registry

### DIFF
--- a/docs/attributes-registry/README.md
+++ b/docs/attributes-registry/README.md
@@ -37,6 +37,7 @@ Currently, the following namespaces exist:
 * [HTTP](http.md)
 * [Network](network.md)
 * [OCI](oci.md)
+* [OS](os.md)
 * [Process](process.md)
 * [RPC](rpc.md)
 * [Server](server.md)

--- a/docs/attributes-registry/os.md
+++ b/docs/attributes-registry/os.md
@@ -1,0 +1,37 @@
+# Operating System
+
+**Status**: [Experimental][DocumentStatus]
+
+**type:** `os`
+
+**Description**: The operating system (OS) on which the process represented by this resource is running.
+
+In case of virtualized environments, this is the operating system as it is observed by the process, i.e., the virtualized guest rather than the underlying host.
+
+<!-- semconv registry.os -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `os.build_id` | string | Unique identifier for a particular build or compilation of the operating system. | `TQ3C.230805.001.B2`; `20E247`; `22621` | Recommended |
+| `os.description` | string | Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands. | `Microsoft Windows [Version 10.0.18363.778]`; `Ubuntu 18.04.1 LTS` | Recommended |
+| `os.name` | string | Human readable operating system name. | `iOS`; `Android`; `Ubuntu` | Recommended |
+| `os.type` | string | The operating system type. | `windows` | Required |
+| `os.version` | string | The version string of the operating system as defined in [Version Attributes](/docs/resource/README.md#version-attributes). | `14.2.1`; `18.04.1` | Recommended |
+
+`os.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `windows` | Microsoft Windows |
+| `linux` | Linux |
+| `darwin` | Apple Darwin |
+| `freebsd` | FreeBSD |
+| `netbsd` | NetBSD |
+| `openbsd` | OpenBSD |
+| `dragonflybsd` | DragonFly BSD |
+| `hpux` | HP-UX (Hewlett Packard Unix) |
+| `aix` | AIX (Advanced Interactive eXecutive) |
+| `solaris` | SunOS, Oracle Solaris |
+| `z_os` | IBM z/OS |
+<!-- endsemconv -->
+
+[DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/docs/resource/os.md
+++ b/docs/resource/os.md
@@ -11,27 +11,11 @@ In case of virtualized environments, this is the operating system as it is obser
 <!-- semconv os -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `os.build_id` | string | Unique identifier for a particular build or compilation of the operating system. | `TQ3C.230805.001.B2`; `20E247`; `22621` | Recommended |
-| `os.description` | string | Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands. | `Microsoft Windows [Version 10.0.18363.778]`; `Ubuntu 18.04.1 LTS` | Recommended |
-| `os.name` | string | Human readable operating system name. | `iOS`; `Android`; `Ubuntu` | Recommended |
-| `os.type` | string | The operating system type. | `windows` | Required |
-| `os.version` | string | The version string of the operating system as defined in [Version Attributes](/docs/resource/README.md#version-attributes). | `14.2.1`; `18.04.1` | Recommended |
-
-`os.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `windows` | Microsoft Windows |
-| `linux` | Linux |
-| `darwin` | Apple Darwin |
-| `freebsd` | FreeBSD |
-| `netbsd` | NetBSD |
-| `openbsd` | OpenBSD |
-| `dragonflybsd` | DragonFly BSD |
-| `hpux` | HP-UX (Hewlett Packard Unix) |
-| `aix` | AIX (Advanced Interactive eXecutive) |
-| `solaris` | SunOS, Oracle Solaris |
-| `z_os` | IBM z/OS |
+| [`os.build_id`](../attributes-registry/os.md) | string | Unique identifier for a particular build or compilation of the operating system. | `TQ3C.230805.001.B2`; `20E247`; `22621` | Recommended |
+| [`os.description`](../attributes-registry/os.md) | string | Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands. | `Microsoft Windows [Version 10.0.18363.778]`; `Ubuntu 18.04.1 LTS` | Recommended |
+| [`os.name`](../attributes-registry/os.md) | string | Human readable operating system name. | `iOS`; `Android`; `Ubuntu` | Recommended |
+| [`os.type`](../attributes-registry/os.md) | string | The operating system type. | `windows` | Required |
+| [`os.version`](../attributes-registry/os.md) | string | The version string of the operating system as defined in [Version Attributes](/docs/resource/README.md#version-attributes). | `14.2.1`; `18.04.1` | Recommended |
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/model/registry/os.yaml
+++ b/model/registry/os.yaml
@@ -1,0 +1,69 @@
+groups:
+  - id: registry.os
+    prefix: os
+    type: resource
+    brief: >
+        The operating system (OS) on which the process represented by this resource is running.
+    note: >
+        In case of virtualized environments, this is the operating system as it is observed by
+        the process, i.e., the virtualized guest rather than the underlying host.
+    attributes:
+      - id: type
+        type:
+          allow_custom_values: true
+          members:
+            - id: windows
+              value: 'windows'
+              brief: "Microsoft Windows"
+            - id: linux
+              value: 'linux'
+              brief: "Linux"
+            - id: darwin
+              value: 'darwin'
+              brief: "Apple Darwin"
+            - id: freebsd
+              value: 'freebsd'
+              brief: "FreeBSD"
+            - id: netbsd
+              value: 'netbsd'
+              brief: "NetBSD"
+            - id: openbsd
+              value: 'openbsd'
+              brief: "OpenBSD"
+            - id: dragonflybsd
+              value: 'dragonflybsd'
+              brief: "DragonFly BSD"
+            - id: hpux
+              value: 'hpux'
+              brief: "HP-UX (Hewlett Packard Unix)"
+            - id: aix
+              value: 'aix'
+              brief: "AIX (Advanced Interactive eXecutive)"
+            - id: solaris
+              value: 'solaris'
+              brief: "SunOS, Oracle Solaris"
+            - id: z_os
+              value: 'z_os'
+              brief: "IBM z/OS"
+        requirement_level: required
+        brief: 'The operating system type.'
+      - id: description
+        type: string
+        brief: >
+          Human readable (not intended to be parsed) OS version information,
+          like e.g. reported by `ver` or `lsb_release -a` commands.
+        examples: ['Microsoft Windows [Version 10.0.18363.778]', 'Ubuntu 18.04.1 LTS']
+      - id: name
+        type: string
+        brief: 'Human readable operating system name.'
+        examples: ['iOS', 'Android', 'Ubuntu']
+      - id: version
+        type: string
+        brief: >
+          The version string of the operating system as defined in
+          [Version Attributes](/docs/resource/README.md#version-attributes).
+        examples: ['14.2.1', '18.04.1']
+      - id: build_id
+        type: string
+        brief: 'Unique identifier for a particular build or compilation of the operating system.'
+        examples: ['TQ3C.230805.001.B2', '20E247', '22621']

--- a/model/resource/os.yaml
+++ b/model/resource/os.yaml
@@ -8,62 +8,9 @@ groups:
         In case of virtualized environments, this is the operating system as it is observed by
         the process, i.e., the virtualized guest rather than the underlying host.
     attributes:
-      - id: type
-        type:
-          allow_custom_values: true
-          members:
-            - id: windows
-              value: 'windows'
-              brief: "Microsoft Windows"
-            - id: linux
-              value: 'linux'
-              brief: "Linux"
-            - id: darwin
-              value: 'darwin'
-              brief: "Apple Darwin"
-            - id: freebsd
-              value: 'freebsd'
-              brief: "FreeBSD"
-            - id: netbsd
-              value: 'netbsd'
-              brief: "NetBSD"
-            - id: openbsd
-              value: 'openbsd'
-              brief: "OpenBSD"
-            - id: dragonflybsd
-              value: 'dragonflybsd'
-              brief: "DragonFly BSD"
-            - id: hpux
-              value: 'hpux'
-              brief: "HP-UX (Hewlett Packard Unix)"
-            - id: aix
-              value: 'aix'
-              brief: "AIX (Advanced Interactive eXecutive)"
-            - id: solaris
-              value: 'solaris'
-              brief: "SunOS, Oracle Solaris"
-            - id: z_os
-              value: 'z_os'
-              brief: "IBM z/OS"
+      - ref: os.type
         requirement_level: required
-        brief: 'The operating system type.'
-      - id: description
-        type: string
-        brief: >
-          Human readable (not intended to be parsed) OS version information,
-          like e.g. reported by `ver` or `lsb_release -a` commands.
-        examples: ['Microsoft Windows [Version 10.0.18363.778]', 'Ubuntu 18.04.1 LTS']
-      - id: name
-        type: string
-        brief: 'Human readable operating system name.'
-        examples: ['iOS', 'Android', 'Ubuntu']
-      - id: version
-        type: string
-        brief: >
-          The version string of the operating system as defined in
-          [Version Attributes](/docs/resource/README.md#version-attributes).
-        examples: ['14.2.1', '18.04.1']
-      - id: build_id
-        type: string
-        brief: 'Unique identifier for a particular build or compilation of the operating system.'
-        examples: ['TQ3C.230805.001.B2', '20E247', '22621']
+      - ref: os.description
+      - ref: os.name
+      - ref: os.version
+      - ref: os.build_id


### PR DESCRIPTION
## Changes

Refactoring: move OS namespace to the registry

Part of https://github.com/open-telemetry/semantic-conventions/issues/407

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] ~~[CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.~~
* [ ] ~~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~~
