### PR TITLE
Use db.instance.id instead of specific elasticsearch node name attribute

### DIFF
--- a/.chloggen/738.yaml
+++ b/.chloggen/738.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: db
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update Elasticsearch attributes to use db.instance.id instead of db.elasticsearch.node.name
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [725]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -9,7 +9,6 @@
 - [Cassandra Attributes](#cassandra-attributes)
 - [CosmosDB Attributes](#cosmosdb-attributes)
 - [Elasticsearch Attributes](#elasticsearch-attributes)
-- [JDBC Attributes](#jdbc-attributes)
 - [MongoDB Attributes](#mongodb-attributes)
 - [MSSQL Attributes](#mssql-attributes)
 - [Redis Attributes](#redis-attributes)

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -176,6 +176,14 @@
 **[1]:** Many Elasticsearch url paths allow dynamic values. These SHOULD be recorded in span attributes in the format `db.elasticsearch.path_parts.<key>`, where `<key>` is the url path part name. The implementation SHOULD reference the [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json) in order to map the path part values to their names.
 <!-- endsemconv -->
 
+## JDBC Attributes
+
+<!-- semconv registry.db(omit_requirement_level,tag=tech-specific-jdbc) -->
+| Attribute  | Type | Description  | Examples  |
+|---|---|---|---|
+| `db.jdbc.driver_classname` | string | The fully-qualified class name of the [Java Database Connectivity (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to connect. | `org.postgresql.Driver`; `com.microsoft.sqlserver.jdbc.SQLServerDriver` |
+<!-- endsemconv -->
+
 ## MongoDB Attributes
 
 <!-- semconv registry.db(omit_requirement_level,tag=tech-specific-mongodb) -->
@@ -219,4 +227,12 @@
 |---|---|---|---|
 | `db.connection_string` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `server.address`, `server.port` attributes instead. | `Server=(localdb)\v11.0;Integrated Security=true;` |
 | `db.jdbc.driver_classname` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, no replacement at this time. | `org.postgresql.Driver`; `com.microsoft.sqlserver.jdbc.SQLServerDriver` |
+<!-- endsemconv -->
+
+### Deprecated Elasticsearch Attributes
+
+<!-- semconv attributes.db.deprecated(omit_requirement_level,tag=call-level-tech-specific) -->
+| Attribute  | Type | Description  | Examples  |
+|---|---|---|---|
+| `db.elasticsearch.node.name` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `db.instance.id` instead. | `instance-0000000001` |
 <!-- endsemconv -->

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -233,7 +233,7 @@
 
 ### Deprecated Elasticsearch Attributes
 
-<!-- semconv attributes.db.deprecated(omit_requirement_level,tag=call-level-tech-specific) -->
+<!-- semconv attributes.db.deprecated(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
 | `db.elasticsearch.node.name` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `db.instance.id` instead. | `instance-0000000001` |

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -9,11 +9,13 @@
 - [Cassandra Attributes](#cassandra-attributes)
 - [CosmosDB Attributes](#cosmosdb-attributes)
 - [Elasticsearch Attributes](#elasticsearch-attributes)
+- [JDBC Attributes](#jdbc-attributes)
 - [MongoDB Attributes](#mongodb-attributes)
 - [MSSQL Attributes](#mssql-attributes)
 - [Redis Attributes](#redis-attributes)
 - [SQL Attributes](#sql-attributes)
 - [Deprecated DB Attributes](#deprecated-db-attributes)
+- [Deprecated Elasticsearch Attributes](#deprecated-elasticsearch-attributes)
 
 <!-- tocstop -->
 

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -168,11 +168,11 @@
 ## Elasticsearch Attributes
 
 <!-- semconv registry.db(omit_requirement_level,tag=tech-specific-elasticsearch) -->
-| Attribute  | Type | Description  | Examples  |
-|---|---|---|---|
-| `db.elasticsearch.cluster.name` | string | Represents the identifier of an Elasticsearch cluster. | `e9106fc68e3044f0b1475b04bf4ffd5f` |
-| `db.elasticsearch.node.name` | string | Represents the human-readable identifier of the node/instance to which a request was routed. | `instance-0000000001` |
-| `db.elasticsearch.path_parts.<key>` | string | A dynamic value in the url path. [1] | `db.elasticsearch.path_parts.index=test-index`; `db.elasticsearch.path_parts.doc_id=123` |
+| Attribute  | Type | Description                                                                                 | Examples  |
+|---|---|---------------------------------------------------------------------------------------------|---|
+| `db.elasticsearch.cluster.name` | string | Represents the identifier of an Elasticsearch cluster.                                      | `e9106fc68e3044f0b1475b04bf4ffd5f` |
+| `db.elasticsearch.node.name` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `db.instance.id` instead. | `instance-0000000001` |
+| `db.elasticsearch.path_parts.<key>` | string | A dynamic value in the url path. [1]                                                        | `db.elasticsearch.path_parts.index=test-index`; `db.elasticsearch.path_parts.doc_id=123` |
 
 **[1]:** Many Elasticsearch url paths allow dynamic values. These SHOULD be recorded in span attributes in the format `db.elasticsearch.path_parts.<key>`, where `<key>` is the url path part name. The implementation SHOULD reference the [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json) in order to map the path part values to their names.
 <!-- endsemconv -->

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -168,11 +168,10 @@
 ## Elasticsearch Attributes
 
 <!-- semconv registry.db(omit_requirement_level,tag=tech-specific-elasticsearch) -->
-| Attribute  | Type | Description                                                                                 | Examples  |
-|---|---|---------------------------------------------------------------------------------------------|---|
-| `db.elasticsearch.cluster.name` | string | Represents the identifier of an Elasticsearch cluster.                                      | `e9106fc68e3044f0b1475b04bf4ffd5f` |
-| `db.elasticsearch.node.name` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `db.instance.id` instead. | `instance-0000000001` |
-| `db.elasticsearch.path_parts.<key>` | string | A dynamic value in the url path. [1]                                                        | `db.elasticsearch.path_parts.index=test-index`; `db.elasticsearch.path_parts.doc_id=123` |
+| Attribute  | Type | Description  | Examples  |
+|---|---|---|---|
+| `db.elasticsearch.cluster.name` | string | Represents the identifier of an Elasticsearch cluster. | `e9106fc68e3044f0b1475b04bf4ffd5f` |
+| `db.elasticsearch.path_parts.<key>` | string | A dynamic value in the url path. [1] | `db.elasticsearch.path_parts.index=test-index`; `db.elasticsearch.path_parts.doc_id=123` |
 
 **[1]:** Many Elasticsearch url paths allow dynamic values. These SHOULD be recorded in span attributes in the format `db.elasticsearch.path_parts.<key>`, where `<key>` is the url path part name. The implementation SHOULD reference the [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json) in order to map the path part values to their names.
 <!-- endsemconv -->

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -14,7 +14,7 @@
 - [Redis Attributes](#redis-attributes)
 - [SQL Attributes](#sql-attributes)
 - [Deprecated DB Attributes](#deprecated-db-attributes)
-- [Deprecated Elasticsearch Attributes](#deprecated-elasticsearch-attributes)
+  - [Deprecated Elasticsearch Attributes](#deprecated-elasticsearch-attributes)
 
 <!-- tocstop -->
 

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -177,14 +177,6 @@
 **[1]:** Many Elasticsearch url paths allow dynamic values. These SHOULD be recorded in span attributes in the format `db.elasticsearch.path_parts.<key>`, where `<key>` is the url path part name. The implementation SHOULD reference the [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json) in order to map the path part values to their names.
 <!-- endsemconv -->
 
-## JDBC Attributes
-
-<!-- semconv registry.db(omit_requirement_level,tag=tech-specific-jdbc) -->
-| Attribute  | Type | Description  | Examples  |
-|---|---|---|---|
-| `db.jdbc.driver_classname` | string | The fully-qualified class name of the [Java Database Connectivity (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to connect. | `org.postgresql.Driver`; `com.microsoft.sqlserver.jdbc.SQLServerDriver` |
-<!-- endsemconv -->
-
 ## MongoDB Attributes
 
 <!-- semconv registry.db(omit_requirement_level,tag=tech-specific-mongodb) -->

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -219,6 +219,7 @@
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
 | `db.connection_string` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `server.address`, `server.port` attributes instead. | `Server=(localdb)\v11.0;Integrated Security=true;` |
+| `db.elasticsearch.node.name` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `db.instance.id` instead. | `instance-0000000001` |
 | `db.jdbc.driver_classname` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, no replacement at this time. | `org.postgresql.Driver`; `com.microsoft.sqlserver.jdbc.SQLServerDriver` |
 <!-- endsemconv -->
 
@@ -227,5 +228,7 @@
 <!-- semconv attributes.db.deprecated(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
+| `db.connection_string` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `server.address`, `server.port` attributes instead. | `Server=(localdb)\v11.0;Integrated Security=true;` |
 | `db.elasticsearch.node.name` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `db.instance.id` instead. | `instance-0000000001` |
+| `db.jdbc.driver_classname` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, no replacement at this time. | `org.postgresql.Driver`; `com.microsoft.sqlserver.jdbc.SQLServerDriver` |
 <!-- endsemconv -->

--- a/docs/database/elasticsearch.md
+++ b/docs/database/elasticsearch.md
@@ -105,6 +105,6 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 | `url.full`                          | `"https://elasticsearch.mydomain.com:9200/my-index-000001/_search?from=40&size=20"`                                                 |
 | `db.elasticsearch.path_parts.index` | `"my-index-000001"`                                                                                                                 |
 | `db.elasticsearch.cluster.name`     | `"e9106fc68e3044f0b1475b04bf4ffd5f"`                                                                                                |
-| `db.elasticsearch.node.name` | `"instance-0000000001"`                                                                                                             |
+| `db.elasticsearch.instance.id`      | `"instance-0000000001"`                                                                                                             |
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/docs/database/elasticsearch.md
+++ b/docs/database/elasticsearch.md
@@ -105,6 +105,6 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 | `url.full`                          | `"https://elasticsearch.mydomain.com:9200/my-index-000001/_search?from=40&size=20"`                                                 |
 | `db.elasticsearch.path_parts.index` | `"my-index-000001"`                                                                                                                 |
 | `db.elasticsearch.cluster.name`     | `"e9106fc68e3044f0b1475b04bf4ffd5f"`                                                                                                |
-| `db.elasticsearch.instance.id`      | `"instance-0000000001"`                                                                                                             |
+| `db.instance.id`      | `"instance-0000000001"`                                                                                                             |
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/docs/database/elasticsearch.md
+++ b/docs/database/elasticsearch.md
@@ -27,8 +27,8 @@ If the endpoint id is not available, the span name SHOULD be the `http.request.m
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.elasticsearch.cluster.name`](../attributes-registry/db.md) | string | Represents the identifier of an Elasticsearch cluster. | `e9106fc68e3044f0b1475b04bf4ffd5f` | Recommended: [1] |
-| [`db.elasticsearch.node.name`](../attributes-registry/db.md) | string | Represents the human-readable identifier of the node/instance to which a request was routed. | `instance-0000000001` | Recommended: [2] |
-| [`db.elasticsearch.path_parts.<key>`](../attributes-registry/db.md) | string | A dynamic value in the url path. [3] | `db.elasticsearch.path_parts.index=test-index`; `db.elasticsearch.path_parts.doc_id=123` | Conditionally Required: when the url has dynamic values |
+| [`db.elasticsearch.path_parts.<key>`](../attributes-registry/db.md) | string | A dynamic value in the url path. [2] | `db.elasticsearch.path_parts.index=test-index`; `db.elasticsearch.path_parts.doc_id=123` | Conditionally Required: when the url has dynamic values |
+| [`db.instance.id`](../attributes-registry/db.md) | string | An identifier (address, unique name, or any other identifier) of the database instance that is executing queries or mutations on the current connection. This is useful in cases where the database is running in a clustered environment and the instrumentation is able to record the node executing the query. The client may obtain this value in databases like MySQL using queries like `select @@hostname`. | `mysql-e26b99z.example.com` | Recommended: [3] |
 | [`db.operation`](../attributes-registry/db.md) | string | The endpoint identifier for the request. [4] | `search`; `ml.close_job`; `cat.aliases` | Required |
 | [`db.statement`](../attributes-registry/db.md) | string | The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string. | `"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"` | Recommended: [5] |
 | [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [6] | `GET`; `POST`; `HEAD` | Required |
@@ -40,9 +40,9 @@ If the endpoint id is not available, the span name SHOULD be the `http.request.m
 
 **[1]:** When communicating with an Elastic Cloud deployment, this should be collected from the "X-Found-Handling-Cluster" HTTP response header.
 
-**[2]:** When communicating with an Elastic Cloud deployment, this should be collected from the "X-Found-Handling-Instance" HTTP response header.
+**[2]:** Many Elasticsearch url paths allow dynamic values. These SHOULD be recorded in span attributes in the format `db.elasticsearch.path_parts.<key>`, where `<key>` is the url path part name. The implementation SHOULD reference the [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json) in order to map the path part values to their names.
 
-**[3]:** Many Elasticsearch url paths allow dynamic values. These SHOULD be recorded in span attributes in the format `db.elasticsearch.path_parts.<key>`, where `<key>` is the url path part name. The implementation SHOULD reference the [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json) in order to map the path part values to their names.
+**[3]:** When communicating with an Elastic Cloud deployment, this should be collected from the "X-Found-Handling-Instance" HTTP response header.
 
 **[4]:** When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
 

--- a/model/registry/db.yaml
+++ b/model/registry/db.yaml
@@ -173,13 +173,6 @@ groups:
           Represents the identifier of an Elasticsearch cluster.
         examples: ["e9106fc68e3044f0b1475b04bf4ffd5f"]
         tag: tech-specific-elasticsearch
-      - id: elasticsearch.node.name
-        type: string
-        stability: experimental
-        brief: >
-          Represents the human-readable identifier of the node/instance to which a request was routed.
-        examples: ["instance-0000000001"]
-        tag: tech-specific-elasticsearch
       - id: elasticsearch.path_parts
         type: template[string]
         stability: experimental

--- a/model/registry/deprecated/db.yaml
+++ b/model/registry/deprecated/db.yaml
@@ -16,3 +16,8 @@ groups:
         brief: 'Removed, no replacement at this time.'
         deprecated: 'Removed as not used.'
         examples: ['org.postgresql.Driver', 'com.microsoft.sqlserver.jdbc.SQLServerDriver']
+      - id: elasticsearch.node.name
+        type: string
+        brief: 'Deprecated, use `db.instance.id` instead.'
+        deprecated: "Replaced by `db.instance.id`."
+        examples: ["instance-0000000001"]

--- a/model/trace/database.yaml
+++ b/model/trace/database.yaml
@@ -189,7 +189,7 @@ groups:
           recommended: >
             When communicating with an Elastic Cloud deployment, this should be collected from the "X-Found-Handling-Cluster" HTTP response header.
         tag: tech-specific
-      - ref: db.elasticsearch.node.name
+      - ref: db.instance.id
         requirement_level:
           recommended: >
             When communicating with an Elastic Cloud deployment, this should be collected from the "X-Found-Handling-Instance" HTTP response header.


### PR DESCRIPTION
## Changes

As per #725 this PR changes the Elasticsearch semantic conventions to use the `db.instance.id` attribute instead of `db.elasticsearch.node.name`.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
