### PR TITLE
Android activity creation spans

### DIFF
--- a/docs/mobile/android/activity-creation.md
+++ b/docs/mobile/android/activity-creation.md
@@ -2,14 +2,16 @@
 
 **Status**: [Experimental][DocumentStatus]
 
-This document defines semantic conventions for Android Spans related to the creation of an [Activity](https://developer.android.com/reference/android/app/Activity).
+This document defines semantic conventions for Android Spans related to the creation of
+an [Activity](https://developer.android.com/reference/android/app/Activity).
 
-Ensuring that an Activity subclass takes a reasonable amount of time to get started, hence displaying a screen initial content as fast as possible, is important to provide a good user experience. The spans
-mentioned in this document are meant to cover all Activity-creation related methods in order to provide a screen's overall screen rendering time.
+Ensuring that an Activity subclass takes a reasonable amount of time to get started, hence displaying a screen initial
+content as fast as possible, is important to provide a good user experience. The spans mentioned in this document are
+meant to cover all Activity-creation related methods in order to provide a screen's overall rendering time.
 
-There are 3 methods that are relevant to measure the time it takes for an Activity to get created, those are: `onCreate`, `onStart`, and `onResume`. Each of
-those will be called sequentially in that order, therefore, to cover an Activity creation, a span MUST be created for each
-of the those 3 methods per Activity.
+There are 3 methods that are relevant to measure the time it takes for an Activity to get created, those
+are: `onCreate`, `onStart`, and `onResume`. Each of those will be called sequentially in that order, therefore, to cover
+an Activity creation, a span MUST be created for each of the those 3 methods per Activity.
 
 ## Name
 
@@ -19,6 +21,13 @@ For each of the 3 spans, their names MUST start with the method name, followed b
 <method name> [<screen name whenever available>]
 ```
 
-For example, for the creation of an Activity with screen name "Home", the 3 span names would look like the following: `onCreate Home`, `onStart Home`, and `onResume Home`.
+For example, for the creation of an Activity with screen name "Home", the 3 span names would look like the
+following: `onCreate Home`, `onStart Home`, and `onResume Home`.
+
+## Span attributes
+
+| Attribute                                            | Type   | Description                                        | Examples                   | Requirement Level |
+|------------------------------------------------------|--------|----------------------------------------------------|----------------------------|-------------------|
+| [`activity.name`](../attributes-registry/android.md) | string | The fully qualified name of the Activity subclass. | `com.example.HomeActivity` | Recommended       |
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/docs/mobile/android/activity-creation.md
+++ b/docs/mobile/android/activity-creation.md
@@ -1,0 +1,24 @@
+# Semantic Conventions for Android Activity creation Spans
+
+**Status**: [Experimental][DocumentStatus]
+
+This document defines semantic conventions for Android Spans related to the creation of an [Activity](https://developer.android.com/reference/android/app/Activity).
+
+Ensuring that an Activity subclass takes a reasonable amount of time to get started, hence displaying a screen initial content as fast as possible, is important to provide a good user experience. The spans
+mentioned in this document are meant to cover all Activity-creation related methods in order to provide a screen's overall screen rendering time.
+
+There are 3 methods that are relevant to measure the time it takes for an Activity to get created, those are: `onCreate`, `onStart`, and `onResume`. Each of
+those will be called sequentially in that order, therefore, to cover an Activity creation, a span MUST be created for each
+of the those 3 methods per Activity.
+
+## Name
+
+For each of the 3 spans, their names MUST start with the method name, followed by the screen name if available:
+
+```
+<method name> [<screen name whenever available>]
+```
+
+For example, for the creation of an Activity with screen name "Home", the 3 span names would look like the following: `onCreate Home`, `onStart Home`, and `onResume Home`.
+
+[DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md


### PR DESCRIPTION
Fixes #

## Changes

Please provide a brief description of the changes here.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
