### PR TITLE
.NET runtime process resource attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ release.
   ([#21](https://github.com/open-telemetry/semantic-conventions/pull/21))
 - Add `messaging.gcp_pubsub.message.ordering_key` attribute.
   ([#528](https://github.com/open-telemetry/semantic-conventions/pull/528))
+- Define how to set `process.runtime.name`, `process.runtime.version`, `process.runtime.description` for .NET runtime.
+  ([#561](https://github.com/open-telemetry/semantic-conventions/pull/561))
 
 ### Fixes
 

--- a/docs/resource/process.md
+++ b/docs/resource/process.md
@@ -85,7 +85,7 @@ Example:
 
 ### Go Runtimes
 
-Go Runtimes should fill in the as follows:
+Go Runtimes SHOULD fill in the as follows:
 
 - `process.runtime.name` - Fill in an interpretation of Go's [`runtime.Compiler`](https://pkg.go.dev/runtime#Compiler) constant, according to the following rule:
   If the value is `gc`, fill in `go`. Otherwise, fill in the exact value of `runtime.Compiler`.
@@ -116,7 +116,7 @@ Examples for some Go compilers/runtimes:
 
 ### Java runtimes
 
-Java instrumentation should fill in the values by copying from system properties.
+Java instrumentation SHOULD fill in the values by copying from system properties.
 
 - `process.runtime.name` - Fill in the value of `java.runtime.name` as is
 - `process.runtime.version` - Fill in the value of `java.runtime.version` as is
@@ -138,7 +138,7 @@ Examples for some Java runtimes
 
 ### JavaScript runtimes
 
-JavaScript instrumentation should fill in the values by copying from built-in runtime constants.
+JavaScript instrumentation SHOULD fill in the values by copying from built-in runtime constants.
 
 - `process.runtime.name`:
   - When the runtime is Node.js, fill in the constant value `nodejs`.
@@ -156,7 +156,7 @@ Examples for some JavaScript runtimes
 
 ### .NET Runtimes
 
-.NET instrumentation should fill in the values by following values:
+.NET instrumentation SHOULD fill in the values by following values:
 
 - `process.runtime.name` - Fill in the value by the name of runtime.
 - `process.runtime.version` - Fill in the value of `System.Environment.Version`.
@@ -171,7 +171,7 @@ Examples for some .NET runtimes
 
 ### Python Runtimes
 
-Python instrumentation should fill in the values as follows:
+Python instrumentation SHOULD fill in the values as follows:
 
 - `process.runtime.name` -
   Fill in the value of [`sys.implementation.name`][py_impl]
@@ -212,7 +212,7 @@ Pypy provided a CPython-compatible version in `sys.implementation.version` inste
 
 ### Ruby Runtimes
 
-Ruby instrumentation should fill in the values by copying from built-in runtime constants.
+Ruby instrumentation SHOULD fill in the values by copying from built-in runtime constants.
 
 - `process.runtime.name` - Fill in the value of `RUBY_ENGINE` as is
 - `process.runtime.version` - Fill in the value of `RUBY_VERSION` as is

--- a/docs/resource/process.md
+++ b/docs/resource/process.md
@@ -156,13 +156,19 @@ Examples for some JavaScript runtimes
 
 ### .NET Runtimes
 
-TODO(<https://github.com/open-telemetry/opentelemetry-dotnet/issues/1281>): Confirm the contents here
+.NET instrumentation should fill in the values by following values:
 
-| Value | Description |
-| --- | --- |
-| `dotnet-core` | .NET Core, .NET 5+ |
-| `dotnet-framework` | .NET Framework |
-| `mono` | Mono |
+- `process.runtime.name` - Fill in the value by the name of runtime.
+- `process.runtime.version` - Fill in the value of `System.Environment.Version`.
+- `process.runtime.description` - Fill in the values of `System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription`.
+
+Examples for some .NET runtimes
+
+| Name | `process.runtime.name` | `process.runtime.version` | `process.runtime.description` |
+| --- | --- | --- | --- |
+| .NET Framework | .NET Framework | 4.0.30319.42000 | .NET Framework 4.8.9195.0 |
+| .NET Core | .NET Core | 3.1.32 | .NET Core 3.1.32 |
+| .NET | .NET | 7.0.14 | .NET 7.0.14 |
 
 ### Python Runtimes
 

--- a/docs/resource/process.md
+++ b/docs/resource/process.md
@@ -167,7 +167,6 @@ Examples for some .NET runtimes
 | Name | `process.runtime.name` | `process.runtime.version` | `process.runtime.description` |
 | --- | --- | --- | --- |
 | .NET Framework | .NET Framework | 4.0.30319.42000 | .NET Framework 4.8.9195.0 |
-| .NET Core | .NET Core | 3.1.32 | .NET Core 3.1.32 |
 | .NET | .NET | 7.0.14 | .NET 7.0.14 |
 
 ### Python Runtimes

--- a/docs/resource/process.md
+++ b/docs/resource/process.md
@@ -175,7 +175,7 @@ Examples for some .NET runtimes
 
 | Name | `process.runtime.name` | `process.runtime.version` | `process.runtime.description` |
 | --- | --- | --- | --- |
-| .NET Framework | .NET Framework | 4.8.9195.0 | .NET Framework 4.8.9195.0 |
+| .NET Framework | .NET Framework | 4.8 | .NET Framework 4.8.9195.0 |
 | .NET | .NET | 7.0.14 | .NET 7.0.14 |
 
 ### Python Runtimes

--- a/docs/resource/process.md
+++ b/docs/resource/process.md
@@ -159,14 +159,16 @@ Examples for some JavaScript runtimes
 .NET instrumentation SHOULD fill in the values by following values:
 
 - `process.runtime.name` - Fill in the value by the name of runtime.
-- `process.runtime.version` - Fill in the value of `System.Environment.Version`.
+- `process.runtime.version` - Fill in the value of `System.Environment.Version` for .NET,
+  Use version part from `System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription`
+  for .NET Framework.
 - `process.runtime.description` - Fill in the values of `System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription`.
 
 Examples for some .NET runtimes
 
 | Name | `process.runtime.name` | `process.runtime.version` | `process.runtime.description` |
 | --- | --- | --- | --- |
-| .NET Framework | .NET Framework | 4.0.30319.42000 | .NET Framework 4.8.9195.0 |
+| .NET Framework | .NET Framework | 4.8.9195.0 | .NET Framework 4.8.9195.0 |
 | .NET | .NET | 7.0.14 | .NET 7.0.14 |
 
 ### Python Runtimes

--- a/docs/resource/process.md
+++ b/docs/resource/process.md
@@ -164,6 +164,13 @@ Examples for some JavaScript runtimes
   for .NET Framework
 - `process.runtime.description` - Fill in the values of `System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription`.
 
+`process.runtime.name` has the following list of well-known values. If one of them applies, then the respective value SHOULD be used, otherwise a custom value SHOULD be used.
+
+- .NET Framework
+- .NET
+- .NET Core
+- .NET Native
+
 Examples for some .NET runtimes
 
 | Name | `process.runtime.name` | `process.runtime.version` | `process.runtime.description` |

--- a/docs/resource/process.md
+++ b/docs/resource/process.md
@@ -160,8 +160,8 @@ Examples for some JavaScript runtimes
 
 - `process.runtime.name` - Fill in the value by the name of runtime.
 - `process.runtime.version` - Fill in the value of `System.Environment.Version` for .NET,
-  Use version part from `System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription`
-  for .NET Framework.
+  determine version based on the [registry values](https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#query-the-registry-using-code)
+  for .NET Framework
 - `process.runtime.description` - Fill in the values of `System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription`.
 
 Examples for some .NET runtimes


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/1281

## Changes

Defines what values should be set to `process.runtime.*` attributes for .NET.

Implementation can be found in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1449

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* ~~[ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~~ N/A?
