### PR TITLE
Fix PPID abbreviation in process attributes description

### DIFF
--- a/docs/attributes-registry/process.md
+++ b/docs/attributes-registry/process.md
@@ -14,7 +14,7 @@
 | `process.executable.name` | string | The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`. | `otelcol` |
 | `process.executable.path` | string | The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`. | `/usr/bin/cmd/otelcol` |
 | `process.owner` | string | The username of the user that owns the process. | `root` |
-| `process.parent_pid` | int | Parent Process identifier (PID). | `111` |
+| `process.parent_pid` | int | Parent Process identifier (PPID). | `111` |
 | `process.pid` | int | Process identifier (PID). | `1234` |
 | `process.runtime.description` | string | An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment. | `Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0` |
 | `process.runtime.name` | string | The name of the runtime of this process. For compiled native binaries, this SHOULD be the name of the compiler. | `OpenJDK Runtime Environment` |

--- a/docs/resource/process.md
+++ b/docs/resource/process.md
@@ -33,7 +33,7 @@
 | [`process.executable.name`](../attributes-registry/process.md) | string | The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`. | `otelcol` | Conditionally Required: See alternative attributes below. |
 | [`process.executable.path`](../attributes-registry/process.md) | string | The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`. | `/usr/bin/cmd/otelcol` | Conditionally Required: See alternative attributes below. |
 | [`process.owner`](../attributes-registry/process.md) | string | The username of the user that owns the process. | `root` | Recommended |
-| [`process.parent_pid`](../attributes-registry/process.md) | int | Parent Process identifier (PID). | `111` | Recommended |
+| [`process.parent_pid`](../attributes-registry/process.md) | int | Parent Process identifier (PPID). | `111` | Recommended |
 | [`process.pid`](../attributes-registry/process.md) | int | Process identifier (PID). | `1234` | Recommended |
 
 **Additional attribute requirements:** At least one of the following sets of attributes is required:

--- a/model/registry/process.yaml
+++ b/model/registry/process.yaml
@@ -13,7 +13,7 @@ groups:
       - id: parent_pid
         type: int
         brief: >
-          Parent Process identifier (PID).
+          Parent Process identifier (PPID).
         examples: [111]
       - id: executable.name
         type: string


### PR DESCRIPTION
## Changes

In process.parent_pid description, change abbreviation to PPID.  PPID is the usual abbreviation for Parent Process ID.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
