### PR TITLE
Separate messaging.system values from the spec

### DIFF
--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -31,7 +31,7 @@
 | `messaging.message.envelope.size` | int | The size of the message body and metadata in bytes. [6] | `2738` |
 | `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` |
 | `messaging.operation` | string | A string identifying the kind of messaging operation. [7] | `publish` |
-| `messaging.system` | string | An identifier for the messaging system being used. See below for a list of well-known identifiers. | `activemq` |
+| `messaging.system` | string | An identifier for the messaging system being used. [8] | `kafka`; `rabbitmq` |
 
 **[1]:** Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
 
@@ -51,6 +51,8 @@ size should be used.
 
 **[7]:** If a custom value is used, it MUST be of low cardinality.
 
+**[8]:** Messaging instrumentations MUST use applicable value from the [list of known messaging systems](/docs/messaging/README.md#technology-specific-semantic-conventions) when it is available. When instrumenting a new messaging system, instrumentation authors should document the new system name and add it to the [list](/docs/messaging/README.md#technology-specific-semantic-conventions).
+
 `messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
@@ -59,21 +61,6 @@ size should be used.
 | `create` | A message is created. "Create" spans always refer to a single message and are used to provide a unique creation context for messages in batch publishing scenarios. |
 | `receive` | One or more messages are requested by a consumer. This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages. |
 | `deliver` | One or more messages are passed to a consumer. This operation refers to push-based scenarios, where consumer register callbacks which get called by messaging SDKs. |
-
-`messaging.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `activemq` | Apache ActiveMQ |
-| `aws_sqs` | Amazon Simple Queue Service (SQS) |
-| `azure_eventgrid` | Azure Event Grid |
-| `azure_eventhubs` | Azure Event Hubs |
-| `azure_servicebus` | Azure Service Bus |
-| `gcp_pubsub` | Google Cloud Pub/Sub |
-| `jms` | Java Message Service |
-| `kafka` | Apache Kafka |
-| `rabbitmq` | RabbitMQ |
-| `rocketmq` | Apache RocketMQ |
 <!-- endsemconv -->
 
 ## GCP Pub/Sub Attributes

--- a/docs/faas/aws-lambda.md
+++ b/docs/faas/aws-lambda.md
@@ -146,8 +146,8 @@ added as a link to the span. This means the span may have as many links as messa
 See [compatibility](../../supplementary-guidelines/compatibility/aws.md#context-propagation) for more info.
 
 - [`faas.trigger`][faas] MUST be set to `pubsub`.
-- [`messaging.operation`](/docs/messaging/messaging-spans.md) MUST be set to `process`.
-- [`messaging.system`](/docs/messaging/messaging-spans.md) MUST be set to `AmazonSQS`.
+- [`messaging.operation`](/docs/messaging/messaging-spans.md) MUST be set to `deliver`.
+- [`messaging.system`](/docs/messaging/messaging-spans.md) MUST be set to `aws_sqs`.
 
 ### SQS Message
 
@@ -159,8 +159,8 @@ added as a link to the span.
 See [compatibility](../../supplementary-guidelines/compatibility/aws.md#context-propagation) for more info.
 
 - [`faas.trigger`][faas] MUST be set to `pubsub`.
-- [`messaging.operation`](/docs/messaging/messaging-spans.md#messaging-attributes) MUST be set to `process`.
-- [`messaging.system`](/docs/messaging/messaging-spans.md#messaging-attributes) MUST be set to `AmazonSQS`.
+- [`messaging.operation`](/docs/messaging/messaging-spans.md#messaging-attributes) MUST be set to `deliver`.
+- [`messaging.system`](/docs/messaging/messaging-spans.md#messaging-attributes) MUST be set to `aws_sqs`.
 
 Other [Messaging attributes](/docs/messaging/messaging-spans.md#messaging-attributes) SHOULD be set based on the available information in the SQS message
 event.
@@ -239,9 +239,9 @@ Function F:                      | Span ProcBatch |
 | Links |  |  |  | Span Prod1 | Span Prod2 |
 | SpanKind | `PRODUCER` | `PRODUCER` | `CONSUMER` | `CONSUMER` | `CONSUMER` |
 | Status | `Ok` | `Ok` | `Ok` | `Ok` | `Ok` |
-| `messaging.system` | `AmazonSQS` | `AmazonSQS` | `AmazonSQS` | `AmazonSQS` | `AmazonSQS` |
+| `messaging.system` | `aws_sqs` | `aws_sqs` | `aws_sqs` | `aws_sqs` | `aws_sqs` |
 | `messaging.destination.name` | `Q` | `Q` | `Q` | `Q` | `Q` |
-| `messaging.operation` |  |  | `process` | `process` | `process` |
+| `messaging.operation` | `publish` | `publish` | `deliver` | `deliver` | `deliver` |
 | `messaging.message.id` | | | | `"a1"` | `"a2"` |
 
 Note that if Span Prod1 and Span Prod2 were sent to different queues, Span ProcBatch would not have

--- a/docs/messaging/README.md
+++ b/docs/messaging/README.md
@@ -16,11 +16,28 @@ Semantic conventions for messaging systems are defined for the following signals
 * [Messaging Spans](messaging-spans.md): Semantic Conventions for messaging *spans*.
 * [Messaging Metrics](messaging-metrics.md): Semantic Conventions for messaging *metrics*.
 
-Technology specific semantic conventions are defined for the following messaging systems:
+## Technology specific semantic conventions
 
-* [Kafka](kafka.md): Semantic Conventions for *Apache Kafka*.
-* [RabbitMQ](rabbitmq.md): Semantic Conventions for *RabbitMQ*.
-* [RocketMQ](rocketmq.md): Semantic Conventions for *Apache RocketMQ*.
-* [Google Cloud Pub/Sub](gcp-pubsub.md): Semantic Conventions for *Google Cloud Pub/Sub*.
+**Status**: [Experimental][DocumentStatus]
+<!-- Individual messaging systems may be declared stable along with the corresponding messaging.system value, but this list as a whole is not intended to be stabilized. -->
+
+Messaging system name is recorded on telemetry signals with `messaging.system` attribute.
+
+`messaging.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used.
+
+| Value  | Description | Semantic Conventions |
+|---|---|---|
+| `activemq` | Apache ActiveMQ |  |
+| `aws_sqs` | Amazon Simple Queue Service (SQS) |  |
+| `azure_eventgrid` | Azure Event Grid |  |
+| `azure_eventhubs` | Azure Event Hubs |  |
+| `azure_servicebus` | Azure Service Bus |  |
+| `gcp_pubsub` | Google Cloud Pub/Sub | [Google Cloud Pub/Sub](gcp-pubsub.md) |
+| `jms` | Java Message Service |
+| `kafka` | Apache Kafka | [Kafka](kafka.md)|
+| `rabbitmq` | RabbitMQ | [RabbitMQ](rabbitmq.md) |
+| `rocketmq` | Apache RocketMQ | [RocketMQ](rocketmq.md) |
+
+If none of these values apply, consider submitting a proposal to this specification to add a new system.
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/docs/messaging/README.md
+++ b/docs/messaging/README.md
@@ -25,6 +25,7 @@ Messaging system name is recorded on telemetry signals with `messaging.system` a
 
 `messaging.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used.
 
+<!-- TODO this could be auto-generated if is implemented https://github.com/open-telemetry/build-tools/issues/192 -->
 | Value  | Description | Semantic Conventions |
 |---|---|---|
 | `activemq` | Apache ActiveMQ |  |

--- a/docs/messaging/messaging-metrics.md
+++ b/docs/messaging/messaging-metrics.md
@@ -28,11 +28,11 @@ All messaging metrics share the same set of attributes:
 | [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [1] | `amqp:decode-error`; `KAFKA_STORAGE_ERROR`; `channel-error` | Conditionally Required: [2] |
 | [`messaging.destination.name`](../attributes-registry/messaging.md) | string | The message destination name [3] | `MyQueue`; `MyTopic` | Conditionally Required: [4] |
 | [`messaging.destination.template`](../attributes-registry/messaging.md) | string | Low cardinality representation of the messaging destination name [5] | `/customers/{customerId}` | Conditionally Required: if available. |
-| [`messaging.system`](../attributes-registry/messaging.md) | string | An identifier for the messaging system being used. See below for a list of well-known identifiers. | `activemq` | Required |
-| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [6] | `amqp`; `mqtt` | Conditionally Required: [7] |
-| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [8] | `3.1.1` | Recommended |
-| [`server.address`](../attributes-registry/server.md) | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [9] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Conditionally Required: If available. |
-| [`server.port`](../attributes-registry/server.md) | int | Server port number. [10] | `80`; `8080`; `443` | Recommended |
+| [`messaging.system`](../attributes-registry/messaging.md) | string | An identifier for the messaging system being used. [6] | `kafka`; `rabbitmq` | Required |
+| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [7] | `amqp`; `mqtt` | Conditionally Required: [8] |
+| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [9] | `3.1.1` | Recommended |
+| [`server.address`](../attributes-registry/server.md) | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [10] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Conditionally Required: If available. |
+| [`server.port`](../attributes-registry/server.md) | int | Server port number. [11] | `80`; `8080`; `443` | Recommended |
 
 **[1]:** The `error.type` SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
@@ -59,36 +59,23 @@ the broker doesn't have such notion, the destination name SHOULD uniquely identi
 
 **[5]:** Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
 
-**[6]:** The value SHOULD be normalized to lowercase.
+**[6]:** Messaging instrumentations MUST use applicable value from the [list of known messaging systems](/docs/messaging/README.md#technology-specific-semantic-conventions) when it is available. When instrumenting a new messaging system, instrumentation authors should document the new system name and add it to the [list](/docs/messaging/README.md#technology-specific-semantic-conventions).
 
-**[7]:** Only for messaging systems and frameworks that support more than one protocol.
+**[7]:** The value SHOULD be normalized to lowercase.
 
-**[8]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[8]:** Only for messaging systems and frameworks that support more than one protocol.
 
-**[9]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
+**[9]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
-**[10]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
+**[10]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
+
+**[11]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
 
 `error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
 | Value  | Description |
 |---|---|
 | `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. |
-
-`messaging.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `activemq` | Apache ActiveMQ |
-| `aws_sqs` | Amazon Simple Queue Service (SQS) |
-| `azure_eventgrid` | Azure Event Grid |
-| `azure_eventhubs` | Azure Event Hubs |
-| `azure_servicebus` | Azure Service Bus |
-| `gcp_pubsub` | Google Cloud Pub/Sub |
-| `jms` | Java Message Service |
-| `kafka` | Apache Kafka |
-| `rabbitmq` | RabbitMQ |
-| `rocketmq` | Apache RocketMQ |
 <!-- endsemconv -->
 
 ## Producer metrics

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -299,15 +299,15 @@ as described in [Attributes specific to certain messaging systems](#attributes-s
 | [`messaging.message.envelope.size`](../attributes-registry/messaging.md) | int | The size of the message body and metadata in bytes. [12] | `2738` | Recommended |
 | [`messaging.message.id`](../attributes-registry/messaging.md) | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | Recommended |
 | [`messaging.operation`](../attributes-registry/messaging.md) | string | A string identifying the kind of messaging operation. [13] | `publish` | Required |
-| [`messaging.system`](../attributes-registry/messaging.md) | string | An identifier for the messaging system being used. See below for a list of well-known identifiers. | `activemq` | Required |
+| [`messaging.system`](../attributes-registry/messaging.md) | string | An identifier for the messaging system being used. [14] | `kafka`; `rabbitmq` | Required |
 | [`network.peer.address`](../attributes-registry/network.md) | string | Peer address of the network connection - IP address or Unix domain socket name. | `10.1.2.80`; `/tmp/my.sock` | Recommended |
 | [`network.peer.port`](../attributes-registry/network.md) | int | Peer port number of the network connection. | `65123` | Recommended: If `network.peer.address` is set. |
-| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [14] | `amqp`; `mqtt` | Conditionally Required: [15] |
-| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [16] | `3.1.1` | Recommended |
-| [`network.transport`](../attributes-registry/network.md) | string | [OSI transport layer](https://osi-model.com/transport-layer/) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication). [17] | `tcp`; `udp` | Recommended |
-| [`network.type`](../attributes-registry/network.md) | string | [OSI network layer](https://osi-model.com/network-layer/) or non-OSI equivalent. [18] | `ipv4`; `ipv6` | Recommended |
-| [`server.address`](../attributes-registry/server.md) | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [19] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Conditionally Required: If available. |
-| [`server.port`](../attributes-registry/server.md) | int | Server port number. [20] | `80`; `8080`; `443` | Recommended |
+| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [15] | `amqp`; `mqtt` | Conditionally Required: [16] |
+| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [17] | `3.1.1` | Recommended |
+| [`network.transport`](../attributes-registry/network.md) | string | [OSI transport layer](https://osi-model.com/transport-layer/) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication). [18] | `tcp`; `udp` | Recommended |
+| [`network.type`](../attributes-registry/network.md) | string | [OSI network layer](https://osi-model.com/network-layer/) or non-OSI equivalent. [19] | `ipv4`; `ipv6` | Recommended |
+| [`server.address`](../attributes-registry/server.md) | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [20] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Conditionally Required: If available. |
+| [`server.port`](../attributes-registry/server.md) | int | Server port number. [21] | `80`; `8080`; `443` | Recommended |
 
 **[1]:** The `error.type` SHOULD be predictable and SHOULD have low cardinality.
 Instrumentations SHOULD document the list of errors they report.
@@ -352,23 +352,25 @@ size should be used.
 
 **[13]:** If a custom value is used, it MUST be of low cardinality.
 
-**[14]:** The value SHOULD be normalized to lowercase.
+**[14]:** Messaging instrumentations MUST use applicable value from the [list of known messaging systems](/docs/messaging/README.md#technology-specific-semantic-conventions) when it is available. When instrumenting a new messaging system, instrumentation authors should document the new system name and add it to the [list](/docs/messaging/README.md#technology-specific-semantic-conventions).
 
-**[15]:** Only for messaging systems and frameworks that support more than one protocol.
+**[15]:** The value SHOULD be normalized to lowercase.
 
-**[16]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[16]:** Only for messaging systems and frameworks that support more than one protocol.
 
-**[17]:** The value SHOULD be normalized to lowercase.
+**[17]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[18]:** The value SHOULD be normalized to lowercase.
 
 Consider always setting the transport when setting a port number, since
 a port number is ambiguous without knowing the transport. For example
 different processes could be listening on TCP port 12345 and UDP port 12345.
 
-**[18]:** The value SHOULD be normalized to lowercase.
+**[19]:** The value SHOULD be normalized to lowercase.
 
-**[19]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
+**[20]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
 
-**[20]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
+**[21]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
 
 `error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -384,21 +386,6 @@ different processes could be listening on TCP port 12345 and UDP port 12345.
 | `create` | A message is created. "Create" spans always refer to a single message and are used to provide a unique creation context for messages in batch publishing scenarios. |
 | `receive` | One or more messages are requested by a consumer. This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages. |
 | `deliver` | One or more messages are passed to a consumer. This operation refers to push-based scenarios, where consumer register callbacks which get called by messaging SDKs. |
-
-`messaging.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `activemq` | Apache ActiveMQ |
-| `aws_sqs` | Amazon Simple Queue Service (SQS) |
-| `azure_eventgrid` | Azure Event Grid |
-| `azure_eventhubs` | Azure Event Hubs |
-| `azure_servicebus` | Azure Service Bus |
-| `gcp_pubsub` | Google Cloud Pub/Sub |
-| `jms` | Java Message Service |
-| `kafka` | Apache Kafka |
-| `rabbitmq` | RabbitMQ |
-| `rocketmq` | Apache RocketMQ |
 
 `network.transport` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -238,38 +238,12 @@ groups:
         tag: tech-specific-gcp-pubsub
       - id: system
         brief: >
-          An identifier for the messaging system being used. See below for a list of well-known identifiers.
-        type:
-          allow_custom_values: true
-          members:
-            - id: activemq
-              value: 'activemq'
-              brief: 'Apache ActiveMQ'
-            - id: aws_sqs
-              value: 'aws_sqs'
-              brief: 'Amazon Simple Queue Service (SQS)'
-            - id: azure_eventgrid
-              value: 'azure_eventgrid'
-              brief: 'Azure Event Grid'
-            - id: azure_eventhubs
-              value: 'azure_eventhubs'
-              brief: 'Azure Event Hubs'
-            - id: azure_servicebus
-              value: 'azure_servicebus'
-              brief: 'Azure Service Bus'
-            - id: gcp_pubsub
-              value: 'gcp_pubsub'
-              brief: 'Google Cloud Pub/Sub'
-            - id: jms
-              value: 'jms'
-              brief: 'Java Message Service'
-            - id: kafka
-              value: 'kafka'
-              brief: 'Apache Kafka'
-            - id: rabbitmq
-              value: 'rabbitmq'
-              brief: 'RabbitMQ'
-            - id: rocketmq
-              value: 'rocketmq'
-              brief: 'Apache RocketMQ'
+          An identifier for the messaging system being used.
+        type: string
+        examples: ['kafka', 'rabbitmq']
+        note: >
+          Messaging instrumentations MUST use applicable value from the
+          [list of known messaging systems](/docs/messaging/README.md#technology-specific-semantic-conventions) when it is available.
+          When instrumenting a new messaging system, instrumentation authors should document the new system name and add it to the
+          [list](/docs/messaging/README.md#technology-specific-semantic-conventions).
         tag: messaging-generic

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -239,10 +239,19 @@ groups:
       - id: system
         brief: >
           An identifier for the messaging system being used.
-        type: string
+        type:
+          allow_custom_values: true
+          members:
+            - id: kafka
+              value: 'kafka'
+              brief: "Apache kafka"
+            - id: rabbitmq
+              value: 'rabbitmq'
+              brief: 'RabbitMQ'
         examples: ['kafka', 'rabbitmq']
         note: >
-          Messaging instrumentations MUST use applicable value from the
+          Semantic convention extensions MUST override value with their own identifier.
+          Instrumentation MUST use applicable value from the
           [list of known messaging systems](/docs/messaging/README.md#technology-specific-semantic-conventions) when it is available.
           When instrumenting a new messaging system, instrumentation authors should document the new system name and add it to the
           [list](/docs/messaging/README.md#technology-specific-semantic-conventions).

--- a/model/trace/messaging.yaml
+++ b/model/trace/messaging.yaml
@@ -113,8 +113,13 @@ groups:
       Attributes for Apache Kafka
     attributes:
       - ref: messaging.system
-        brief: >
-          MUST be set to `"kafka"`
+        type:
+          allow_custom_values: false
+          members:
+            - id: kafka
+              value: 'kafka'
+              brief: "Apache kafka"
+        examples: 'kafka'
       - ref: messaging.kafka.message.key
         tag: tech-specific-kafka
       - ref: messaging.kafka.consumer.group
@@ -135,8 +140,13 @@ groups:
       Attributes for Apache RocketMQ
     attributes:
       - ref: messaging.system
-        brief: >
-          MUST be set to `"rocketmq"`
+        type:
+          allow_custom_values: false
+          members:
+            - id: rocketmq
+              value: 'rocketmq'
+              brief: "Rocket MQ"
+        examples: 'rocketmq'
       - ref: messaging.rocketmq.namespace
         requirement_level: required
         tag: tech-specific-rocketmq
@@ -170,9 +180,58 @@ groups:
       Attributes for Google Cloud Pub/Sub
     attributes:
       - ref: messaging.system
-        brief: >
-          MUST be set to `"gcp_pubsub"`
+        type:
+          allow_custom_values: false
+          members:
+            - id: gcp_pubsub
+              value: 'gcp_pubsub'
+              brief: "Google Pub/Sub"
+        examples: 'gcp_pubsub'
       - ref: messaging.gcp_pubsub.message.ordering_key
         tag: tech-specific-gcp-pubsub
         requirement_level:
           conditionally_required: If the message type has an ordering key set.
+  - id: messaging.activemq
+    type: attribute_group
+    extends: messaging
+    brief: >
+      Attributes for ActiveMQ
+    attributes:
+      - ref: messaging.system
+        type:
+          allow_custom_values: false
+          members:
+            - id: activemq
+              value: 'activemq'
+              brief: "Active MQ"
+        examples: 'activemq'
+
+  - id: messaging.aws_sqs
+    type: attribute_group
+    extends: messaging
+    brief: >
+      Attributes for AWS SQS
+    attributes:
+      - ref: messaging.system
+        type:
+          allow_custom_values: false
+          members:
+            - id: aws_sqs
+              value: 'aws_sqs'
+              brief: "AWS SQS"
+        examples: 'aws_sqs'
+
+  - id: messaging.servicebus
+    type: attribute_group
+    extends: messaging
+    brief: >
+      Attributes for Azure ServiceBus
+    attributes:
+      - ref: messaging.system
+        type:
+          allow_custom_values: false
+          members:
+            - id: servicebus
+              value: 'servicebus'
+              brief: "Azure ServiceBus"
+        examples: 'servicebus'

--- a/model/trace/messaging.yaml
+++ b/model/trace/messaging.yaml
@@ -98,6 +98,9 @@ groups:
     brief: >
       Attributes for RabbitMQ
     attributes:
+      - ref: messaging.system
+        brief: >
+          MUST be set to `"rabbitmq"`
       - ref: messaging.rabbitmq.destination.routing_key
         requirement_level:
           conditionally_required: If not empty.
@@ -109,6 +112,9 @@ groups:
     brief: >
       Attributes for Apache Kafka
     attributes:
+      - ref: messaging.system
+        brief: >
+          MUST be set to `"kafka"`
       - ref: messaging.kafka.message.key
         tag: tech-specific-kafka
       - ref: messaging.kafka.consumer.group
@@ -128,6 +134,9 @@ groups:
     brief: >
       Attributes for Apache RocketMQ
     attributes:
+      - ref: messaging.system
+        brief: >
+          MUST be set to `"rocketmq"`
       - ref: messaging.rocketmq.namespace
         requirement_level: required
         tag: tech-specific-rocketmq
@@ -160,6 +169,9 @@ groups:
     brief: >
       Attributes for Google Cloud Pub/Sub
     attributes:
+      - ref: messaging.system
+        brief: >
+          MUST be set to `"gcp_pubsub"`
       - ref: messaging.gcp_pubsub.message.ordering_key
         tag: tech-specific-gcp-pubsub
         requirement_level:


### PR DESCRIPTION
Fixes #670

## Changes

Please provide a brief description of the changes here.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] ~~schema-next.yaml~~
