### PR TITLE
App unresponsive UI event

### DIFF
--- a/docs/mobile/events.md
+++ b/docs/mobile/events.md
@@ -8,11 +8,26 @@ events on mobile platforms. All mobile events MUST use a namespace of
 
 <!-- toc -->
 
+- [Application unresponsive UI](#application-unresponsive-ui)
 - [Lifecycle instrumentation](#lifecycle-instrumentation)
   * [iOS](#ios)
   * [Android](#android)
 
 <!-- tocstop -->
+
+## Application unresponsive UI
+
+This event denotes when an application's UI "freezes", making users unable to interact with the app. It happens when the
+main thread (which is in charge of rendering the UI) gets blocked by a long-running task for a certain amount of time.
+
+The amount of time the UI must be frozen to trigger this event is implementation-specific, however, for Android applications
+it is recommended to be 5 seconds.
+
+The event name MUST be `device.app.unresponsive_ui`.
+
+| Attribute              | Type | Description                        | Examples                                                                                                                 | Requirement Level |
+|------------------------|---|------------------------------------|--------------------------------------------------------------------------------------------------------------------------|-------------------|
+| `stacktrace` | string | The stacktrace of the main thread. | `com.example.Type.aMethod(Type.java:39)\njava.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)` | Recommended       |
 
 ## Lifecycle instrumentation
 

--- a/model/logs/mobile-events.yaml
+++ b/model/logs/mobile-events.yaml
@@ -1,4 +1,17 @@
 groups:
+  - id: device.app.unresponsive_ui
+    type: event
+    name: device.app.unresponsive_ui
+    brief: >
+      This event denotes when an application's UI "freezes", making users unable to interact with the app. It happens when the
+      main thread (which is in charge of rendering the UI) gets blocked by a long-running task for a certain amount of time.
+
+      The amount of time the UI must be frozen to trigger this event is implementation-specific, however, for Android applications
+      it is recommended to be 5 seconds.
+    attributes:
+      - id: stacktrace
+        requirement_level: opt_in
+        brief: The stacktrace of the main thread.
   - id: ios.lifecycle.events
     type: event
     prefix: ios


### PR DESCRIPTION
Fixes #

## Changes

Please provide a brief description of the changes here.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
