### PR TITLE
Mark JVM metrics stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ release.
   ([#488](https://github.com/open-telemetry/semantic-conventions/pull/488))
 - Remove no longer relevant Oct 1 mention from `OTEL_SEMCONV_STABILITY_OPT_IN`
   ([#541](https://github.com/open-telemetry/semantic-conventions/pull/541))
+- JVM metrics marked stable
+  ([#569](https://github.com/open-telemetry/semantic-conventions/pull/569))
 
 ## v1.23.0 (2023-11-03)
 

--- a/docs/runtime/jvm-metrics.md
+++ b/docs/runtime/jvm-metrics.md
@@ -29,7 +29,7 @@ This document describes semantic conventions for JVM metrics in OpenTelemetry.
   * [Metric: `jvm.cpu.time`](#metric-jvmcputime)
   * [Metric: `jvm.cpu.count`](#metric-jvmcpucount)
   * [Metric: `jvm.cpu.recent_utilization`](#metric-jvmcpurecent_utilization)
-- [Experimental](#very-experimental)
+- [Experimental](#experimental)
   * [Metric: `jvm.memory.init`](#metric-jvmmemoryinit)
   * [Metric: `jvm.system.cpu.utilization`](#metric-jvmsystemcpuutilization)
   * [Metric: `jvm.system.cpu.load_1m`](#metric-jvmsystemcpuload_1m)
@@ -59,8 +59,8 @@ This metric is obtained from [`MemoryPoolMXBean#getUsage()`](https://docs.oracle
 <!-- semconv metric.jvm.memory.used(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `jvm.memory.pool.name` | string | Name of the memory pool. [1] | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | Recommended |
-| `jvm.memory.type` | string | The type of memory. | `heap`; `non_heap` | Recommended |
+| `jvm.memory.pool.name` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>Name of the memory pool. [1] | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | Recommended |
+| `jvm.memory.type` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>The type of memory. | `heap`; `non_heap` | Recommended |
 
 **[1]:** Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()).
 
@@ -86,8 +86,8 @@ This metric is obtained from [`MemoryPoolMXBean#getUsage()`](https://docs.oracle
 <!-- semconv metric.jvm.memory.committed(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `jvm.memory.pool.name` | string | Name of the memory pool. [1] | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | Recommended |
-| `jvm.memory.type` | string | The type of memory. | `heap`; `non_heap` | Recommended |
+| `jvm.memory.pool.name` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>Name of the memory pool. [1] | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | Recommended |
+| `jvm.memory.type` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>The type of memory. | `heap`; `non_heap` | Recommended |
 
 **[1]:** Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()).
 
@@ -113,8 +113,8 @@ This metric is obtained from [`MemoryPoolMXBean#getUsage()`](https://docs.oracle
 <!-- semconv metric.jvm.memory.limit(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `jvm.memory.pool.name` | string | Name of the memory pool. [1] | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | Recommended |
-| `jvm.memory.type` | string | The type of memory. | `heap`; `non_heap` | Recommended |
+| `jvm.memory.pool.name` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>Name of the memory pool. [1] | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | Recommended |
+| `jvm.memory.type` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>The type of memory. | `heap`; `non_heap` | Recommended |
 
 **[1]:** Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()).
 
@@ -140,8 +140,8 @@ This metric is obtained from [`MemoryPoolMXBean#getCollectionUsage()`](https://d
 <!-- semconv metric.jvm.memory.used_after_last_gc(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `jvm.memory.pool.name` | string | Name of the memory pool. [1] | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | Recommended |
-| `jvm.memory.type` | string | The type of memory. | `heap`; `non_heap` | Recommended |
+| `jvm.memory.pool.name` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>Name of the memory pool. [1] | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | Recommended |
+| `jvm.memory.type` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>The type of memory. | `heap`; `non_heap` | Recommended |
 
 **[1]:** Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()).
 
@@ -178,8 +178,8 @@ of `[ 0.01, 0.1, 1, 10 ]`.
 <!-- semconv metric.jvm.gc.duration(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `jvm.gc.action` | string | Name of the garbage collector action. [1] | `end of minor GC`; `end of major GC` | Recommended |
-| `jvm.gc.name` | string | Name of the garbage collector. [2] | `G1 Young Generation`; `G1 Old Generation` | Recommended |
+| `jvm.gc.action` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>Name of the garbage collector action. [1] | `end of minor GC`; `end of major GC` | Recommended |
+| `jvm.gc.name` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>Name of the garbage collector. [2] | `G1 Young Generation`; `G1 Old Generation` | Recommended |
 
 **[1]:** Garbage collector action is generally obtained via [GarbageCollectionNotificationInfo#getGcAction()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()).
 
@@ -211,8 +211,8 @@ Note that this is the number of platform threads (as opposed to virtual threads)
 <!-- semconv metric.jvm.thread.count(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `jvm.thread.daemon` | boolean | Whether the thread is daemon or not. |  | Recommended |
-| `jvm.thread.state` | string | State of the thread. | `runnable`; `blocked` | Recommended |
+| `jvm.thread.daemon` | boolean | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>Whether the thread is daemon or not. |  | Recommended |
+| `jvm.thread.state` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>State of the thread. | `runnable`; `blocked` | Recommended |
 
 `jvm.thread.state` MUST be one of the following:
 
@@ -331,7 +331,7 @@ Note that the JVM does not provide a definition of what "recent" means.
 
 **Status**: [Experimental][DocumentStatus]
 
-**Description:** Very experimental Java Virtual Machine (JVM) metrics captured under `jvm.`
+**Description:** Experimental Java Virtual Machine (JVM) metrics captured under `jvm.`
 
 ### Metric: `jvm.memory.init`
 
@@ -347,8 +347,8 @@ This metric is obtained from [`MemoryPoolMXBean#getUsage()`](https://docs.oracle
 <!-- semconv metric.jvm.memory.init(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `jvm.memory.pool.name` | string | Name of the memory pool. [1] | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | Recommended |
-| `jvm.memory.type` | string | The type of memory. | `heap`; `non_heap` | Recommended |
+| `jvm.memory.pool.name` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>Name of the memory pool. [1] | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | Recommended |
+| `jvm.memory.type` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>The type of memory. | `heap`; `non_heap` | Recommended |
 
 **[1]:** Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()).
 

--- a/docs/runtime/jvm-metrics.md
+++ b/docs/runtime/jvm-metrics.md
@@ -4,7 +4,7 @@ linkTitle: Runtime Environment
 
 # Semantic Conventions for JVM Metrics
 
-**Status**: [Experimental][DocumentStatus]
+**Status**: [Mixed][DocumentStatus]
 
 This document describes semantic conventions for JVM metrics in OpenTelemetry.
 
@@ -29,7 +29,7 @@ This document describes semantic conventions for JVM metrics in OpenTelemetry.
   * [Metric: `jvm.cpu.time`](#metric-jvmcputime)
   * [Metric: `jvm.cpu.count`](#metric-jvmcpucount)
   * [Metric: `jvm.cpu.recent_utilization`](#metric-jvmcpurecent_utilization)
-- [Very experimental](#very-experimental)
+- [Experimental](#very-experimental)
   * [Metric: `jvm.memory.init`](#metric-jvmmemoryinit)
   * [Metric: `jvm.system.cpu.utilization`](#metric-jvmsystemcpuutilization)
   * [Metric: `jvm.system.cpu.load_1m`](#metric-jvmsystemcpuload_1m)
@@ -40,6 +40,8 @@ This document describes semantic conventions for JVM metrics in OpenTelemetry.
 <!-- tocstop -->
 
 ## JVM Memory
+
+**Status**: [Stable][DocumentStatus]
 
 **Description:** Java Virtual Machine (JVM) metrics captured under the namespace `jvm.memory.*`
 
@@ -152,6 +154,8 @@ This metric is obtained from [`MemoryPoolMXBean#getCollectionUsage()`](https://d
 <!-- endsemconv -->
 
 ## JVM Garbage Collection
+
+**Status**: [Stable][DocumentStatus]
 
 **Description:** Java Virtual Machine (JVM) metrics captured under the namespace `jvm.gc.*`
 
@@ -270,6 +274,8 @@ This metric is obtained from [`ClassLoadingMXBean#getLoadedClassCount()`](https:
 
 ## JVM CPU
 
+**Status**: [Stable][DocumentStatus]
+
 **Description:** Java Virtual Machine (JVM) metrics captured under the namespace `jvm.cpu.*`
 
 ### Metric: `jvm.cpu.time`
@@ -321,7 +327,9 @@ Note that the JVM does not provide a definition of what "recent" means.
 <!-- semconv metric.jvm.cpu.recent_utilization(full) -->
 <!-- endsemconv -->
 
-## Very experimental
+## Experimental
+
+**Status**: [Experimental][DocumentStatus]
 
 **Description:** Very experimental Java Virtual Machine (JVM) metrics captured under `jvm.`
 

--- a/model/metrics/jvm-metrics.yaml
+++ b/model/metrics/jvm-metrics.yaml
@@ -5,6 +5,7 @@ groups:
     prefix: jvm.memory
     attributes:
       - id: type
+        stability: stable
         type:
           allow_custom_values: false
           members:
@@ -18,6 +19,7 @@ groups:
         brief: The type of memory.
         examples: ["heap", "non_heap"]
       - id: pool.name
+        stability: stable
         type: string
         requirement_level: recommended
         brief: Name of the memory pool.
@@ -67,6 +69,7 @@ groups:
     prefix: jvm.gc
     attributes:
       - id: name
+        stability: stable
         type: string
         requirement_level: recommended
         brief: Name of the garbage collector.
@@ -75,6 +78,7 @@ groups:
           Garbage collector name is generally obtained via
           [GarbageCollectionNotificationInfo#getGcName()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcName()).
       - id: action
+        stability: stable
         type: string
         requirement_level: recommended
         brief: Name of the garbage collector action.
@@ -91,10 +95,12 @@ groups:
     unit: "{thread}"
     attributes:
       - id: jvm.thread.daemon
+        stability: stable
         type: boolean
         requirement_level: recommended
         brief: "Whether the thread is daemon or not."
       - id: jvm.thread.state
+        stability: stable
         requirement_level: recommended
         type:
           allow_custom_values: false


### PR DESCRIPTION
## Changes

Marks JVM metrics stable.

Java Instrumentation 1.32.0 already implements these behind `OTEL_SEMCONV_STABILITY_OPT_IN=jvm`, and we are planning to enable them by default in upcoming Java Instrumentation 2.0: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9963

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* ~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~
