### PR TITLE
Fix problem in `xray-lambda` propagator definition

### DIFF
--- a/.chloggen/778.yaml
+++ b/.chloggen/778.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: aws-lambda
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix problem in `xray-lambda` propagator definition
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [778]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/faas/aws-lambda.md
+++ b/docs/faas/aws-lambda.md
@@ -70,37 +70,50 @@ Users MUST be able to [configure the propagator](#xray-lambda-propagator-configu
 
 SDK's that have instrumentation for AWS Lambda SHOULD provide an additional propagator alongside the X-Ray propagator
 that can [be configured](#xray-lambda-propagator-configuration) via the `OTEL_PROPAGATORS` environment variable setting as `xray-lambda`.
-This propagator ignores the provided carrier instance and instead attempts to propagate the span context from the `_X_AMZN_TRACE_ID` environment variable
-(and the `com.amazonaws.xray.traceHeader` system property for Java Lambda functions with priority given to the system property if set).
-
-To avoid potential issues when extracting with an active span context, the `xray-lambda` propagator SHOULD check if the provided context already has an active span context. If found, the propagator SHOULD return the provided context unmodified.
-
-Example pseudo implementation:
+This propagator is expected to replace the `xray` propagator in the `OTEL_PROPAGATORS` list. The behavior for this propagator is described in pseudo code below.
 
 ```
 extract(context, carrier) {
+    // To avoid potential issues when extracting with an active span context (such as with a span link),
+    // the `xray-lambda` propagator SHOULD check if the provided context already has an active span context.
+    // If found, the propagator SHOULD just return the extract result of the `xray` propagator.
     if (Span.fromContext(context).getSpanContext().isValid())
-      return context
+      return xrayPropagator.extract(context, carrier)
 
-    traceHeader = getEnvironment("_X_AMZN_TRACE_ID");
+    // Update context with the extract result from xray propagator.
+    context = xrayPropagator.extract(context, carrier)
+
+    // If xray-lambda environment variable not set, return.
+    traceHeader = getEnvironment("_X_AMZN_TRACE_ID")
     if (isEmptyOrNull(traceHeader))
       return context
 
+    // Apply the xray propagator using the span context contained in the xray-lambda environment variable.
     return xrayPropagator.extract(context, ["_X_AMZN_TRACE_ID": traceHeader])
 }
 ```
 
+*Note:* Java implementations should use the system property value of the key `com.amazonaws.xray.traceHeader`
+instead of the environment variable if the system property is not empty.
+
 #### `xray-lambda` Propagator Configuration
 
-Since propagators are invoked in order, users would give priority to X-Ray's "Active Tracing" span context by setting the environment variable:
+**When reporting spans to AWS X-Ray** from AWS Lambda, the `xray-lambda` propagator SHOULD replace the `xray` propagator in the `OTEL_PROPAGATORS` configuration. Including both will prevent `xray-lambda` from functioning properly.
 
-`OTEL_PROPAGATORS=tracecontext,baggage,xray,xray-lambda`
+Example valid configuration when reporting spans to AWS X-Ray:
 
-To avoid broken traces, if OpenTelemetry is reporting traces to another system besides AWS X-Ray, users should either omit `xray-lambda` or add it to the beginning:
+- `OTEL_PROPAGATORS=tracecontext,baggage,xray-lambda`
 
-`OTEL_PROPAGATORS=xray-lambda,tracecontext,baggage,xray`
+Example invalid configurations:
 
-*Note: The `xray-lambda` propagator can only `extract` context. The `inject` operation MUST be a no-op.*
+- `OTEL_PROPAGATORS=tracecontext,baggage,xray,xray-lambda`
+- `OTEL_PROPAGATORS=tracecontext,baggage,xray-lambda,xray`
+
+**When OpenTelemetry is reporting traces to another system besides AWS X-Ray**, users SHOULD NOT use `xray-lambda` or reported traces will be broken:
+
+Example valid configuration when OpenTelemetry is reporting traces to another system besides AWS X-Ray:
+
+- `OTEL_PROPAGATORS=xray-lambda,tracecontext,baggage,xray`
 
 ## API Gateway
 

--- a/docs/faas/aws-lambda.md
+++ b/docs/faas/aws-lambda.md
@@ -80,7 +80,7 @@ extract(context, carrier) {
     if (Span.fromContext(context).getSpanContext().isValid())
       return xrayPropagator.extract(context, carrier)
 
-    // Update context with the extract result from xray propagator.
+    // Update context with the extracted result from xray propagator.
     context = xrayPropagator.extract(context, carrier)
 
     // If xray-lambda environment variable not set, return.
@@ -113,7 +113,7 @@ Example invalid configurations:
 
 Example valid configuration when OpenTelemetry is reporting traces to another system besides AWS X-Ray:
 
-- `OTEL_PROPAGATORS=xray-lambda,tracecontext,baggage,xray`
+- `OTEL_PROPAGATORS=tracecontext,baggage,xray`
 
 ## API Gateway
 

--- a/docs/faas/aws-lambda.md
+++ b/docs/faas/aws-lambda.md
@@ -74,22 +74,21 @@ This propagator is expected to replace the `xray` propagator in the `OTEL_PROPAG
 
 ```
 extract(context, carrier) {
+    xrayContext = xrayPropagator.extract(context, carrier)
+
     // To avoid potential issues when extracting with an active span context (such as with a span link),
     // the `xray-lambda` propagator SHOULD check if the provided context already has an active span context.
     // If found, the propagator SHOULD just return the extract result of the `xray` propagator.
     if (Span.fromContext(context).getSpanContext().isValid())
-      return xrayPropagator.extract(context, carrier)
+      return xrayContext
 
-    // Update context with the extracted result from xray propagator.
-    context = xrayPropagator.extract(context, carrier)
-
-    // If xray-lambda environment variable not set, return.
+    // If xray-lambda environment variable not set, return the xray extract result.
     traceHeader = getEnvironment("_X_AMZN_TRACE_ID")
     if (isEmptyOrNull(traceHeader))
-      return context
+      return xrayContext
 
     // Apply the xray propagator using the span context contained in the xray-lambda environment variable.
-    return xrayPropagator.extract(context, ["X-Amzn-Trace-Id": traceHeader])
+    return xrayPropagator.extract(xrayContext, ["X-Amzn-Trace-Id": traceHeader])
 }
 ```
 

--- a/docs/faas/aws-lambda.md
+++ b/docs/faas/aws-lambda.md
@@ -89,7 +89,7 @@ extract(context, carrier) {
       return context
 
     // Apply the xray propagator using the span context contained in the xray-lambda environment variable.
-    return xrayPropagator.extract(context, ["_X_AMZN_TRACE_ID": traceHeader])
+    return xrayPropagator.extract(context, ["X-Amzn-Trace-Id": traceHeader])
 }
 ```
 
@@ -109,7 +109,7 @@ Example invalid configurations:
 - `OTEL_PROPAGATORS=tracecontext,baggage,xray,xray-lambda`
 - `OTEL_PROPAGATORS=tracecontext,baggage,xray-lambda,xray`
 
-**When OpenTelemetry is reporting traces to another system besides AWS X-Ray**, users SHOULD NOT use `xray-lambda` or reported traces will be broken:
+**When OpenTelemetry is reporting traces to another system besides AWS X-Ray**, users SHOULD NOT use `xray-lambda` or reported traces will be broken.
 
 Example valid configuration when OpenTelemetry is reporting traces to another system besides AWS X-Ray:
 


### PR DESCRIPTION
the problem comes from this "late" addition:
> To avoid potential issues when extracting with an active span context, the xray-lambda propagator SHOULD check if the provided context already has an active span context. If found, the propagator SHOULD return the provided context unmodified.

This is a problem because `xray-lambda` can't check the original context, only the context that is provided to it, which is modified by prior propagators in the chain.

This means if the original carrier has an x-ray context and an x-ray environment variable set, and if the xray propagator is configured as we expect it to be, then the xray-lambda will be either overwritten (if configured first), or will no-op because it detects an existing span context.

Proposed solution: change `xray-lambda` to replace `xray` in the configured list instead of work together with. This way, it is able to check the context before `xray` modifies it.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
