### PR TITLE
Changed `messaging.system` attribute type to an open enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ release.
   ([#317](https://github.com/open-telemetry/semantic-conventions/pull/317))
 - BREAKING: Change type of `host.cpu.model.id` and `host.cpu.model.family` to string.
   ([#495](https://github.com/open-telemetry/semantic-conventions/issues/495))
+- Changed `messaging.system` attribute type to an open enum
+  ([#517](https://github.com/open-telemetry/semantic-conventions/pull/517))
 
 ### Features
 

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -36,7 +36,7 @@
 | `messaging.rocketmq.message.tag` | string | The secondary classifier of message besides topic. | `tagA` |
 | `messaging.rocketmq.message.type` | string | Type of message. | `normal` |
 | `messaging.rocketmq.namespace` | string | Namespace of RocketMQ resources, resources in different namespaces are individual. | `myNamespace` |
-| `messaging.system` | string | A string identifying the messaging system. | `kafka`; `rabbitmq`; `rocketmq`; `activemq` |
+| `messaging.system` | string | An identifier for the messaging system being used. See below for a list of well-known identifiers. | `activemq` |
 
 **[1]:** Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
 
@@ -82,4 +82,16 @@ size should be used.
 | `fifo` | FIFO message |
 | `delay` | Delay message |
 | `transaction` | Transaction message |
+
+`messaging.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `activemq` | ActiveMQ |
+| `AmazonSQS` | Amazon Simple Queue Service (SQS) |
+| `gcp_pubsub` | Google Cloud Pub/Sub |
+| `jms` | Java Message Service |
+| `kafka` | Kafka |
+| `rabbitmq` | RabbitMQ |
+| `rocketmq` | RocketMQ |
 <!-- endsemconv -->

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -89,6 +89,9 @@ size should be used.
 |---|---|
 | `activemq` | Apache ActiveMQ |
 | `aws_sqs` | Amazon Simple Queue Service (SQS) |
+| `azure_eventgrid` | Azure Event Grid |
+| `azure_eventhubs` | Azure Event Hubs |
+| `azure_servicebus` | Azure Service Bus |
 | `gcp_pubsub` | Google Cloud Pub/Sub |
 | `jms` | Java Message Service |
 | `kafka` | Apache Kafka |

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -87,11 +87,11 @@ size should be used.
 
 | Value  | Description |
 |---|---|
-| `activemq` | ActiveMQ |
+| `activemq` | Apache ActiveMQ |
 | `AmazonSQS` | Amazon Simple Queue Service (SQS) |
 | `gcp_pubsub` | Google Cloud Pub/Sub |
 | `jms` | Java Message Service |
-| `kafka` | Kafka |
+| `kafka` | Apache Kafka |
 | `rabbitmq` | RabbitMQ |
-| `rocketmq` | RocketMQ |
+| `rocketmq` | Apache RocketMQ |
 <!-- endsemconv -->

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -88,7 +88,7 @@ size should be used.
 | Value  | Description |
 |---|---|
 | `activemq` | Apache ActiveMQ |
-| `AmazonSQS` | Amazon Simple Queue Service (SQS) |
+| `amazon_sqs` | Amazon Simple Queue Service (SQS) |
 | `gcp_pubsub` | Google Cloud Pub/Sub |
 | `jms` | Java Message Service |
 | `kafka` | Apache Kafka |

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -88,7 +88,7 @@ size should be used.
 | Value  | Description |
 |---|---|
 | `activemq` | Apache ActiveMQ |
-| `amazon_sqs` | Amazon Simple Queue Service (SQS) |
+| `aws_sqs` | Amazon Simple Queue Service (SQS) |
 | `gcp_pubsub` | Google Cloud Pub/Sub |
 | `jms` | Java Message Service |
 | `kafka` | Apache Kafka |

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -358,6 +358,9 @@ different processes could be listening on TCP port 12345 and UDP port 12345.
 |---|---|
 | `activemq` | Apache ActiveMQ |
 | `aws_sqs` | Amazon Simple Queue Service (SQS) |
+| `azure_eventgrid` | Azure Event Grid |
+| `azure_eventhubs` | Azure Event Hubs |
+| `azure_servicebus` | Azure Service Bus |
 | `gcp_pubsub` | Google Cloud Pub/Sub |
 | `jms` | Java Message Service |
 | `kafka` | Apache Kafka |

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -357,7 +357,7 @@ different processes could be listening on TCP port 12345 and UDP port 12345.
 | Value  | Description |
 |---|---|
 | `activemq` | Apache ActiveMQ |
-| `AmazonSQS` | Amazon Simple Queue Service (SQS) |
+| `amazon_sqs` | Amazon Simple Queue Service (SQS) |
 | `gcp_pubsub` | Google Cloud Pub/Sub |
 | `jms` | Java Message Service |
 | `kafka` | Apache Kafka |

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -357,7 +357,7 @@ different processes could be listening on TCP port 12345 and UDP port 12345.
 | Value  | Description |
 |---|---|
 | `activemq` | Apache ActiveMQ |
-| `amazon_sqs` | Amazon Simple Queue Service (SQS) |
+| `aws_sqs` | Amazon Simple Queue Service (SQS) |
 | `gcp_pubsub` | Google Cloud Pub/Sub |
 | `jms` | Java Message Service |
 | `kafka` | Apache Kafka |

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -287,7 +287,7 @@ messages were received). For each message it accounts for, the "Deliver" or
 | [`messaging.message.envelope.size`](../attributes-registry/messaging.md) | int | The size of the message body and metadata in bytes. [12] | `2738` | Recommended: [13] |
 | [`messaging.message.id`](../attributes-registry/messaging.md) | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | Recommended: [14] |
 | [`messaging.operation`](../attributes-registry/messaging.md) | string | A string identifying the kind of messaging operation. [15] | `publish` | Required |
-| [`messaging.system`](../attributes-registry/messaging.md) | string | A string identifying the messaging system. | `kafka`; `rabbitmq`; `rocketmq`; `activemq` | Required |
+| [`messaging.system`](../attributes-registry/messaging.md) | string | An identifier for the messaging system being used. See below for a list of well-known identifiers. | `activemq` | Required |
 | [`network.peer.address`](../attributes-registry/network.md) | string | Peer address of the network connection - IP address or Unix domain socket name. | `10.1.2.80`; `/tmp/my.sock` | Recommended |
 | [`network.peer.port`](../attributes-registry/network.md) | int | Peer port number of the network connection. | `65123` | Recommended: If `network.peer.address` is set. |
 | [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [16] | `amqp`; `mqtt` | Recommended |
@@ -351,6 +351,18 @@ different processes could be listening on TCP port 12345 and UDP port 12345.
 | `create` | A message is created. "Create" spans always refer to a single message and are used to provide a unique creation context for messages in batch publishing scenarios. |
 | `receive` | One or more messages are requested by a consumer. This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages. |
 | `deliver` | One or more messages are passed to a consumer. This operation refers to push-based scenarios, where consumer register callbacks which get called by messaging SDKs. |
+
+`messaging.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `activemq` | ActiveMQ |
+| `AmazonSQS` | Amazon Simple Queue Service (SQS) |
+| `gcp_pubsub` | Google Cloud Pub/Sub |
+| `jms` | Java Message Service |
+| `kafka` | Kafka |
+| `rabbitmq` | RabbitMQ |
+| `rocketmq` | RocketMQ |
 
 `network.transport` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -356,13 +356,13 @@ different processes could be listening on TCP port 12345 and UDP port 12345.
 
 | Value  | Description |
 |---|---|
-| `activemq` | ActiveMQ |
+| `activemq` | Apache ActiveMQ |
 | `AmazonSQS` | Amazon Simple Queue Service (SQS) |
 | `gcp_pubsub` | Google Cloud Pub/Sub |
 | `jms` | Java Message Service |
-| `kafka` | Kafka |
+| `kafka` | Apache Kafka |
 | `rabbitmq` | RabbitMQ |
-| `rocketmq` | RocketMQ |
+| `rocketmq` | Apache RocketMQ |
 
 `network.transport` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -210,7 +210,7 @@ groups:
           members:
             - id: activemq
               value: 'activemq'
-              brief: 'ActiveMQ'
+              brief: 'Apache ActiveMQ'
             - id: amazonsqs
               value: 'AmazonSQS'
               brief: 'Amazon Simple Queue Service (SQS)'
@@ -222,10 +222,10 @@ groups:
               brief: 'Java Message Service'
             - id: kafka
               value: 'kafka'
-              brief: 'Kafka'
+              brief: 'Apache Kafka'
             - id: rabbitmq
               value: 'rabbitmq'
               brief: 'RabbitMQ'
             - id: rocketmq
               value: 'rocketmq'
-              brief: 'RocketMQ'
+              brief: 'Apache RocketMQ'

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -203,6 +203,29 @@ groups:
           Namespace of RocketMQ resources, resources in different namespaces are individual.
         examples: 'myNamespace'
       - id: system
-        type: string
-        brief: 'A string identifying the messaging system.'
-        examples: ['kafka', 'rabbitmq', 'rocketmq', 'activemq']
+        brief: >
+          An identifier for the messaging system being used. See below for a list of well-known identifiers.
+        type:
+          allow_custom_values: true
+          members:
+            - id: activemq
+              value: 'activemq'
+              brief: 'ActiveMQ'
+            - id: amazonsqs
+              value: 'AmazonSQS'
+              brief: 'Amazon Simple Queue Service (SQS)'
+            - id: gcp_pubsub
+              value: 'gcp_pubsub'
+              brief: 'Google Cloud Pub/Sub'
+            - id: jms
+              value: 'jms'
+              brief: 'Java Message Service'
+            - id: kafka
+              value: 'kafka'
+              brief: 'Kafka'
+            - id: rabbitmq
+              value: 'rabbitmq'
+              brief: 'RabbitMQ'
+            - id: rocketmq
+              value: 'rocketmq'
+              brief: 'RocketMQ'

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -211,8 +211,8 @@ groups:
             - id: activemq
               value: 'activemq'
               brief: 'Apache ActiveMQ'
-            - id: amazonsqs
-              value: 'AmazonSQS'
+            - id: amazon_sqs
+              value: 'amazon_sqs'
               brief: 'Amazon Simple Queue Service (SQS)'
             - id: gcp_pubsub
               value: 'gcp_pubsub'

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -214,6 +214,15 @@ groups:
             - id: aws_sqs
               value: 'aws_sqs'
               brief: 'Amazon Simple Queue Service (SQS)'
+            - id: azure_eventgrid
+              value: 'azure_eventgrid'
+              brief: 'Azure Event Grid'
+            - id: azure_eventhubs
+              value: 'azure_eventhubs'
+              brief: 'Azure Event Hubs'
+            - id: azure_servicebus
+              value: 'azure_servicebus'
+              brief: 'Azure Service Bus'
             - id: gcp_pubsub
               value: 'gcp_pubsub'
               brief: 'Google Cloud Pub/Sub'

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -211,8 +211,8 @@ groups:
             - id: activemq
               value: 'activemq'
               brief: 'Apache ActiveMQ'
-            - id: amazon_sqs
-              value: 'amazon_sqs'
+            - id: aws_sqs
+              value: 'aws_sqs'
               brief: 'Amazon Simple Queue Service (SQS)'
             - id: gcp_pubsub
               value: 'gcp_pubsub'


### PR DESCRIPTION
## Changes

Follow-up from https://github.com/open-telemetry/semantic-conventions/pull/490#discussion_r1391129817

For consistency with `database.system` changing the `messaging.system` attribute type from string to enum. This also helps with documenting well-known values to be used for different messaging systems.


## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
