### PR TITLE
Omit version on changelog preview cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ chlog-validate: $(CHLOGGEN)
 
 .PHONY: chlog-preview
 chlog-preview: $(CHLOGGEN)
-	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --dry --version $(VERSION)
+	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --dry
 
 .PHONY: chlog-update
 chlog-update: $(CHLOGGEN)


### PR DESCRIPTION
The command `chlog-preview` had a version which prevents the [GH action to pass](https://github.com/open-telemetry/semantic-conventions/actions/runs/7792072479/job/21249390943?pr=566). The command don't need the version, as it will use a `vTODO` by default for that. 

CC @breedx-splk
