### PR TITLE
Editorial: update HTTP request duration metrics stability in yaml (to stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ release.
   ([#488](https://github.com/open-telemetry/semantic-conventions/pull/488))
 - Remove no longer relevant Oct 1 mention from `OTEL_SEMCONV_STABILITY_OPT_IN`
   ([#541](https://github.com/open-telemetry/semantic-conventions/pull/541))
+- Update stability definitions of HTTP client and server duration metrics to
+  be consistent with markdown.
+  ([#587](https://github.com/open-telemetry/semantic-conventions/pull/587))
 
 ## v1.23.1 (2023-11-17)
 

--- a/model/metrics/http.yaml
+++ b/model/metrics/http.yaml
@@ -29,6 +29,7 @@ groups:
     brief: "Duration of HTTP server requests."
     instrument: histogram
     unit: "s"
+    stability: stable
     extends: metric_attributes.http.server
 
   - id: metric.http.server.active_requests
@@ -92,6 +93,7 @@ groups:
     brief: "Duration of HTTP client requests."
     instrument: histogram
     unit: "s"
+    stability: stable
     extends: metric_attributes.http.client
 
   - id: metric.http.client.request.body.size


### PR DESCRIPTION
## Changes

We didn't mark metric definitions as stable in the yaml in #377 🤦‍♀️ 

It has no effect on markdown and is not used by other tooling (yet), so I assume no need to hotfix 1.23.1.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [x] ~~schema-next.yaml~~
