### PR TITLE
[chore] Attempt two: Avoid running stale bot on issues

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -14,5 +14,9 @@ jobs:
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           exempt-pr-labels: 'bug,work in progress,experts needed'
           exempt-draft-pr: true
+          # opt out of defaults to avoid marking issues as stale
+          days-before-stale: -1
+          days-before-close: -1
+          # overrides the above only for pull requests
           days-before-pr-stale: 15
           days-before-pr-close: 7


### PR DESCRIPTION
I noticed again that the Stale bot is marking issues as stale and closing them. I found [this thread](https://github.com/actions/stale/issues/1112) and read it again and noticed that actually to opt out from issues, one needs to use `-1` on the defaults, otherwise they will still apply, even though using the `*-pr` config variants, urgh. 

Hopefully, this should be it. 🤞 
