### PR TITLE
Stabilize exception semantic conventions.

### DIFF
--- a/docs/attributes-registry/exception.md
+++ b/docs/attributes-registry/exception.md
@@ -8,10 +8,10 @@
 <!-- semconv registry.exception(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
-| `exception.escaped` | boolean | SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span. [1] |  |
-| `exception.message` | string | The exception message. | `Division by zero`; `Can't convert 'int' object to str implicitly` |
-| `exception.stacktrace` | string | A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG. | `Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)` |
-| `exception.type` | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.net.ConnectException`; `OSError` |
+| `exception.escaped` | boolean | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span. [1] |  |
+| `exception.message` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>The exception message. | `Division by zero`; `Can't convert 'int' object to str implicitly` |
+| `exception.stacktrace` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG. | `Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)` |
+| `exception.type` | string | ![Stable](https://img.shields.io/badge/-stable-lightgreen)<br>The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.net.ConnectException`; `OSError` |
 
 **[1]:** An exception is considered to have escaped (or left) the scope of a span,
 if that span is ended while the exception is still logically "in flight".

--- a/docs/exceptions/exceptions-logs.md
+++ b/docs/exceptions/exceptions-logs.md
@@ -4,7 +4,7 @@ linkTitle: Logs
 
 # Semantic Conventions for Exceptions in Logs
 
-**Status**: [Experimental][DocumentStatus]
+**Status**: [Stable][DocumentStatus]
 
 This document defines semantic conventions for recording exceptions on
 [logs](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/logs/bridge-api.md#emit-a-logrecord) and [events](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/logs/event-api.md#emit-event)

--- a/docs/exceptions/exceptions-spans.md
+++ b/docs/exceptions/exceptions-spans.md
@@ -4,7 +4,7 @@ linkTitle: Spans
 
 # Semantic Conventions for Exceptions on Spans
 
-**Status**: [Experimental][DocumentStatus]
+**Status**: [Stable][DocumentStatus]
 
 This document defines semantic conventions for recording application
 exceptions associated with spans.

--- a/model/registry/exception.yaml
+++ b/model/registry/exception.yaml
@@ -8,6 +8,7 @@ groups:
     attributes:
       - id: type
         type: string
+        stability: stable
         brief: >
           The type of the exception (its fully-qualified class name, if applicable).
           The dynamic type of the exception should be preferred over the static type
@@ -15,10 +16,12 @@ groups:
         examples: ["java.net.ConnectException", "OSError"]
       - id: message
         type: string
+        stability: stable
         brief: The exception message.
         examples: ["Division by zero", "Can't convert 'int' object to str implicitly"]
       - id: stacktrace
         type: string
+        stability: stable
         brief: >
           A stacktrace as a string in the natural representation for the language runtime.
           The representation is to be determined and documented by each language SIG.
@@ -28,6 +31,7 @@ groups:
         at com.example.GenerateTrace.main(GenerateTrace.java:5)'
       - id: escaped
         type: boolean
+        stability: stable
         brief: >
           SHOULD be set to true if the exception event is recorded at a point where
           it is known that the exception is escaping the scope of the span.


### PR DESCRIPTION
Marks existing exception semconv as stable.

- These have been defacto stable for years now, with little changes.
- Any changes we want to make going forward *needs* to be non-breaking.
  - e.g. we may *add* a  representation of stacktraces that would complement pure strings.
  - New Languages are free to add more stacktrace representations
  
If we're all agreed, I'll update the changelog.

## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [X] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
