### PR TITLE
Add extensions .NET 8 metrics

### DIFF
--- a/model/metrics/dotnet/dotnet-aspnetcore.yaml
+++ b/model/metrics/dotnet/dotnet-aspnetcore.yaml
@@ -48,6 +48,11 @@ groups:
         examples: [true]
         requirement_level:
           conditionally_required: if and only if the request was not handled.
+      - id: aspnetcore.header_parsing.header.name
+        type: string
+        brief: The header name.
+        examples: ["Content-Type"]
+        requirement_level: required
 
   # routing
   - id: metric.aspnetcore.routing.match_attempts
@@ -78,6 +83,46 @@ groups:
         requirement_level: required
         brief: Match result - success or failure
         examples: ["success", "failure"]
+
+  # header parsing
+  - id: metric.aspnetcore.header_parsing.parse_errors
+    type: metric
+    metric_name: aspnetcore.header_parsing.parse_errors
+    brief: Number of errors that occurred when parsing HTTP request headers.
+    instrument: counter
+    unit: "{parse_error}"
+    note: |
+      Meter name: `Microsoft.AspNetCore.HeaderParsing`; Added in: ASP.NET Core 8.0
+    attributes:
+      - ref: aspnetcore.header_parsing.header.name
+      - ref: error.type
+        brief: The error message.
+        examples: [`Unable to parse media type value.`]
+        requirement_level: required
+
+  - id: metric.aspnetcore.header_parsing.cache_accesses
+    type: metric
+    metric_name: aspnetcore.header_parsing.cache_accesses
+    brief: Number of times a cache storing parsed header values was accessed.
+    instrument: counter
+    unit: "{cache_access}"
+    note: |
+      Meter name: `Microsoft.AspNetCore.HeaderParsing`; Added in: ASP.NET Core 8.0
+    attributes:
+      - ref: aspnetcore.header_parsing.header.name
+      - id: aspnetcore.header_parsing.cache_access.type
+        type:
+          allow_custom_values: true
+          members:
+            - id: hit
+              value: 'Hit'
+              brief: 'The header's value was found in the cache.'
+            - id: miss
+              value: 'Miss'
+              brief: 'The header's value wasn't found in the cache.'
+        brief: A value indicating whether the header's value was found in the cache or not.
+        examples: ["Hit", "Miss"]
+        requirement_level: required
 
   # diagnostics
   - id: metric.aspnetcore.diagnostics.exceptions

--- a/model/metrics/dotnet/dotnet-aspnetcore.yaml
+++ b/model/metrics/dotnet/dotnet-aspnetcore.yaml
@@ -97,7 +97,7 @@ groups:
       - ref: aspnetcore.header_parsing.header.name
       - ref: error.type
         brief: The error message.
-        examples: [`Unable to parse media type value.`]
+        examples: ["Unable to parse media type value."]
         requirement_level: required
 
   - id: metric.aspnetcore.header_parsing.cache_accesses

--- a/model/metrics/dotnet/dotnet-health_checks.yaml
+++ b/model/metrics/dotnet/dotnet-health_checks.yaml
@@ -1,0 +1,49 @@
+groups:
+  - id: health_checks
+    prefix: health_checks
+    type: attribute_group
+    brief: Health Check attributes
+    attributes:
+      - id: dotnet.health_check.status
+        type:
+          allow_custom_values: true
+          members:
+            - id: degraded
+              value: 'Degraded'
+              brief: "An application was in degraded state."
+            - id: healthy
+              value: 'Healthy'
+              brief: "An application was healthy."
+            - id: unhealthy
+              value: 'Unhealthy'
+              brief: "An application was unhealthy."
+        brief: The health status of an application.
+        examples: ["Healthy", "Unhealthy"]
+        requirement_level: required
+
+  - id: metric.dotnet.health_check.reports
+    type: metric
+    metric_name: dotnet.health_check.reports
+    brief: Number of times a health report reported the health status of an application.
+    instrument: counter
+    unit: "{report}"
+    note: |
+      Meter name: `Microsoft.Extensions.Diagnostics.HealthChecks`; Added in: .NET 8.0
+    attributes:
+      - ref: dotnet.health_check.status
+
+  - id: metric.dotnet.health_check.reports
+    type: metric
+    metric_name: dotnet.health_check.reports
+    brief: Number of times a health report reported the health status of an application.
+    instrument: counter
+    unit: "{report}"
+    note: |
+      Meter name: `Microsoft.Extensions.Diagnostics.HealthChecks`; Added in: .NET 8.0
+    attributes:
+      - id: dotnet.health_check.name
+        type: string
+        brief: The name of the health check.
+        requirement_level: required
+        examples: ["ApplicationLifecycle"]
+      - ref: dotnet.health_check.status


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/628

## Changes

The dotnet/extensions repo added some metrics. These were added to .NET docs but not semantic conventions. This PR adds them.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
