### PR TITLE
Update Azure messaging: settlement attributes and span names

### DIFF
--- a/.chloggen/697.yaml
+++ b/.chloggen/697.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+
+component: messaging
+
+note: Clarifies span names for Azure messaging systems and adds `messaging.servicebus.disposition_status attribute`.
+
+issues: [697]

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -157,7 +157,7 @@ size should be used.
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
 | `messaging.servicebus.destination.subscription_name` | string | The name of the subscription in the topic messages are received from. | `mySubscription` |
-| `messaging.servicebus.disposition_status` | string | Describes [settlement type](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock). | `complete` |
+| `messaging.servicebus.disposition_status` | string | Describes [settlement type](https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock). | `complete` |
 | `messaging.servicebus.message.delivery_count` | int | Number of deliveries that have been attempted for this message. | `2` |
 | `messaging.servicebus.message.enqueued_time` | int | The UTC epoch seconds at which the message has been accepted and stored in the entity. | `1701393730` |
 

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -157,7 +157,7 @@ size should be used.
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
 | `messaging.servicebus.destination.subscription_name` | string | The name of the subscription in the topic messages are received from. | `mySubscription` |
-| `messaging.servicebus.disposition_status` | string | Describes [settlement type](https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock). | `complete` |
+| `messaging.servicebus.disposition_status` | string | Describes the [settlement type](https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock). | `complete` |
 | `messaging.servicebus.message.delivery_count` | int | Number of deliveries that have been attempted for this message. | `2` |
 | `messaging.servicebus.message.enqueued_time` | int | The UTC epoch seconds at which the message has been accepted and stored in the entity. | `1701393730` |
 

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -157,6 +157,16 @@ size should be used.
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
 | `messaging.servicebus.destination.subscription_name` | string | The name of the subscription in the topic messages are received from. | `mySubscription` |
+| `messaging.servicebus.disposition_status` | string | Describes [settlement type](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock). | `complete` |
 | `messaging.servicebus.message.delivery_count` | int | Number of deliveries that have been attempted for this message. | `2` |
 | `messaging.servicebus.message.enqueued_time` | int | The UTC epoch seconds at which the message has been accepted and stored in the entity. | `1701393730` |
+
+`messaging.servicebus.disposition_status` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+
+| Value  | Description |
+|---|---|
+| `complete` | Message is completed |
+| `abandon` | Message is abandoned |
+| `dead_letter` | Message is sent to dead letter queue |
+| `defer` | Message is deferred |
 <!-- endsemconv -->

--- a/docs/messaging/azure-messaging.md
+++ b/docs/messaging/azure-messaging.md
@@ -14,8 +14,8 @@ The Semantic Conventions for [Azure Service Bus](https://learn.microsoft.com/azu
 
 ### Span names
 
-The span name SHOULD follow [the general messaging span name pattern](../messaging/azure-messaging.md): it SHOULD start with the messaging destination name (Event Hubs queue or topic name) and
-contain a low-cardinality name of the operation the span describes:
+The span name SHOULD follow [the general messaging span name pattern](../messaging/azure-messaging.md): it SHOULD start with the messaging destination name (Event Hubs queue or topic name) and contain a low-cardinality name of the operation the span describes:
+
 - Spans names for `settle` operations SHOULD follow the `<destination name> {messaging.servicebus.disposition_status}` pattern.
   For example, `my-queue complete` or `my-queue abandon`.
 - Spans names for `publish` operations SHOULD follow the `<destination name> send` pattern.

--- a/docs/messaging/azure-messaging.md
+++ b/docs/messaging/azure-messaging.md
@@ -29,7 +29,7 @@ The following additional attributes are defined:
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`messaging.servicebus.destination.subscription_name`](../attributes-registry/messaging.md) | string | The name of the subscription in the topic messages are received from. | `mySubscription` | Conditionally Required: If messages are received from the subscription. |
-| [`messaging.servicebus.disposition_status`](../attributes-registry/messaging.md) | string | Describes [settlement type](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock). | `complete` | Conditionally Required: if and only if `messaging.operation` is `settle`. |
+| [`messaging.servicebus.disposition_status`](../attributes-registry/messaging.md) | string | Describes [settlement type](https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock). | `complete` | Conditionally Required: if and only if `messaging.operation` is `settle`. |
 | [`messaging.servicebus.message.delivery_count`](../attributes-registry/messaging.md) | int | Number of deliveries that have been attempted for this message. | `2` | Conditionally Required: [1] |
 | [`messaging.servicebus.message.enqueued_time`](../attributes-registry/messaging.md) | int | The UTC epoch seconds at which the message has been accepted and stored in the entity. | `1701393730` | Recommended |
 

