### PR TITLE
Allow relative links to other blobs in Markdown

### DIFF
--- a/.markdown_link_check_config.json
+++ b/.markdown_link_check_config.json
@@ -6,12 +6,16 @@
   ],
   "replacementPatterns": [
     {
-      "pattern": "^/",
-      "replacement": "{{BASEURL}}/"
-    },
-    {
       "pattern": "^https://github.com/open-telemetry/semantic-conventions/(blob|tree)/[^/]+/docs/",
       "replacement": "LINK-CHECK-ERROR-USE-LOCAL-PATH-TO-DOC-PAGE-NOT-EXTERNAL-URL/"
+    },
+    {
+      "pattern": "^/../",
+      "replacement": "https://github.com/open-telemetry/semantic-conventions/blob/"
+    },
+    {
+      "pattern": "^/",
+      "replacement": "{{BASEURL}}/"
     }
   ],
   "retryOn429": true,


### PR DESCRIPTION
Adjust the `replacementPatterns` for `markdown-link-check` to allow relative links to other blobs in Markdown. Apply the same replacement as GitHub is doing: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#relative-links.

This will fix the failing CI in https://github.com/open-telemetry/semantic-conventions/pull/579

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
