### PR TITLE
[chore] Bring a few attributes that were removed back (as deprecated)

### DIFF
--- a/docs/attributes-registry/network.md
+++ b/docs/attributes-registry/network.md
@@ -100,7 +100,7 @@ different processes could be listening on TCP port 12345 and UDP port 12345.
 
 ## Deprecated Network Attributes
 
-<!-- semconv network-deprecated(omit_requirement_level) -->
+<!-- semconv attributes.network.deprecated(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
 | `net.host.name` | string | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Deprecated, use `server.address`. | `example.com` |

--- a/model/registry/deprecated/container.yaml
+++ b/model/registry/deprecated/container.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: deprecated.container.attributes
+  - id: attributes.container.deprecated
     type: attribute_group
     brief: "Describes deprecated container attributes."
     attributes:

--- a/model/registry/deprecated/container.yaml
+++ b/model/registry/deprecated/container.yaml
@@ -1,0 +1,10 @@
+groups:
+  - id: deprecated.container.attributes
+    type: attribute_group
+    brief: "Describes deprecated container attributes."
+    attributes:
+      - id: container.labels
+        type: template[string]
+        examples: [ 'container.label.app=nginx' ]
+        brief: "Deprecated, use `container.label` instead."
+        deprecated: "Replaced by `container.label`."

--- a/model/registry/deprecated/k8s.yaml
+++ b/model/registry/deprecated/k8s.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: deprecated.k8s.attributes
+  - id: attributes.k8s.deprecated
     type: attribute_group
     brief: "Describes deprecated k8s attributes."
     attributes:

--- a/model/registry/deprecated/k8s.yaml
+++ b/model/registry/deprecated/k8s.yaml
@@ -1,0 +1,10 @@
+groups:
+  - id: deprecated.k8s.attributes
+    type: attribute_group
+    brief: "Describes deprecated k8s attributes."
+    attributes:
+      - id: k8s.pod.labels
+        type: template[string]
+        examples: ['k8s.pod.label.app=my-app']
+        brief: "Deprecated, use `k8s.pod.label` instead."
+        deprecated: "Replaced by `k8s.pod.label`."

--- a/model/registry/deprecated/network.yaml
+++ b/model/registry/deprecated/network.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: network-deprecated
+  - id: attributes.network.deprecated
     prefix: net
     type: attribute_group
     brief: >

--- a/model/registry/deprecated/system.yaml
+++ b/model/registry/deprecated/system.yaml
@@ -1,0 +1,20 @@
+groups:
+  - id: attributes.system.deprecated
+    type: attribute_group
+    brief: "Deprecated system attributes."
+    attributes:
+      - id: system.processes.status
+        type:
+          allow_custom_values: true
+          members:
+            - id: running
+              value: 'running'
+            - id: sleeping
+              value: 'sleeping'
+            - id: stopped
+              value: 'stopped'
+            - id: defunct
+              value: 'defunct'
+        brief: "Deprecated, use `system.process.status` instead."
+        deprecated: "Replaced by `system.process.status`."
+        examples: ["running"]


### PR DESCRIPTION
## Changes

Removing attributes introduces a lot of pain to code generation - see #740 or #551 for the context.
I hope we'll be able to automate checks soon with https://github.com/open-telemetry/build-tools/pull/271.

For now, I found some attributes that were removed from yaml in currently unreleased version and this PR is bringing them back.

The goal is to make it easy for the codegen, so no need to mention them in md files.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* ~~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~~
