### PR TITLE
Adding a few browser related attribute conventions

### DIFF
--- a/docs/resource/browser.md
+++ b/docs/resource/browser.md
@@ -12,10 +12,13 @@ All of these attributes can be provided by the user agent itself in the form of 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `browser.brands` | string[] | Array of brand name and version separated by a space [1] | `[ Not A;Brand 99, Chromium 99, Chrome 99]` | Recommended |
+| `browser.instance.id` | string | Represents a browser instance, either a window or a tab | `ec34d777-1daf-416b-98b0-05beddfaa199` | Recommended |
 | `browser.language` | string | Preferred language of the user using the browser [2] | `en`; `en-US`; `fr`; `fr-FR` | Recommended |
 | `browser.mobile` | boolean | A boolean that is true if the browser is running on a mobile device [3] |  | Recommended |
-| `browser.platform` | string | The platform on which the browser is running [4] | `Windows`; `macOS`; `Android` | Recommended |
-| [`user_agent.original`](../attributes-registry/user-agent.md) | string | Full user-agent string provided by the browser [5] | `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36` | Recommended |
+| `browser.page.instance.id` | string | Represents an instance of a page in the browser [4] | `4e58989a-4e4d-4f62-bf4f-ac5cd49b4b9a` | Recommended |
+| `browser.page.url` | string | Full URL of a page [5] | `https://www.netflix.com/Login` | Recommended |
+| `browser.platform` | string | The platform on which the browser is running [6] | `Windows`; `macOS`; `Android` | Recommended |
+| [`user_agent.original`](../attributes-registry/user-agent.md) | string | Full user-agent string provided by the browser [7] | `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36` | Recommended |
 
 **[1]:** This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.brands`).
 
@@ -23,10 +26,14 @@ All of these attributes can be provided by the user agent itself in the form of 
 
 **[3]:** This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.mobile`). If unavailable, this attribute SHOULD be left unset.
 
-**[4]:** This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.platform`). If unavailable, the legacy `navigator.platform` API SHOULD NOT be used instead and this attribute SHOULD be left unset in order for the values to be consistent.
+**[4]:** The same page when visited at a different time represents a new instance and should get a new id.
+
+**[5]:** Represents the url of the current page in the browser.
+
+**[6]:** This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.platform`). If unavailable, the legacy `navigator.platform` API SHOULD NOT be used instead and this attribute SHOULD be left unset in order for the values to be consistent.
 The list of possible values is defined in the [W3C User-Agent Client Hints specification](https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform). Note that some (but not all) of these values can overlap with values in the [`os.type` and `os.name` attributes](./os.md). However, for consistency, the values in the `browser.platform` attribute should capture the exact value that the user agent provides.
 
-**[5]:** The user-agent value SHOULD be provided only from browsers that do not have a mechanism to retrieve brands and platform individually from the User-Agent Client Hints API. To retrieve the value, the legacy `navigator.userAgent` API can be used.
+**[7]:** The user-agent value SHOULD be provided only from browsers that do not have a mechanism to retrieve brands and platform individually from the User-Agent Client Hints API. To retrieve the value, the legacy `navigator.userAgent` API can be used.
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/docs/resource/browser.md
+++ b/docs/resource/browser.md
@@ -13,6 +13,7 @@ All of these attributes can be provided by the user agent itself in the form of 
 |---|---|---|---|---|
 | `browser.brands` | string[] | Array of brand name and version separated by a space [1] | `[ Not A;Brand 99, Chromium 99, Chrome 99]` | Recommended |
 | `browser.instance.id` | string | Represents a browser instance, either a window or a tab | `ec34d777-1daf-416b-98b0-05beddfaa199` | Recommended |
+| `browser.instance.visibility_state` | string | Visibility status of the browser instance | `visible`; `hidden` | Recommended |
 | `browser.language` | string | Preferred language of the user using the browser [2] | `en`; `en-US`; `fr`; `fr-FR` | Recommended |
 | `browser.mobile` | boolean | A boolean that is true if the browser is running on a mobile device [3] |  | Recommended |
 | `browser.page.instance.id` | string | Represents an instance of a page in the browser [4] | `4e58989a-4e4d-4f62-bf4f-ac5cd49b4b9a` | Recommended |
@@ -34,6 +35,13 @@ All of these attributes can be provided by the user agent itself in the form of 
 The list of possible values is defined in the [W3C User-Agent Client Hints specification](https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform). Note that some (but not all) of these values can overlap with values in the [`os.type` and `os.name` attributes](./os.md). However, for consistency, the values in the `browser.platform` attribute should capture the exact value that the user agent provides.
 
 **[7]:** The user-agent value SHOULD be provided only from browsers that do not have a mechanism to retrieve brands and platform individually from the User-Agent Client Hints API. To retrieve the value, the legacy `navigator.userAgent` API can be used.
+
+`browser.instance.visibility_state` MUST be one of the following:
+
+| Value  | Description |
+|---|---|
+| `visible` | Browser instance is visible |
+| `hidden` | Browser instance is hidden |
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/model/resource/browser.yaml
+++ b/model/resource/browser.yaml
@@ -54,3 +54,19 @@ groups:
           to retrieve brands and platform individually from the User-Agent Client Hints API.
           To retrieve the value, the legacy `navigator.userAgent` API can be used.
         examples: ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36']
+      - id: page.url
+        type: string
+        brief: 'Full URL of a page'
+        note: >
+          Represents the url of the current page in the browser.
+        examples: ["https://www.netflix.com/Login"]
+      - id: page.instance.id
+        type: string
+        brief: 'Represents an instance of a page in the browser'
+        note: >
+          The same page when visited at a different time represents a new instance and should get a new id.
+        examples: ["4e58989a-4e4d-4f62-bf4f-ac5cd49b4b9a"]
+      - id: instance.id
+        type: string
+        brief: 'Represents a browser instance, either a window or a tab'
+        examples: ["ec34d777-1daf-416b-98b0-05beddfaa199"]

--- a/model/resource/browser.yaml
+++ b/model/resource/browser.yaml
@@ -70,3 +70,15 @@ groups:
         type: string
         brief: 'Represents a browser instance, either a window or a tab'
         examples: ["ec34d777-1daf-416b-98b0-05beddfaa199"]
+      - id: instance.visibility_state
+        type:
+          allow_custom_values: false
+          members:
+            - id: 'visible'
+              value: 'visible'
+              brief: 'Browser instance is visible'
+            - id: 'hidden'
+              value: 'hidden'
+              brief: 'Browser instance is hidden'
+        brief: 'Visibility status of the browser instance'
+        examples: ["visible", "hidden"]


### PR DESCRIPTION
Introducing a few attribute conventions under browser namespace.

## Changes

* Introducing browser.page.url, browser.page.instance.id and browser.instance.id

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
