### PR TITLE
[backport to 1.23.x] Temp fix for separation of resource and semantic attributes (#524)

### DIFF
--- a/model/registry/cloud.yaml
+++ b/model/registry/cloud.yaml
@@ -1,7 +1,7 @@
 groups:
   - id: registry.cloud
     prefix: cloud
-    type: attribute_group
+    type: resource
     brief: >
       A cloud environment (e.g. GCP, Azure, AWS).
     attributes:

--- a/model/registry/container.yaml
+++ b/model/registry/container.yaml
@@ -1,7 +1,7 @@
 groups:
   - id: registry.container
     prefix: container
-    type: attribute_group
+    type: resource
     brief: >
       A container instance.
     attributes:

--- a/model/registry/oci.yaml
+++ b/model/registry/oci.yaml
@@ -1,7 +1,7 @@
 groups:
   - id: registry.oci.manifest
     prefix: oci.manifest
-    type: attribute_group
+    type: resource
     brief: >
       An OCI image manifest.
     attributes:


### PR DESCRIPTION
(cherry picked from commit 2817a7fa5b5d230f70314fdf425e1c468163f1e0)

Related to #533.
