### PR TITLE
feat: add os.kernel to os resource semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ release.
   ([#615](https://github.com/open-telemetry/semantic-conventions/pull/615))
 - Add an example for gcp_pubsub asynchronous batch publish
   ([#545](https://github.com/open-telemetry/semantic-conventions/pull/545)).
+- Add `os.kernel` to `os` resource semantic conventions
+  ([#655](https://github.com/open-telemetry/semantic-conventions/pull/655))
 
 ### Fixes
 

--- a/docs/attributes-registry/os.md
+++ b/docs/attributes-registry/os.md
@@ -10,6 +10,7 @@ linkTitle: OS
 |---|---|---|---|
 | `os.build_id` | string | Unique identifier for a particular build or compilation of the operating system. | `TQ3C.230805.001.B2`; `20E247`; `22621` |
 | `os.description` | string | Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands. | `Microsoft Windows [Version 10.0.18363.778]`; `Ubuntu 18.04.1 LTS` |
+| `os.kernel` | string | The version string of the kernel as defined in [Version Attributes](/docs/resource/README.md#version-attributes). | `6.7.0-arch3-1` |
 | `os.name` | string | Human readable operating system name. | `iOS`; `Android`; `Ubuntu` |
 | `os.type` | string | The operating system type. | `windows` |
 | `os.version` | string | The version string of the operating system as defined in [Version Attributes](/docs/resource/README.md#version-attributes). | `14.2.1`; `18.04.1` |

--- a/docs/resource/os.md
+++ b/docs/resource/os.md
@@ -13,6 +13,7 @@ In case of virtualized environments, this is the operating system as it is obser
 |---|---|---|---|---|
 | [`os.build_id`](../attributes-registry/os.md) | string | Unique identifier for a particular build or compilation of the operating system. | `TQ3C.230805.001.B2`; `20E247`; `22621` | Recommended |
 | [`os.description`](../attributes-registry/os.md) | string | Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands. | `Microsoft Windows [Version 10.0.18363.778]`; `Ubuntu 18.04.1 LTS` | Recommended |
+| [`os.kernel`](../attributes-registry/os.md) | string | The version string of the kernel as defined in [Version Attributes](/docs/resource/README.md#version-attributes). | `6.7.0-arch3-1` | Recommended |
 | [`os.name`](../attributes-registry/os.md) | string | Human readable operating system name. | `iOS`; `Android`; `Ubuntu` | Recommended |
 | [`os.type`](../attributes-registry/os.md) | string | The operating system type. | `windows` | Required |
 | [`os.version`](../attributes-registry/os.md) | string | The version string of the operating system as defined in [Version Attributes](/docs/resource/README.md#version-attributes). | `14.2.1`; `18.04.1` | Recommended |

--- a/model/registry/os.yaml
+++ b/model/registry/os.yaml
@@ -63,6 +63,12 @@ groups:
           The version string of the operating system as defined in
           [Version Attributes](/docs/resource/README.md#version-attributes).
         examples: ['14.2.1', '18.04.1']
+      - id: kernel
+        type: string
+        brief: >
+          The version string of the kernel as defined in
+          [Version Attributes](/docs/resource/README.md#version-attributes).
+        examples: ['6.7.0-arch3-1']
       - id: build_id
         type: string
         brief: 'Unique identifier for a particular build or compilation of the operating system.'

--- a/model/resource/os.yaml
+++ b/model/resource/os.yaml
@@ -14,3 +14,4 @@ groups:
       - ref: os.name
       - ref: os.version
       - ref: os.build_id
+      - ref: os.kernel


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/656

## Changes

Please provide a brief description of the changes here.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
