### PR TITLE
Introduce instrument naming convention for used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ release.
   ([#503](https://github.com/open-telemetry/semantic-conventions/pull/503))
 - Add Semantic conventions for TLS/SSL encrypted communication.
   ([#21](https://github.com/open-telemetry/semantic-conventions/pull/21))
+- Introduce instrument naming convention for **used**.
+  ([#523](https://github.com/open-telemetry/semantic-conventions/pull/523))
 
 ### Fixes
 

--- a/docs/general/metrics.md
+++ b/docs/general/metrics.md
@@ -161,7 +161,7 @@ for the total amount of memory on a system.
 `state = used | cached | free | ...` for the amount of memory in a each state.
 
 - **used** - an instrument that measures an amount used but does not have
-a limit (or the limit is unknowable) should be called `entity.used`.
+a limit (or the limit is unknowable) should be called `<entity>.used`.
 For example, the maximum possible amount of virtual memory that a process
 may consume may fluctuate over time and is not typically known.
 

--- a/docs/general/metrics.md
+++ b/docs/general/metrics.md
@@ -158,7 +158,7 @@ for the total amount of memory on a system.
 - **usage** - an instrument that measures an amount used out of a known total
 (**limit**) and has dimensions which add up to the **limit** should be called
 `<entity>.usage`. For example, `system.memory.usage` with attribute
-`state = used | cached | free | ...` for the amount of memory in a each state.
+`<entity.state> = used | cached | free | ...` for the amount of memory in a each state.
 
 - **used** - an instrument that measures an amount used but does not have
 a limit (or the limit is unknowable) should be called `<entity>.used`.

--- a/docs/general/metrics.md
+++ b/docs/general/metrics.md
@@ -156,15 +156,14 @@ something should be called `entity.limit`. For example, `system.memory.limit`
 for the total amount of memory on a system.
 
 - **usage** - an instrument that measures an amount used out of a known total
-(**limit**) amount should be called `entity.usage`. For example,
-`system.memory.usage` with attribute `state = used | cached | free | ...` for the
-amount of memory in a each state. Where appropriate, the sum of **usage**
-over all attribute values SHOULD be equal to the **limit**.
+(**limit**) and has dimensions which add up to the **limit** should be called
+`entity.usage`. For example, `system.memory.usage` with attribute
+`state = used | cached | free | ...` for the amount of memory in a each state.
 
-  A measure of the amount consumed of an unlimited resource, or of a resource
-  whose limit is unknowable, is differentiated from **usage**. For example, the
-  maximum possible amount of virtual memory that a process may consume may
-  fluctuate over time and is not typically known.
+- **used** - an instrument that measures an amount used but does not have
+a limit (or the limit is unknowable) should be called `entity.used`.
+For example, the maximum possible amount of virtual memory that a process
+may consume may fluctuate over time and is not typically known.
 
 - **utilization** - an instrument that measures the *fraction* of **usage**
 out of its **limit** should be called `entity.utilization`. For example,

--- a/docs/general/metrics.md
+++ b/docs/general/metrics.md
@@ -163,7 +163,8 @@ for the total amount of memory on a system.
 - **used** - an instrument that measures an amount used but does not have
 a limit (or the limit is unknowable) should be called `<entity>.used`.
 For example, the maximum possible amount of virtual memory that a process
-may consume may fluctuate over time and is not typically known.
+may consume may fluctuate over time and is not typically known,
+so only the currently used memory is reported as `*.memory.used`.
 
 - **utilization** - an instrument that measures the *fraction* of **usage**
 out of its **limit** should be called `entity.utilization`. For example,

--- a/docs/general/metrics.md
+++ b/docs/general/metrics.md
@@ -157,7 +157,7 @@ for the total amount of memory on a system.
 
 - **usage** - an instrument that measures an amount used out of a known total
 (**limit**) and has dimensions which add up to the **limit** should be called
-`entity.usage`. For example, `system.memory.usage` with attribute
+`<entity>.usage`. For example, `system.memory.usage` with attribute
 `state = used | cached | free | ...` for the amount of memory in a each state.
 
 - **used** - an instrument that measures an amount used but does not have


### PR DESCRIPTION
Fixes #508

## Changes

Introduce instrument naming convention for **used**

IMPORTANT: I believe if this PR is accepted, then we should rename `process.memory.usage` to `process.memory.used`

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~