### PR TITLE
Temp fix for separation of resource and semantic attributes

### DIFF
--- a/model/registry/cloud.yaml
+++ b/model/registry/cloud.yaml
@@ -1,7 +1,7 @@
 groups:
   - id: registry.cloud
     prefix: cloud
-    type: attribute_group
+    type: resource
     brief: >
       A cloud environment (e.g. GCP, Azure, AWS).
     attributes:

--- a/model/registry/container.yaml
+++ b/model/registry/container.yaml
@@ -1,7 +1,7 @@
 groups:
   - id: registry.container
     prefix: container
-    type: attribute_group
+    type: resource
     brief: >
       A container instance.
     attributes:

--- a/model/registry/device.yaml
+++ b/model/registry/device.yaml
@@ -1,7 +1,7 @@
 groups:
   - id: registry.device
     prefix: device
-    type: attribute_group
+    type: resource
     brief: >
         Describes device attributes.
     attributes:

--- a/model/registry/host.yaml
+++ b/model/registry/host.yaml
@@ -1,7 +1,7 @@
 groups:
   - id: registry.host
     prefix: host
-    type: attribute_group
+    type: resource
     brief: >
       A host is defined as a computing instance. For example, physical servers, virtual machines, switches or disk array.
     attributes:

--- a/model/registry/oci.yaml
+++ b/model/registry/oci.yaml
@@ -1,7 +1,7 @@
 groups:
   - id: registry.oci.manifest
     prefix: oci.manifest
-    type: attribute_group
+    type: resource
     brief: >
       An OCI image manifest.
     attributes:

--- a/model/registry/os.yaml
+++ b/model/registry/os.yaml
@@ -1,7 +1,7 @@
 groups:
   - id: registry.os
     prefix: os
-    type: attribute_group
+    type: resource
     brief: >
         The operating system (OS) on which the process represented by this resource is running.
     note: >

--- a/model/registry/process.yaml
+++ b/model/registry/process.yaml
@@ -1,7 +1,7 @@
 groups:
   - id: registry.process
     prefix: process
-    type: attribute_group
+    type: resource
     brief: >
         An operating system process.
     attributes:


### PR DESCRIPTION
Fixes broken code generation that assumes that resource attributes are strictly separated from semantic attributes.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] ~[CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.~
* [ ] ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~
