### PR TITLE
Re-open: Clarify that service.* conventions apply to all telemetry sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ release.
 
 ### Fixes
 
+- Clarify that `service.*` attributes apply to all telemetry sources.
+  ([#630](https://github.com/open-telemetry/semantic-conventions/pull/630))
+
 ## v1.24.0 (2023-12-15)
 
 ### Breaking

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -77,7 +77,7 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 
 **type:** `service`
 
-**Description:** A service instance.
+**Description:** A telemetry source. OpenTelemetry has adopted a broad interpretation such that every telemetry source is a service. Examples include, but are not limited to: web services, hosts, mobile applications, browser application, edge computing devices, functions as a service, databases, message brokers, etc. Specific types of telemetry sources may have additional conventions defining domain specific information, but the `service` conventions are applicable to all telemetry sources.
 
 <!-- semconv service -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
@@ -94,7 +94,7 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 
 **type:** `service`
 
-**Description:** Additions to service instance.
+**Description:** Experimental additions to service.
 
 <!-- semconv service_experimental -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |

--- a/model/resource/service.yaml
+++ b/model/resource/service.yaml
@@ -3,7 +3,12 @@ groups:
     prefix: service
     type: resource
     brief: >
-      A service instance.
+      A telemetry source. OpenTelemetry has adopted a broad interpretation such that every
+      telemetry source is a service. Examples include, but are not limited to: web services,
+      hosts, mobile applications, browser application, edge computing devices, functions as
+      a service, databases, message brokers, etc. Specific types of telemetry sources may have
+      additional conventions defining domain specific information, but the `service`
+      conventions are applicable to all telemetry sources.
     attributes:
       - id: name
         type: string

--- a/model/resource/service_experimental.yaml
+++ b/model/resource/service_experimental.yaml
@@ -3,7 +3,7 @@ groups:
     prefix: service
     type: resource
     brief: >
-      A service instance.
+      Experimental additions to service.
     attributes:
       - id: namespace
         type: string


### PR DESCRIPTION
This is the second attempt at #630, which was [reverted](https://github.com/open-telemetry/semantic-conventions/pull/638) over concerns that it was merged too quickly.

Including the original PR description below because it still stands:

The question of whether the `service.*` conventions are applicable only to web services is an important one that has come up several times. If the answer is yes, then everything that isn't a web service needs its own version of `service.name`, `service.instance.id`, `service.namespace`, `service.version` to uniquely define the thing producing telemetry. We've discussed this at length several times and while we don't have anything written down yet in the spec / semantic-conventions, the actions we've taken (i.e. rejecting alternatives like `telemetry.source`, `app.name`, etc) confirm that the `service.*` attributes are applicable to _all_ telemetry services, not some narrower subset that some people consider a web service.

This PR aims to clarify this to avoid repeating the same discussion.

Some PRs, issues that are related:

- https://github.com/open-telemetry/oteps/issues/244
- https://github.com/open-telemetry/opentelemetry-specification/issues/3791
- https://github.com/open-telemetry/semantic-conventions/pull/557
- open-telemetry/opentelemetry-specification#2050
- open-telemetry/opentelemetry-specification#2111
- open-telemetry/opentelemetry-specification#2115
- open-telemetry/opentelemetry-specification#2192
- open-telemetry/oteps#194

The conversation on #630 that [took place after merging](https://github.com/open-telemetry/semantic-conventions/pull/630#issuecomment-1887848300) is relevant to all reviewers.