### PR TITLE
Add messaging.gcp_pubsub.message.ack_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 - Add Azure Service Bus and Event Hubs messaging attributes
   ([#572](https://github.com/open-telemetry/semantic-conventions/pull/572))
 - Add `messaging.gcp_pubsub.message.ack_result` span attribute
-  ([add PR link])
+  ([737](https://github.com/open-telemetry/semantic-conventions/pull/737))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
   ([#597](https://github.com/open-telemetry/semantic-conventions/pull/597))
 - Add Azure Service Bus and Event Hubs messaging attributes
   ([#572](https://github.com/open-telemetry/semantic-conventions/pull/572))
+- Add `messaging.gcp_pubsub.message.ack_result` span attribute
+  ([add PR link])
 
 ### Fixes
 

--- a/docs/messaging/gcp-pubsub.md
+++ b/docs/messaging/gcp-pubsub.md
@@ -16,7 +16,15 @@ For Google Cloud Pub/Sub, the following additional attributes are defined:
 <!-- semconv messaging.gcp_pubsub(full,tag=tech-specific-gcp-pubsub) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
+| `messaging.gcp_pubsub.message.ack_result` | string | The subscriber's acknowledgement of a message. If missing, the subscriber did not chose whether or not to acknowledge the message. | `ack`; `nack` | Conditionally Required: If the subscriber ACKs or NACKs the message. |
 | [`messaging.gcp_pubsub.message.ordering_key`](../attributes-registry/messaging.md) | string | The ordering key for a given message. If the attribute is not present, the message does not have an ordering key. | `ordering_key` | Conditionally Required: If the message type has an ordering key set. |
+
+`messaging.gcp_pubsub.message.ack_result` MUST be one of the following:
+
+| Value  | Description |
+|---|---|
+| `ack` | The subscriber chose to acknowledge the message. |
+| `nack` | The subscriber chose to NOT acknowledge the message. |
 <!-- endsemconv -->
 
 ## Examples

--- a/model/trace/messaging.yaml
+++ b/model/trace/messaging.yaml
@@ -164,6 +164,22 @@ groups:
         tag: tech-specific-gcp-pubsub
         requirement_level:
           conditionally_required: If the message type has an ordering key set.
+      - id: messaging.gcp_pubsub.message.ack_result
+        tag: tech-specific-gcp-pubsub
+        brief: >
+          The subscriber's acknowledgement of a message. If missing, the subscriber did not chose whether or not to acknowledge the message.
+        requirement_level:
+          conditionally_required: If the subscriber ACKs or NACKs the message.
+        examples: ['ack', 'nack']
+        type:
+          allow_custom_values: false
+          members:
+            - id: ack
+              value: 'ack'
+              brief: The subscriber chose to acknowledge the message.
+            - id: nack
+              value: 'nack'
+              brief: The subscriber chose to NOT acknowledge the message.
   - id: messaging.servicebus
     type: attribute_group
     extends: messaging


### PR DESCRIPTION
Fixes #

## Changes

Add attribute `messaging.gcp_pubsub.message.ack_result` for spans from pubsub subscribers handling a message.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
