### PR TITLE
[Editorial] Add missing stable status markers

### DIFF
--- a/docs/runtime/jvm-metrics.md
+++ b/docs/runtime/jvm-metrics.md
@@ -188,6 +188,8 @@ of `[ 0.01, 0.1, 1, 10 ]`.
 
 ## JVM Threads
 
+**Status**: [Stable][DocumentStatus]
+
 **Description:** Java Virtual Machine (JVM) metrics captured under the namespace `jvm.thread.*`
 
 ### Metric: `jvm.thread.count`
@@ -227,6 +229,8 @@ Note that this is the number of platform threads (as opposed to virtual threads)
 <!-- endsemconv -->
 
 ## JVM Classes
+
+**Status**: [Stable][DocumentStatus]
 
 **Description:** Java Virtual Machine (JVM) metrics captured under the namespace `jvm.class.*`
 


### PR DESCRIPTION
I missed these in #569.

The yaml for these 4 metrics are already tagged with `stability: stable`:

https://github.com/open-telemetry/semantic-conventions/blob/13a8238b4dcdd4261751b16012edef6388654f86/model/metrics/jvm-metrics.yaml#L133

https://github.com/open-telemetry/semantic-conventions/blob/13a8238b4dcdd4261751b16012edef6388654f86/model/metrics/jvm-metrics.yaml#L141

https://github.com/open-telemetry/semantic-conventions/blob/13a8238b4dcdd4261751b16012edef6388654f86/model/metrics/jvm-metrics.yaml#L149

https://github.com/open-telemetry/semantic-conventions/blob/13a8238b4dcdd4261751b16012edef6388654f86/model/metrics/jvm-metrics.yaml#L157