### PR TITLE
[chore] Change Traces SemConv Status to Mixed

### DIFF
--- a/docs/general/trace.md
+++ b/docs/general/trace.md
@@ -5,7 +5,7 @@ aliases: [docs/specs/semconv/general/trace-general]
 
 # Trace Semantic Conventions
 
-**Status**: [Experimental][DocumentStatus]
+**Status**: [Mixed][DocumentStatus]
 
 In OpenTelemetry spans can be created freely and it’s up to the implementor to
 annotate them with attributes specific to the represented operation. Spans


### PR DESCRIPTION
Fixes #

## Changes

Now that HTTP Span/Trace Semantic Conventions are marked stable, the overall status should be "Mixed" 

## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
