### PR TITLE
Improve visibility of used spec version in the semconv repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ key, but non-obvious, aspects:
   defined in a schema file. As part of any contribution, you should
   include attribute changes defined in the `schema-next.yaml` file.
   For details, please read [the schema specification](https://opentelemetry.io/docs/specs/otel/schemas/).
+- Links to the specification repository MUST point to a tag and **not** to the `main` branch.
+  The tag version MUST match with the one defined in [README](README.md).
 - After creating a pull request, please update the [CHANGELOG](CHANGELOG.md) file with
   a description of your changes.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # OpenTelemetry Semantic Conventions
 
-Welcome to the new repository!
+[![Checks](https://github.com/open-telemetry/semantic-conventions/workflows/Checks/badge.svg?branch=main)](https://github.com/open-telemetry/semantic-conventions/actions?query=workflow%3A%22Checks%22+branch%3Amain)
+![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/open-telemetry/semantic-conventions.svg?logo=opentelemetry&&color=f5a800&label=Latest%20release)
+![Specification Version](https://img.shields.io/badge/Specification_version-v1.26.0-blue?logo=opentelemetry&color=f5a800)
 
-This is currently a direct copy/filter-branch of the Specification repository
-with only semantic conventions included.
+![OpenTelemetry Logo](https://opentelemetry.io/img/logos/opentelemetry-horizontal-color.png)
 
-This repository is currently using [this specification version][SpecificationVersion].
+The **[Semantic Conventions][]** define a contract between the signals that
+instrumentation will provide and analysis tools that consumes
+the instrumentation (e.g. dashboards, alerts, queries, etc.).
 
 ## Read the docs
 
@@ -34,6 +37,4 @@ Maintainers ([@open-telemetry/specs-semconv-maintainers](https://github.com/orgs
 - [Josh Suereth](https://github.com/jsuereth), Google
 - [Reiley Yang](https://github.com/reyang), Microsoft
 
-_Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer)._
-
-[SpecificationVersion]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0
+_Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ the instrumentation (e.g. dashboards, alerts, queries, etc.).
 
 ## Read the docs
 
-The documentation currently resides in the [docs](docs/README.md) folder.
+The human-readable version of the semantic conventions resides in the [docs](docs/README.md) folder.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the instrumentation (e.g. dashboards, alerts, queries, etc.).
 ## Read the docs
 
 The human-readable version of the semantic conventions resides in the [docs](docs/README.md) folder.
-Major parts of these Markdown documents are generated from the YAML definitions located in the [model](model/) folder.
+Major parts of these Markdown documents are generated from the YAML definitions located in the [model](model/README.md) folder.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
 ![OpenTelemetry Logo](https://opentelemetry.io/img/logos/opentelemetry-horizontal-color.png)
 
 Semantic Conventions define a contract between the signals that
-instrumentation will provide and analysis tools that consumes
+instrumentation will provide and analysis tools that consume
 the instrumentation (e.g. dashboards, alerts, queries, etc.).
 
 ## Read the docs
 
 The human-readable version of the semantic conventions resides in the [docs](docs/README.md) folder.
+Major parts of these Markdown documents are generated from the YAML definitions located in the [model](model/) folder.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
-# OpenTelemetry Semantic Conventions
+# <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> OpenTelemetry Semantic Conventions
 
 [![Checks](https://github.com/open-telemetry/semantic-conventions/workflows/Checks/badge.svg?branch=main)](https://github.com/open-telemetry/semantic-conventions/actions?query=workflow%3A%22Checks%22+branch%3Amain)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/open-telemetry/semantic-conventions.svg?logo=opentelemetry&&color=f5a800&label=Latest%20release)](https://github.com/open-telemetry/semantic-conventions/releases/latest)
 [![Specification Version](https://img.shields.io/badge/OTel_specification_version-v1.26.0-blue?logo=opentelemetry&color=f5a800)](https://github.com/open-telemetry/opentelemetry-specification/releases/tag/v1.26.0)
 
-![OpenTelemetry Logo](https://opentelemetry.io/img/logos/opentelemetry-horizontal-color.png)
-
-Semantic Conventions define a contract between the signals that
-instrumentation will provide and analysis tools that consume
-the instrumentation (e.g. dashboards, alerts, queries, etc.).
+Semantic Conventions define a common set of (semantic) attributes which
+provide meaning to data when collecting, producing and consuming it.
 
 ## Read the docs
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![OpenTelemetry Logo](https://opentelemetry.io/img/logos/opentelemetry-horizontal-color.png)
 
-The **[Semantic Conventions][]** define a contract between the signals that
+Semantic Conventions define a contract between the signals that
 instrumentation will provide and analysis tools that consumes
 the instrumentation (e.g. dashboards, alerts, queries, etc.).
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OpenTelemetry Semantic Conventions
 
 [![Checks](https://github.com/open-telemetry/semantic-conventions/workflows/Checks/badge.svg?branch=main)](https://github.com/open-telemetry/semantic-conventions/actions?query=workflow%3A%22Checks%22+branch%3Amain)
-![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/open-telemetry/semantic-conventions.svg?logo=opentelemetry&&color=f5a800&label=Latest%20release)
-![Specification Version](https://img.shields.io/badge/Specification_version-v1.26.0-blue?logo=opentelemetry&color=f5a800)
+[![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/open-telemetry/semantic-conventions.svg?logo=opentelemetry&&color=f5a800&label=Latest%20release)](https://github.com/open-telemetry/semantic-conventions/releases/latest)
+[![Specification Version](https://img.shields.io/badge/OTel_specification_version-v1.26.0-blue?logo=opentelemetry&color=f5a800)](https://github.com/open-telemetry/opentelemetry-specification/releases/tag/v1.26.0)
 
 ![OpenTelemetry Logo](https://opentelemetry.io/img/logos/opentelemetry-horizontal-color.png)
 

--- a/internal/tools/update_specification_version.sh
+++ b/internal/tools/update_specification_version.sh
@@ -12,6 +12,8 @@ LATEST_SPECIFICATION_VERSION="v1.26.0"
 # The specific pattern we look for when replacing URLs
 SPECIFICATION_URL_PREFIX="https://github.com/open-telemetry/opentelemetry-specification/tree/"
 SPECIFICATION_BLOB_URL_PREFIX="https://github.com/open-telemetry/opentelemetry-specification/blob/"
+# The specific pattern we look for updating the Badge with the spec version
+SPECIFICATION_BADGE_PREFIX="https://img.shields.io/badge/Specification_version-"
 
 
 fix_file() {
@@ -19,6 +21,7 @@ fix_file() {
   sed -i \
    -e "s,${SPECIFICATION_URL_PREFIX}${PREVIOUS_SPECIFICATION_VERSION},${SPECIFICATION_URL_PREFIX}${LATEST_SPECIFICATION_VERSION},g" \
    -e "s,${SPECIFICATION_BLOB_URL_PREFIX}${PREVIOUS_SPECIFICATION_VERSION},${SPECIFICATION_URL_PREFIX}${LATEST_SPECIFICATION_VERSION},g" \
+   -e "s,${SPECIFICATION_BADGE_PREFIX}${PREVIOUS_SPECIFICATION_VERSION},${SPECIFICATION_BADGE_PREFIX}${LATEST_SPECIFICATION_VERSION},g" \
    "$1"
 }
 

--- a/internal/tools/update_specification_version.sh
+++ b/internal/tools/update_specification_version.sh
@@ -13,7 +13,8 @@ LATEST_SPECIFICATION_VERSION="v1.26.0"
 SPECIFICATION_URL_PREFIX="https://github.com/open-telemetry/opentelemetry-specification/tree/"
 SPECIFICATION_BLOB_URL_PREFIX="https://github.com/open-telemetry/opentelemetry-specification/blob/"
 # The specific pattern we look for updating the Badge with the spec version
-SPECIFICATION_BADGE_PREFIX="https://img.shields.io/badge/Specification_version-"
+SPECIFICATION_BADGE_PREFIX="https://img.shields.io/badge/OTel_specification_version-"
+SPECIFICATION_BADGE_RELEASE_TAG_PREFIX="https://github.com/open-telemetry/opentelemetry-specification/releases/tag/"
 
 
 fix_file() {
@@ -22,6 +23,7 @@ fix_file() {
    -e "s,${SPECIFICATION_URL_PREFIX}${PREVIOUS_SPECIFICATION_VERSION},${SPECIFICATION_URL_PREFIX}${LATEST_SPECIFICATION_VERSION},g" \
    -e "s,${SPECIFICATION_BLOB_URL_PREFIX}${PREVIOUS_SPECIFICATION_VERSION},${SPECIFICATION_URL_PREFIX}${LATEST_SPECIFICATION_VERSION},g" \
    -e "s,${SPECIFICATION_BADGE_PREFIX}${PREVIOUS_SPECIFICATION_VERSION},${SPECIFICATION_BADGE_PREFIX}${LATEST_SPECIFICATION_VERSION},g" \
+   -e "s,${SPECIFICATION_BADGE_RELEASE_TAG_PREFIX}${PREVIOUS_SPECIFICATION_VERSION},${SPECIFICATION_BADGE_RELEASE_TAG_PREFIX}${LATEST_SPECIFICATION_VERSION},g" \
    "$1"
 }
 


### PR DESCRIPTION
In #473 there was some confusion and back and forth regarding links to the specification repo. The confusion was about if links to the spec repo should point to `main` or to a specific tag. 

Today, we don't have any mention in `CONTRIBUTING.md` that links to the spec should point to a tag. Also, it is not clear which version of the spec this repo is targeting. We only have this text in the root readme:

>This repository is currently using [this specification version](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0)

Which can be easily missed since it's not obvious at first sight. 

To improve things, I propose in this PR:

- To add a badge where we can show which spec version we are currently targeting
- Add the requirement to `CONTRIBUTING.md` that links to the spec should point to the current used spec version
- Update the badge version when the `update_specification_version.sh` is executed
