### PR TITLE
Add placeholder for database stability transition plan

### DIFF
--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -12,6 +12,13 @@ path_base_for_github_subdir:
 This document defines semantic conventions for database client spans as well as
 database metrics and logs.
 
+> **Warning**
+> Existing database instrumentations that are using
+> [v1.24.0 of this document](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/README.md)
+> (or prior) SHOULD NOT change the version of the database conventions that they emit
+> until a transition plan to the (future) stable semantic conventions has been published.
+> Conventions include, but are not limited to, attributes, metric and span names, and unit of measure.
+
 Semantic conventions for database operations are defined for the following signals:
 
 * [DB Spans](database-spans.md): Semantic Conventions for database client *spans*.

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -28,6 +28,13 @@ and attributes but more may be added in the future.
 
 <!-- tocstop -->
 
+> **Warning**
+> Existing database instrumentations that are using
+> [v1.24.0 of this document](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/database-metrics.md)
+> (or prior) SHOULD NOT change the version of the database conventions that they emit
+> until a transition plan to the (future) stable semantic conventions has been published.
+> Conventions include, but are not limited to, attributes, metric and span names, and unit of measure.
+
 ## Connection pools
 
 The following metric instruments describe database client connection pool operations.

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -24,6 +24,7 @@ linkTitle: Client Calls
 > until a transition plan to the (future) stable semantic conventions has been published.
 > Conventions include, but are not limited to, attributes, metric and span names, and unit of measure.
 
+
 > **Warning**
 > Existing Database instrumentations that are using
 > [v1.20.0 of this document](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/database.md)

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -23,8 +23,7 @@ linkTitle: Client Calls
 > (or prior) SHOULD NOT change the version of the database conventions that they emit
 > until a transition plan to the (future) stable semantic conventions has been published.
 > Conventions include, but are not limited to, attributes, metric and span names, and unit of measure.
-
-
+>
 > **Warning**
 > Existing Database instrumentations that are using
 > [v1.20.0 of this document](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/database.md)

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -18,6 +18,13 @@ linkTitle: Client Calls
 <!-- tocstop -->
 
 > **Warning**
+> Existing database instrumentations that are using
+> [v1.24.0 of this document](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/database-spans.md)
+> (or prior) SHOULD NOT change the version of the database conventions that they emit
+> until a transition plan to the (future) stable semantic conventions has been published.
+> Conventions include, but are not limited to, attributes, metric and span names, and unit of measure.
+
+> **Warning**
 > Existing Database instrumentations that are using
 > [v1.20.0 of this document](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/database.md)
 > (or prior):


### PR DESCRIPTION
Related to #719

This will allow us to start sending PRs as part of the database semantic convention stability effort.