### PR TITLE
docs(messaging): move activemq to its on doc and update the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ release.
   ([#503](https://github.com/open-telemetry/semantic-conventions/pull/503))
 - Add Semantic conventions for TLS/SSL encrypted communication.
   ([#21](https://github.com/open-telemetry/semantic-conventions/pull/21))
+- Add `gcp_pubsub` value for messaging system
+  ([#490](https://github.com/open-telemetry/semantic-conventions/pull/490))
 
 ### Fixes
 
@@ -118,7 +120,7 @@ stabilized.
 
 - Remove experimental Kafka metrics ([#338](https://github.com/open-telemetry/semantic-conventions/pull/338))
 - Adds `session.id` and session.md to general docs and model
-([#215](https://github.com/open-telemetry/semantic-conventions/pull/215))
+  ([#215](https://github.com/open-telemetry/semantic-conventions/pull/215))
 - Add `container.labels.<key>` attributes.
   ([#125](https://github.com/open-telemetry/semantic-conventions/pull/125))
 - Add `cluster.name` and `node.name` attributes to Elasticsearch semantic conventions.

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -36,7 +36,7 @@
 | `messaging.rocketmq.message.tag` | string | The secondary classifier of message besides topic. | `tagA` |
 | `messaging.rocketmq.message.type` | string | Type of message. | `normal` |
 | `messaging.rocketmq.namespace` | string | Namespace of RocketMQ resources, resources in different namespaces are individual. | `myNamespace` |
-| `messaging.system` | string | A string identifying the messaging system. | `kafka`; `rabbitmq`; `rocketmq`; `activemq` |
+| `messaging.system` | string | A string identifying the messaging system. | `kafka`; `rabbitmq`; `rocketmq` |
 
 **[1]:** Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
 

--- a/docs/messaging/activemq.md
+++ b/docs/messaging/activemq.md
@@ -1,0 +1,13 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: ActiveMQ
+--->
+
+# Semantic Conventions for ActiveMQ
+
+**Status**: [Experimental][DocumentStatus]
+
+The Semantic Conventions for [ActiveMQ](https://activemq.apache.org/) extend and override the [Messaging Semantic Conventions](README.md) that describe common messaging operations attributes in addition to the Semantic Conventions described on this page.
+
+`messaging.system` MUST be set to `"activemq"`.
+
+[DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -287,7 +287,7 @@ messages were received). For each message it accounts for, the "Deliver" or
 | [`messaging.message.envelope.size`](../attributes-registry/messaging.md) | int | The size of the message body and metadata in bytes. [12] | `2738` | Recommended: [13] |
 | [`messaging.message.id`](../attributes-registry/messaging.md) | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | Recommended: [14] |
 | [`messaging.operation`](../attributes-registry/messaging.md) | string | A string identifying the kind of messaging operation. [15] | `publish` | Required |
-| [`messaging.system`](../attributes-registry/messaging.md) | string | A string identifying the messaging system. | `kafka`; `rabbitmq`; `rocketmq`; `activemq` | Required |
+| [`messaging.system`](../attributes-registry/messaging.md) | string | A string identifying the messaging system. | `kafka`; `rabbitmq`; `rocketmq` | Required |
 | [`network.peer.address`](../attributes-registry/network.md) | string | Peer address of the network connection - IP address or Unix domain socket name. | `10.1.2.80`; `/tmp/my.sock` | Recommended |
 | [`network.peer.port`](../attributes-registry/network.md) | int | Peer port number of the network connection. | `65123` | Recommended: If `network.peer.address` is set. |
 | [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [16] | `amqp`; `mqtt` | Recommended |

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -205,4 +205,4 @@ groups:
       - id: system
         type: string
         brief: 'A string identifying the messaging system.'
-        examples: ['kafka', 'rabbitmq', 'rocketmq', 'activemq']
+        examples: ['kafka', 'rabbitmq', 'rocketmq']


### PR DESCRIPTION
## Changes

The rest of the changes for https://github.com/open-telemetry/semantic-conventions/pull/490. The initial PR was submitted before I could address the nits.

This PR does the following
- Creates a separate page for ActiveMQ
- Adds a note in the changelog

I ran the following commands
- `make fix`
- `make table-generation`
Before submitting.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
