### PR TITLE
Use deprecated property instead of stability level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ release.
 - Update stability definitions of HTTP client and server duration metrics to
   be consistent with markdown.
   ([#587](https://github.com/open-telemetry/semantic-conventions/pull/587))
+- Use `deprecated` property to mark attributes as deprecated instead of `stability`
+  ([#TODO](https://github.com/open-telemetry/semantic-conventions/pull/TODO))
 
 ## v1.23.1 (2023-11-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ release.
   be consistent with markdown.
   ([#587](https://github.com/open-telemetry/semantic-conventions/pull/587))
 - Use `deprecated` property to mark attributes as deprecated instead of `stability`
-  ([#TODO](https://github.com/open-telemetry/semantic-conventions/pull/TODO))
+  ([#588](https://github.com/open-telemetry/semantic-conventions/pull/588))
 
 ## v1.23.1 (2023-11-17)
 

--- a/docs/attributes-registry/http.md
+++ b/docs/attributes-registry/http.md
@@ -67,15 +67,15 @@ SHOULD include the [application root](/docs/http/http-spans.md#http-server-defin
 <!-- semconv attributes.http.deprecated(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
-| `http.flavor` | string | Deprecated, use `network.protocol.name` instead. | `1.0` |
-| `http.method` | string | Deprecated, use `http.request.method` instead. | `GET`; `POST`; `HEAD` |
-| `http.request_content_length` | int | Deprecated, use `http.request.header.content-length` instead. | `3495` |
-| `http.response_content_length` | int | Deprecated, use `http.response.header.content-length` instead. | `3495` |
-| `http.scheme` | string | Deprecated, use `url.scheme` instead. | `http`; `https` |
-| `http.status_code` | int | Deprecated, use `http.response.status_code` instead. | `200` |
-| `http.target` | string | Deprecated, use `url.path` and `url.query` instead. | `/search?q=OpenTelemetry#SemConv` |
-| `http.url` | string | Deprecated, use `url.full` instead. | `https://www.foo.bar/search?q=OpenTelemetry#SemConv` |
-| `http.user_agent` | string | Deprecated, use `user_agent.original` instead. | `CERN-LineMode/2.15 libwww/2.17b3`; `Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1` |
+| `http.flavor` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `network.protocol.name` instead. | `1.0` |
+| `http.method` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `http.request.method` instead. | `GET`; `POST`; `HEAD` |
+| `http.request_content_length` | int | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `http.request.header.content-length` instead. | `3495` |
+| `http.response_content_length` | int | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `http.response.header.content-length` instead. | `3495` |
+| `http.scheme` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `url.scheme` instead. | `http`; `https` |
+| `http.status_code` | int | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `http.response.status_code` instead. | `200` |
+| `http.target` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `url.path` and `url.query` instead. | `/search?q=OpenTelemetry#SemConv` |
+| `http.url` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `url.full` instead. | `https://www.foo.bar/search?q=OpenTelemetry#SemConv` |
+| `http.user_agent` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `user_agent.original` instead. | `CERN-LineMode/2.15 libwww/2.17b3`; `Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1` |
 
 `http.flavor` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/docs/attributes-registry/network.md
+++ b/docs/attributes-registry/network.md
@@ -103,19 +103,19 @@ different processes could be listening on TCP port 12345 and UDP port 12345.
 <!-- semconv network-deprecated(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
-| `net.host.name` | string | Deprecated, use `server.address`. | `example.com` |
-| `net.host.port` | int | Deprecated, use `server.port`. | `8080` |
-| `net.peer.name` | string | Deprecated, use `server.address` on client spans and `client.address` on server spans. | `example.com` |
-| `net.peer.port` | int | Deprecated, use `server.port` on client spans and `client.port` on server spans. | `8080` |
-| `net.protocol.name` | string | Deprecated, use `network.protocol.name`. | `amqp`; `http`; `mqtt` |
-| `net.protocol.version` | string | Deprecated, use `network.protocol.version`. | `3.1.1` |
-| `net.sock.family` | string | Deprecated, use `network.transport` and `network.type`. | `inet` |
-| `net.sock.host.addr` | string | Deprecated, use `network.local.address`. | `/var/my.sock` |
-| `net.sock.host.port` | int | Deprecated, use `network.local.port`. | `8080` |
-| `net.sock.peer.addr` | string | Deprecated, use `network.peer.address`. | `192.168.0.1` |
-| `net.sock.peer.name` | string | Deprecated, no replacement at this time. | `/var/my.sock` |
-| `net.sock.peer.port` | int | Deprecated, use `network.peer.port`. | `65531` |
-| `net.transport` | string | Deprecated, use `network.transport`. | `ip_tcp` |
+| `net.host.name` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `server.address`. | `example.com` |
+| `net.host.port` | int | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `server.port`. | `8080` |
+| `net.peer.name` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `server.address` on client spans and `client.address` on server spans. | `example.com` |
+| `net.peer.port` | int | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `server.port` on client spans and `client.port` on server spans. | `8080` |
+| `net.protocol.name` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `network.protocol.name`. | `amqp`; `http`; `mqtt` |
+| `net.protocol.version` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `network.protocol.version`. | `3.1.1` |
+| `net.sock.family` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `network.transport` and `network.type`. | `inet` |
+| `net.sock.host.addr` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `network.local.address`. | `/var/my.sock` |
+| `net.sock.host.port` | int | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `network.local.port`. | `8080` |
+| `net.sock.peer.addr` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `network.peer.address`. | `192.168.0.1` |
+| `net.sock.peer.name` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, no replacement at this time. | `/var/my.sock` |
+| `net.sock.peer.port` | int | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `network.peer.port`. | `65531` |
+| `net.transport` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `network.transport`. | `ip_tcp` |
 
 `net.sock.family` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/model/registry/deprecated/http.yaml
+++ b/model/registry/deprecated/http.yaml
@@ -7,22 +7,22 @@ groups:
       - id: method
         type: string
         brief: 'Deprecated, use `http.request.method` instead.'
-        deprecated: "Renamed to `http.request.method`."
+        deprecated: "Replaced by `http.request.method`."
         examples: ["GET", "POST", "HEAD"]
       - id: status_code
         type: int
         brief: 'Deprecated, use `http.response.status_code` instead.'
-        deprecated: "Renamed to `http.response.status_code`."
+        deprecated: "Replaced by `http.response.status_code`."
         examples: [200]
       - id: scheme
         type: string
         brief: 'Deprecated, use `url.scheme` instead.'
-        deprecated: "Renamed to `url.scheme` instead."
+        deprecated: "Replaced by `url.scheme` instead."
         examples: ['http', 'https']
       - id: url
         type: string
         brief: 'Deprecated, use `url.full` instead.'
-        deprecated: "Renamed to `url.full`."
+        deprecated: "Replaced by `url.full`."
         examples: ['https://www.foo.bar/search?q=OpenTelemetry#SemConv']
       - id: target
         type: string
@@ -32,12 +32,12 @@ groups:
       - id: request_content_length
         type: int
         brief: 'Deprecated, use `http.request.header.content-length` instead.'
-        deprecated: "Renamed to `http.request.header.content-length`."
+        deprecated: "Replaced by `http.request.header.content-length`."
         examples: 3495
       - id: response_content_length
         type: int
         brief: 'Deprecated, use `http.response.header.content-length` instead.'
-        deprecated: "Renamed to `http.response.header.content-length`."
+        deprecated: "Replaced by `http.response.header.content-length`."
         examples: 3495
       - id: flavor
         type:
@@ -62,10 +62,10 @@ groups:
               value: 'QUIC'
               brief: 'QUIC protocol.'
         brief: 'Deprecated, use `network.protocol.name` instead.'
-        deprecated: "Renamed to `network.protocol.name`."
+        deprecated: "Replaced by `network.protocol.name`."
       - id: user_agent
         type: string
         brief: 'Deprecated, use `user_agent.original` instead.'
         examples: ['CERN-LineMode/2.15 libwww/2.17b3',
                    'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1']
-        deprecated: "Renamed to `user_agent.original`."
+        deprecated: "Replaced by `user_agent.original`."

--- a/model/registry/deprecated/http.yaml
+++ b/model/registry/deprecated/http.yaml
@@ -7,37 +7,37 @@ groups:
       - id: method
         type: string
         brief: 'Deprecated, use `http.request.method` instead.'
-        stability: deprecated
+        deprecated: "Renamed to `http.request.method`."
         examples: ["GET", "POST", "HEAD"]
       - id: status_code
         type: int
         brief: 'Deprecated, use `http.response.status_code` instead.'
-        stability: deprecated
+        deprecated: "Renamed to `http.response.status_code`."
         examples: [200]
       - id: scheme
         type: string
         brief: 'Deprecated, use `url.scheme` instead.'
-        stability: deprecated
+        deprecated: "Renamed to `url.scheme` instead."
         examples: ['http', 'https']
       - id: url
         type: string
         brief: 'Deprecated, use `url.full` instead.'
-        stability: deprecated
+        deprecated: "Renamed to `url.full`."
         examples: ['https://www.foo.bar/search?q=OpenTelemetry#SemConv']
       - id: target
         type: string
         brief: 'Deprecated, use `url.path` and `url.query` instead.'
-        stability: deprecated
+        deprecated: "Split to `url.path` and `url.query."
         examples: ['/search?q=OpenTelemetry#SemConv']
       - id: request_content_length
         type: int
         brief: 'Deprecated, use `http.request.header.content-length` instead.'
-        stability: deprecated
+        deprecated: "Renamed to `http.request.header.content-length`."
         examples: 3495
       - id: response_content_length
         type: int
         brief: 'Deprecated, use `http.response.header.content-length` instead.'
-        stability: deprecated
+        deprecated: "Renamed to `http.response.header.content-length`."
         examples: 3495
       - id: flavor
         type:
@@ -62,10 +62,10 @@ groups:
               value: 'QUIC'
               brief: 'QUIC protocol.'
         brief: 'Deprecated, use `network.protocol.name` instead.'
-        stability: deprecated
+        deprecated: "Renamed to `network.protocol.name`."
       - id: user_agent
         type: string
         brief: 'Deprecated, use `user_agent.original` instead.'
         examples: ['CERN-LineMode/2.15 libwww/2.17b3',
                    'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1']
-        stability: deprecated
+        deprecated: "Renamed to `user_agent.original`."

--- a/model/registry/deprecated/network.yaml
+++ b/model/registry/deprecated/network.yaml
@@ -12,42 +12,42 @@ groups:
         examples: ['/var/my.sock']
       - id: sock.peer.addr
         type: string
-        deprecated: "Renamed to `network.peer.address`."
+        deprecated: "Replaced by `network.peer.address`."
         brief: Deprecated, use `network.peer.address`.
         examples: ['192.168.0.1']
       - id: sock.peer.port
         type: int
-        deprecated: "Renamed to `network.peer.port`."
+        deprecated: "Replaced by `network.peer.port`."
         examples: [65531]
         brief: Deprecated, use `network.peer.port`.
       - id: peer.name
         type: string
-        deprecated: "Renamed to `server.address` on client spans and `client.address` on server spans."
+        deprecated: "Replaced by `server.address` on client spans and `client.address` on server spans."
         brief: Deprecated, use `server.address` on client spans and `client.address` on server spans.
         examples: ['example.com']
       - id: peer.port
         type: int
-        deprecated: "Renamed tp `server.port` on client spans and `client.port` on server spans."
+        deprecated: "Replaced by `server.port` on client spans and `client.port` on server spans."
         brief: Deprecated, use `server.port` on client spans and `client.port` on server spans.
         examples: [8080]
       - id: host.name
         type: string
-        deprecated: "Renamed to `server.address`."
+        deprecated: "Replaced by `server.address`."
         brief: Deprecated, use `server.address`.
         examples: ['example.com']
       - id: host.port
         type: int
-        deprecated: "Renamed to `server.port`."
+        deprecated: "Replaced by `server.port`."
         brief: Deprecated, use `server.port`.
         examples: [8080]
       - id: sock.host.addr
         type: string
-        deprecated: "Renamed to `network.local.address`."
+        deprecated: "Replaced by `network.local.address`."
         brief: Deprecated, use `network.local.address`.
         examples: ['/var/my.sock']
       - id: sock.host.port
         type: int
-        deprecated: "Renamed to `network.local.port`."
+        deprecated: "Replaced by `network.local.port`."
         brief: Deprecated, use `network.local.port`.
         examples: [8080]
       - id: transport
@@ -71,16 +71,16 @@ groups:
             - id: other
               value: "other"
               brief: 'Something else (non IP-based).'
-        deprecated: "Renamed to `network.transport`."
+        deprecated: "Replaced by `network.transport`."
         brief: Deprecated, use `network.transport`.
       - id: protocol.name
         type: string
-        deprecated: "Renamed to `network.protocol.name`."
+        deprecated: "Replaced by `network.protocol.name`."
         brief: Deprecated, use `network.protocol.name`.
         examples: ['amqp', 'http', 'mqtt']
       - id: protocol.version
         type: string
-        deprecated: "Renamed to `network.protocol.version`."
+        deprecated: "Replaced by `network.protocol.version`."
         brief: Deprecated, use `network.protocol.version`.
         examples: '3.1.1'
       - id: sock.family

--- a/model/registry/deprecated/network.yaml
+++ b/model/registry/deprecated/network.yaml
@@ -7,47 +7,47 @@ groups:
     attributes:
       - id: sock.peer.name
         type: string
-        stability: deprecated
+        deprecated: "Removed."
         brief: Deprecated, no replacement at this time.
         examples: ['/var/my.sock']
       - id: sock.peer.addr
         type: string
-        stability: deprecated
+        deprecated: "Renamed to `network.peer.address`."
         brief: Deprecated, use `network.peer.address`.
         examples: ['192.168.0.1']
       - id: sock.peer.port
         type: int
-        stability: deprecated
+        deprecated: "Renamed to `network.peer.port`."
         examples: [65531]
         brief: Deprecated, use `network.peer.port`.
       - id: peer.name
         type: string
-        stability: deprecated
+        deprecated: "Renamed to `server.address` on client spans and `client.address` on server spans."
         brief: Deprecated, use `server.address` on client spans and `client.address` on server spans.
         examples: ['example.com']
       - id: peer.port
         type: int
-        stability: deprecated
+        deprecated: "Renamed tp `server.port` on client spans and `client.port` on server spans."
         brief: Deprecated, use `server.port` on client spans and `client.port` on server spans.
         examples: [8080]
       - id: host.name
         type: string
-        stability: deprecated
+        deprecated: "Renamed to `server.address`."
         brief: Deprecated, use `server.address`.
         examples: ['example.com']
       - id: host.port
         type: int
-        stability: deprecated
+        deprecated: "Renamed to `server.port`."
         brief: Deprecated, use `server.port`.
         examples: [8080]
       - id: sock.host.addr
         type: string
-        stability: deprecated
+        deprecated: "Renamed to `network.local.address`."
         brief: Deprecated, use `network.local.address`.
         examples: ['/var/my.sock']
       - id: sock.host.port
         type: int
-        stability: deprecated
+        deprecated: "Renamed to `network.local.port`."
         brief: Deprecated, use `network.local.port`.
         examples: [8080]
       - id: transport
@@ -71,16 +71,16 @@ groups:
             - id: other
               value: "other"
               brief: 'Something else (non IP-based).'
-        stability: deprecated
+        deprecated: "Renamed to `network.transport`."
         brief: Deprecated, use `network.transport`.
       - id: protocol.name
         type: string
-        stability: deprecated
+        deprecated: "Renamed to `network.protocol.name`."
         brief: Deprecated, use `network.protocol.name`.
         examples: ['amqp', 'http', 'mqtt']
       - id: protocol.version
         type: string
-        stability: deprecated
+        deprecated: "Renamed to `network.protocol.version`."
         brief: Deprecated, use `network.protocol.version`.
         examples: '3.1.1'
       - id: sock.family
@@ -96,5 +96,5 @@ groups:
             - id: unix
               value: 'unix'
               brief: "Unix domain socket path"
-        stability: deprecated
+        deprecated: "Split to `network.transport` and `network.type`."
         brief: Deprecated, use `network.transport` and `network.type`.


### PR DESCRIPTION
Fixes #582

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [x] ~~schema-next.yaml~~
