### PR TITLE
[resource/host] Change type of `host.cpu.stepping` to string

### DIFF
--- a/docs/attributes-registry/host.md
+++ b/docs/attributes-registry/host.md
@@ -12,7 +12,7 @@
 | `host.cpu.family` | string | Family or generation of the CPU. | `6`; `PA-RISC 1.1e` |
 | `host.cpu.model.id` | string | Model identifier. It provides more granular information about the CPU, distinguishing it from other CPUs within the same family. | `6`; `9000/778/B180L` |
 | `host.cpu.model.name` | string | Model designation of the processor. | `11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz` |
-| `host.cpu.stepping` | int | Stepping or core revisions. | `1` |
+| `host.cpu.stepping` | string | Stepping or core revisions. | `1`; `r1p1` |
 | `host.cpu.vendor.id` | string | Processor manufacturer identifier. A maximum 12-character string. [1] | `GenuineIntel` |
 | `host.id` | string | Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system. | `fdbf79e8af94cb7f9e8df36789187052` |
 | `host.image.id` | string | VM image ID or host OS image ID. For Cloud, this value is from the provider. | `ami-07b06b442921831e5` |

--- a/docs/resource/host.md
+++ b/docs/resource/host.md
@@ -49,7 +49,7 @@ To report host metrics, the `system.*` namespace SHOULD be used.
 | [`host.cpu.family`](../attributes-registry/host.md) | string | Family or generation of the CPU. | `6`; `PA-RISC 1.1e` | Opt-In |
 | [`host.cpu.model.id`](../attributes-registry/host.md) | string | Model identifier. It provides more granular information about the CPU, distinguishing it from other CPUs within the same family. | `6`; `9000/778/B180L` | Opt-In |
 | [`host.cpu.model.name`](../attributes-registry/host.md) | string | Model designation of the processor. | `11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz` | Opt-In |
-| [`host.cpu.stepping`](../attributes-registry/host.md) | int | Stepping or core revisions. | `1` | Opt-In |
+| [`host.cpu.stepping`](../attributes-registry/host.md) | string | Stepping or core revisions. | `1`; `r1p1` | Opt-In |
 | [`host.cpu.vendor.id`](../attributes-registry/host.md) | string | Processor manufacturer identifier. A maximum 12-character string. [1] | `GenuineIntel` | Opt-In |
 
 **[1]:** [CPUID](https://wiki.osdev.org/CPUID) command returns the vendor ID string in EBX, EDX and ECX registers. Writing these to memory in this order results in a 12-character string.

--- a/model/registry/host.yaml
+++ b/model/registry/host.yaml
@@ -111,10 +111,10 @@ groups:
           Model designation of the processor.
         examples: [ '11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz' ]
       - id: cpu.stepping
-        type: int
+        type: string
         brief: >
           Stepping or core revisions.
-        examples: [ 1 ]
+        examples: ["1", "r1p1"]
       - id: cpu.cache.l2.size
         type: int
         brief: >


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/664

## Changes

This PR changes the type of `host.cpu.stepping` to `string` in order to cover values like `r1p1` as described at https://github.com/open-telemetry/semantic-conventions/issues/664.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
