### PR TITLE
Add registry md file for disk attributes

### DIFF
--- a/docs/attributes-registry/README.md
+++ b/docs/attributes-registry/README.md
@@ -34,6 +34,7 @@ Currently, the following namespaces exist:
 * [DB](db.md) (database)
 * [Destination](destination.md)
 * [Device](device.md)
+* [Disk](disk.md)
 * [Error](error.md)
 * [Host](host.md)
 * [HTTP](http.md)

--- a/docs/attributes-registry/disk.md
+++ b/docs/attributes-registry/disk.md
@@ -1,0 +1,19 @@
+<!--- Hugo front matter used to generate the website version of this page:
+--->
+
+# Disk
+
+## Disk Attributes
+
+<!-- semconv registry.disk(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  |
+|---|---|---|---|
+| `disk.io.direction` | string | The disk IO operation direction. | `read` |
+
+`disk.io.direction` MUST be one of the following:
+
+| Value  | Description |
+|---|---|
+| `read` | read |
+| `write` | write |
+<!-- endsemconv -->

--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -359,7 +359,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.disk.io(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `disk.io.direction` | string | The disk IO operation direction. | `read` | Recommended |
+| [`disk.io.direction`](../attributes-registry/disk.md) | string | The disk IO operation direction. | `read` | Recommended |
 | `system.device` | string | The device identifier | `(identifier)` | Recommended |
 
 `disk.io.direction` MUST be one of the following:
@@ -383,7 +383,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.disk.operations(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `disk.io.direction` | string | The disk IO operation direction. | `read` | Recommended |
+| [`disk.io.direction`](../attributes-registry/disk.md) | string | The disk IO operation direction. | `read` | Recommended |
 | `system.device` | string | The device identifier | `(identifier)` | Recommended |
 
 `disk.io.direction` MUST be one of the following:
@@ -435,7 +435,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.disk.operation_time(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `disk.io.direction` | string | The disk IO operation direction. | `read` | Recommended |
+| [`disk.io.direction`](../attributes-registry/disk.md) | string | The disk IO operation direction. | `read` | Recommended |
 | `system.device` | string | The device identifier | `(identifier)` | Recommended |
 
 `disk.io.direction` MUST be one of the following:
@@ -459,7 +459,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.disk.merged(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `disk.io.direction` | string | The disk IO operation direction. | `read` | Recommended |
+| [`disk.io.direction`](../attributes-registry/disk.md) | string | The disk IO operation direction. | `read` | Recommended |
 | `system.device` | string | The device identifier | `(identifier)` | Recommended |
 
 `disk.io.direction` MUST be one of the following:


### PR DESCRIPTION
## Changes

With https://github.com/open-telemetry/semantic-conventions/pull/530 we missed the `disk.md` file of the registry for the Disk attributes.
This PR adds this file to the registry.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
