### PR TITLE
Revert "Clarify that service.* conventions apply to all telemetry sources"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ release.
 
 ### Fixes
 
-- Clarify that `service.*` attributes apply to all telemetry sources.
-  ([#630](https://github.com/open-telemetry/semantic-conventions/pull/630))
-
 ## v1.24.0 (2023-12-15)
 
 ### Breaking

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -77,7 +77,7 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 
 **type:** `service`
 
-**Description:** A telemetry source. OpenTelemetry has adopted a broad interpretation such that every telemetry source is a service. Examples include, but are not limited to: web services, hosts, mobile applications, browser application, edge computing devices, functions as a service, databases, message brokers, etc. Specific types of telemetry sources may have additional conventions defining domain specific information, but the `service` conventions are applicable to all telemetry sources.
+**Description:** A service instance.
 
 <!-- semconv service -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
@@ -94,7 +94,7 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 
 **type:** `service`
 
-**Description:** Experimental additions to service.
+**Description:** Additions to service instance.
 
 <!-- semconv service_experimental -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |

--- a/model/resource/service.yaml
+++ b/model/resource/service.yaml
@@ -3,12 +3,7 @@ groups:
     prefix: service
     type: resource
     brief: >
-      A telemetry source. OpenTelemetry has adopted a broad interpretation such that every
-      telemetry source is a service. Examples include, but are not limited to: web services,
-      hosts, mobile applications, browser application, edge computing devices, functions as
-      a service, databases, message brokers, etc. Specific types of telemetry sources may have
-      additional conventions defining domain specific information, but the `service`
-      conventions are applicable to all telemetry sources.
+      A service instance.
     attributes:
       - id: name
         type: string

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -3,7 +3,7 @@ groups:
     prefix: service
     type: resource
     brief: >
-      Experimental additions to service.
+      A service instance.
     attributes:
       - id: namespace
         type: string


### PR DESCRIPTION
Reverts #630 based on new discussions after merge.

This reverts commit 7f35c490ca2361d9030c504bcda3213d6d102041.