--- a/docs/messaging/azure-messaging.md
+++ b/docs/messaging/azure-messaging.md
@@ -16,10 +16,9 @@ The Semantic Conventions for [Azure Service Bus](https://learn.microsoft.com/azu
 
 The span name SHOULD follow [general messaging span name pattern](../messaging/azure-messaging.md): it SHOULD start with the messaging destination name (Event Hubs queue or topic name) and
 contain a low-cardinality name of an operation span describes:
-
-- Spans for `deliver` operation SHOULD follow `<destination name> process` pattern (matching terminology used in Azure client libraries)
-- Spans for `settle` operation SHOULD follow `<destination name> <disposition status>` pattern. Disposition status MUST match the value of `messaging.servicebus.disposition_status` attribute.
+- Spans names for `settle` operation SHOULD follow `<destination name> {messaging.servicebus.disposition_status}` pattern.
   For example, `my-queue complete` or `my-queue abandon`
+- Spans names for `publish` operation SHOULD follow `<destination name> send` pattern.
 - Spans for `create`, `receive`, and `publish` operations SHOULD follow general `<destination name> <operation name>` pattern
 
 ### Span attributes
@@ -45,8 +44,8 @@ The following additional attributes are defined:
 The span name SHOULD follow [general messaging span name pattern](../messaging/azure-messaging.md): it SHOULD start with the messaging destination name (Event Hubs namespace) and
 contain a low-cardinality name of an operation span describes:
 
-- Spans for `deliver` operation SHOULD follow  `<destination name> process` pattern (matching terminology used in Azure client libraries)
 - Spans for `settle` operation SHOULD follow  `<destination name> checkpoint` (matching Event Hubs terminology)
+- Spans names for `publish` operation SHOULD follow `<destination name> send` pattern
 - Spans for `create`, `receive`, and `publish` operations SHOULD follow general `<destination name> <operation name>` pattern
 
 ### Span attributes

--- a/docs/messaging/azure-messaging.md
+++ b/docs/messaging/azure-messaging.md
@@ -12,6 +12,16 @@ The Semantic Conventions for [Azure Service Bus](https://learn.microsoft.com/azu
 
 `messaging.system` MUST be set to `"servicebus"`.
 
+### Span names
+
+The span name SHOULD follow [general messaging span name pattern](../messaging/azure-messaging.md): it SHOULD start with the messaging destination name (Event Hubs queue or topic name) and
+contain a low-cardinality name of an operation span describes:
+
+- Spans for `deliver` operation SHOULD follow `<destination name> process` pattern (matching terminology used in Azure client libraries)
+- Spans for `settle` operation SHOULD follow `<destination name> <disposition status>` pattern. Disposition status MUST match the value of `messaging.servicebus.disposition_status` attribute.
+  For example, `my-queue complete` or `my-queue abandon`
+- Spans for `create`, `receive`, and `publish` operations SHOULD follow general `<destination name> <operation name>` pattern
+
 ### Span attributes
 
 The following additional attributes are defined:
@@ -19,6 +29,7 @@ The following additional attributes are defined:
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`messaging.servicebus.destination.subscription_name`](../attributes-registry/messaging.md) | string | The name of the subscription in the topic messages are received from. | `mySubscription` | Conditionally Required: If messages are received from the subscription. |
+| [`messaging.servicebus.disposition_status`](../attributes-registry/messaging.md) | string | Describes [settlement type](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock). | `complete` | Conditionally Required: if and only if `messaging.operation` is `settle`. |
 | [`messaging.servicebus.message.delivery_count`](../attributes-registry/messaging.md) | int | Number of deliveries that have been attempted for this message. | `2` | Conditionally Required: [1] |
 | [`messaging.servicebus.message.enqueued_time`](../attributes-registry/messaging.md) | int | The UTC epoch seconds at which the message has been accepted and stored in the entity. | `1701393730` | Recommended |
 
@@ -28,6 +39,15 @@ The following additional attributes are defined:
 ## Azure Event Hubs
 
 `messaging.system` MUST be set to `"eventhubs"`.
+
+### Span names
+
+The span name SHOULD follow [general messaging span name pattern](../messaging/azure-messaging.md): it SHOULD start with the messaging destination name (Event Hubs namespace) and
+contain a low-cardinality name of an operation span describes:
+
+- Spans for `deliver` operation SHOULD follow  `<destination name> process` pattern (matching terminology used in Azure client libraries)
+- Spans for `settle` operation SHOULD follow  `<destination name> checkpoint` (matching Event Hubs terminology)
+- Spans for `create`, `receive`, and `publish` operations SHOULD follow general `<destination name> <operation name>` pattern
 
 ### Span attributes
 

--- a/docs/messaging/azure-messaging.md
+++ b/docs/messaging/azure-messaging.md
@@ -14,12 +14,12 @@ The Semantic Conventions for [Azure Service Bus](https://learn.microsoft.com/azu
 
 ### Span names
 
-The span name SHOULD follow [general messaging span name pattern](../messaging/azure-messaging.md): it SHOULD start with the messaging destination name (Event Hubs queue or topic name) and
-contain a low-cardinality name of an operation span describes:
-- Spans names for `settle` operation SHOULD follow `<destination name> {messaging.servicebus.disposition_status}` pattern.
-  For example, `my-queue complete` or `my-queue abandon`
-- Spans names for `publish` operation SHOULD follow `<destination name> send` pattern.
-- Spans for `create`, `receive`, and `publish` operations SHOULD follow general `<destination name> <operation name>` pattern
+The span name SHOULD follow [the general messaging span name pattern](../messaging/azure-messaging.md): it SHOULD start with the messaging destination name (Event Hubs queue or topic name) and
+contain a low-cardinality name of the operation the span describes:
+- Spans names for `settle` operations SHOULD follow the `<destination name> {messaging.servicebus.disposition_status}` pattern.
+  For example, `my-queue complete` or `my-queue abandon`.
+- Spans names for `publish` operations SHOULD follow the `<destination name> send` pattern.
+- Spans for `create`, `receive`, and `publish` operations SHOULD follow the general `<destination name> <operation name>` pattern.
 
 ### Span attributes
 
@@ -28,7 +28,7 @@ The following additional attributes are defined:
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`messaging.servicebus.destination.subscription_name`](../attributes-registry/messaging.md) | string | The name of the subscription in the topic messages are received from. | `mySubscription` | Conditionally Required: If messages are received from the subscription. |
-| [`messaging.servicebus.disposition_status`](../attributes-registry/messaging.md) | string | Describes [settlement type](https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock). | `complete` | Conditionally Required: if and only if `messaging.operation` is `settle`. |
+| [`messaging.servicebus.disposition_status`](../attributes-registry/messaging.md) | string | Describes the [settlement type](https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock). | `complete` | Conditionally Required: if and only if `messaging.operation` is `settle`. |
 | [`messaging.servicebus.message.delivery_count`](../attributes-registry/messaging.md) | int | Number of deliveries that have been attempted for this message. | `2` | Conditionally Required: [1] |
 | [`messaging.servicebus.message.enqueued_time`](../attributes-registry/messaging.md) | int | The UTC epoch seconds at which the message has been accepted and stored in the entity. | `1701393730` | Recommended |
 
@@ -41,12 +41,12 @@ The following additional attributes are defined:
 
 ### Span names
 
-The span name SHOULD follow [general messaging span name pattern](../messaging/azure-messaging.md): it SHOULD start with the messaging destination name (Event Hubs namespace) and
-contain a low-cardinality name of an operation span describes:
+The span name SHOULD follow the [general messaging span name pattern](../messaging/azure-messaging.md): it SHOULD start with the messaging destination name (Event Hubs namespace) and
+contain a low-cardinality name of an operation the span describes:
 
-- Spans for `settle` operation SHOULD follow  `<destination name> checkpoint` (matching Event Hubs terminology)
-- Spans names for `publish` operation SHOULD follow `<destination name> send` pattern
-- Spans for `create`, `receive`, and `publish` operations SHOULD follow general `<destination name> <operation name>` pattern
+- Spans for `settle` operations SHOULD follow the `<destination name> checkpoint` pattern (matching Event Hubs terminology).
+- Spans names for `publish` operations SHOULD follow the `<destination name> send` pattern.
+- Spans for `create`, `receive`, and `publish` operations SHOULD follow the general `<destination name> <operation name>` pattern.
 
 ### Span attributes
 

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -298,6 +298,25 @@ groups:
           The name of the subscription in the topic messages are received from.
         examples: "mySubscription"
         tag: tech-specific-servicebus
+      - id: servicebus.disposition_status
+        brief: >
+          Describes [settlement type](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock).
+        type:
+          allow_custom_values: true
+          members:
+            - id: complete
+              value: 'complete'
+              brief: 'Message is completed'
+            - id: abandon
+              value: 'abandon'
+              brief: 'Message is abandoned'
+            - id: dead_letter
+              value: 'dead_letter'
+              brief: 'Message is sent to dead letter queue'
+            - id: defer
+              value: 'defer'
+              brief: 'Message is deferred'
+        tag: tech-specific-servicebus
       - id: eventhubs.message.enqueued_time
         type: int
         brief: >

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -316,6 +316,7 @@ groups:
             - id: defer
               value: 'defer'
               brief: 'Message is deferred'
+        stability: experimental
         tag: tech-specific-servicebus
       - id: eventhubs.message.enqueued_time
         type: int

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -300,7 +300,7 @@ groups:
         tag: tech-specific-servicebus
       - id: servicebus.disposition_status
         brief: >
-          Describes [settlement type](https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock).
+          Describes the [settlement type](https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock).
         type:
           allow_custom_values: true
           members:

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -300,7 +300,7 @@ groups:
         tag: tech-specific-servicebus
       - id: servicebus.disposition_status
         brief: >
-          Describes [settlement type](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock).
+          Describes [settlement type](https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock).
         type:
           allow_custom_values: true
           members:

--- a/model/trace/messaging.yaml
+++ b/model/trace/messaging.yaml
@@ -181,6 +181,9 @@ groups:
       - ref: messaging.servicebus.destination.subscription_name
         requirement_level:
           conditionally_required: If messages are received from the subscription.
+      - ref: messaging.servicebus.disposition_status
+        requirement_level:
+          conditionally_required: if and only if `messaging.operation` is `settle`.
   - id: messaging.eventhubs
     type: attribute_group
     extends: messaging


### PR DESCRIPTION
## Changes

- Adds Azure Service Bus-specific attribute describing settlement type (`complete`, `abandon`, `defer`, `dead_letter`)
- Clarifies operation names for settlement and deliver span

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* ~~schema-next.yaml~~
