### PR TITLE
[chore] Exclude issues from stale bot check

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -14,5 +14,5 @@ jobs:
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           exempt-pr-labels: 'bug,work in progress,experts needed'
           exempt-draft-pr: true
-          days-before-stale: 15
-          days-before-close: 7
+          days-before-pr-stale: 15
+          days-before-pr-close: 7


### PR DESCRIPTION
I noticed that the stale bot is applying label to issues, which is not intended. We were using `days-before-stale` which is for PRs and Issues, and now I changed it to the PR specific ones. 

Edit: I went through the issues and removed the label. 