### PR TITLE
Update db and rpc metrics to use seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ release.
 
 ### Breaking
 
+- Update `db.client.connections.create_time` unit to `s` ([#???](https://github.com/open-telemetry/semantic-conventions/pull/???))
+- Update `db.client.connections.wait_time` unit to `s` ([#???](https://github.com/open-telemetry/semantic-conventions/pull/???))
+- Update `db.client.connections.use_time` unit to `s` ([#???](https://github.com/open-telemetry/semantic-conventions/pull/???))
+- Update `rpc.server.duration` unit to `s` ([#???](https://github.com/open-telemetry/semantic-conventions/pull/???))
+- Update `rpc.client.duration` unit to `s` ([#???](https://github.com/open-telemetry/semantic-conventions/pull/???))
+
 ### Features
 
 ### Fixes

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -142,7 +142,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.create_time(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `db.client.connections.create_time` | Histogram | `ms` | The time it took to create a new connection |
+| `db.client.connections.create_time` | Histogram | `s` | The time it took to create a new connection |
 <!-- endsemconv -->
 
 <!-- semconv metric.db.client.connections.create_time(full) -->
@@ -158,7 +158,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.wait_time(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `db.client.connections.wait_time` | Histogram | `ms` | The time it took to obtain an open connection from the pool |
+| `db.client.connections.wait_time` | Histogram | `s` | The time it took to obtain an open connection from the pool |
 <!-- endsemconv -->
 
 <!-- semconv metric.db.client.connections.wait_time(full) -->
@@ -174,7 +174,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.use_time(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `db.client.connections.use_time` | Histogram | `ms` | The time between borrowing a connection and returning it to the pool |
+| `db.client.connections.use_time` | Histogram | `s` | The time between borrowing a connection and returning it to the pool |
 <!-- endsemconv -->
 
 <!-- semconv metric.db.client.connections.use_time(full) -->

--- a/docs/rpc/rpc-metrics.md
+++ b/docs/rpc/rpc-metrics.md
@@ -79,7 +79,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.rpc.server.duration(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `rpc.server.duration` | Histogram | `ms` | Measures the duration of inbound RPC. [1] |
+| `rpc.server.duration` | Histogram | `s` | Measures the duration of inbound RPC. [1] |
 
 **[1]:** While streaming RPCs may record this metric as start-of-batch
 to end-of-batch, it's hard to interpret in practice.
@@ -151,7 +151,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.rpc.client.duration(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `rpc.client.duration` | Histogram | `ms` | Measures the duration of outbound RPC. [1] |
+| `rpc.client.duration` | Histogram | `s` | Measures the duration of outbound RPC. [1] |
 
 **[1]:** While streaming RPCs may record this metric as start-of-batch
 to end-of-batch, it's hard to interpret in practice.

--- a/model/metrics/database-metrics.yaml
+++ b/model/metrics/database-metrics.yaml
@@ -84,7 +84,7 @@ groups:
     metric_name: db.client.connections.create_time
     brief: "The time it took to create a new connection"
     instrument: histogram
-    unit: "ms"
+    unit: "s"
     attributes:
       - ref: pool.name
 
@@ -93,7 +93,7 @@ groups:
     metric_name: db.client.connections.wait_time
     brief: "The time it took to obtain an open connection from the pool"
     instrument: histogram
-    unit: "ms"
+    unit: "s"
     attributes:
       - ref: pool.name
 
@@ -102,6 +102,6 @@ groups:
     metric_name: db.client.connections.use_time
     brief: "The time between borrowing a connection and returning it to the pool"
     instrument: histogram
-    unit: "ms"
+    unit: "s"
     attributes:
       - ref: pool.name

--- a/model/metrics/rpc-metrics.yaml
+++ b/model/metrics/rpc-metrics.yaml
@@ -21,7 +21,7 @@ groups:
     metric_name: rpc.server.duration
     brief: Measures the duration of inbound RPC.
     instrument: histogram
-    unit: "ms"
+    unit: "s"
     note: |
       While streaming RPCs may record this metric as start-of-batch
       to end-of-batch, it's hard to interpret in practice.
@@ -74,7 +74,7 @@ groups:
     metric_name: rpc.client.duration
     brief: Measures the duration of outbound RPC.
     instrument: histogram
-    unit: "ms"
+    unit: "s"
     note: |
       While streaming RPCs may record this metric as start-of-batch
       to end-of-batch, it's hard to interpret in practice.


### PR DESCRIPTION
Fixes use of `ms` when the [recommendation](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics.md#instrument-units) is `s`.

## Changes

Updated `db.client.connections.create_time`, `db.client.connections.wait_time`, `db.client.connections.use_time` `rpc.server.duration`,  and `rpc.client.duration` to use the unit `s` instead of `ms`

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
