### PR TITLE
Add stale bot workflow

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,17 @@
+name: "Close stale spull requests"
+on:
+  schedule:
+    - cron: "12 3 * * *"  # arbitrary time not to DDOS GitHub
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days.'
+          close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
+          exempt-pr-labels: 'release:after-ga'
+          days-before-stale: 15
+          days-before-close: 7


### PR DESCRIPTION
I basically copied it from the spec repository. I went with a 15 days period to consider a PR stale. I'm also not sure if the GitHub Token there has the correct permissions. 
