### PR TITLE
Merge DB connection-level and call-level attributes

### DIFF
--- a/.chloggen/780.yaml
+++ b/.chloggen/780.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: db
+note: Merge DB connection-level and call-level attributes tables
+issues: [780]

--- a/docs/database/cassandra.md
+++ b/docs/database/cassandra.md
@@ -12,9 +12,9 @@ described on this page.
 
 `db.system` MUST be set to `"cassandra"`.
 
-## Call-level attributes
+## Attributes
 
-<!-- semconv db.cassandra(full,tag=call-level-tech-specific-cassandra) -->
+<!-- semconv db.cassandra(full,tag=tech-specific) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.cassandra.consistency_level`](../attributes-registry/db.md) | string | The consistency level of the query. Based on consistency values from [CQL](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html). | `all` | Recommended |

--- a/docs/database/cosmosdb.md
+++ b/docs/database/cosmosdb.md
@@ -11,13 +11,13 @@ extend and override the [Database Semantic Conventions](database-spans.md)
 that describe common database operations attributes in addition to the Semantic Conventions
 described on this page.
 
-## Call-level attributes
+## Attributes
 
 `db.system` MUST be set to `"cosmosdb"`.
 
 Cosmos DB instrumentation includes call-level (public API) surface spans and network spans. Depending on the connection mode (Gateway or Direct), network-level spans may also be created.
 
-<!-- semconv db.cosmosdb(full,tag=call-level-tech-specific) -->
+<!-- semconv db.cosmosdb(full,tag=tech-specific) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.cosmosdb.client_id`](../attributes-registry/db.md) | string | Unique Cosmos client instance id. | `3ba4827d-4422-483f-b59f-85b74211c11d` | Recommended |

--- a/docs/database/couchdb.md
+++ b/docs/database/couchdb.md
@@ -12,9 +12,9 @@ described on this page.
 
 `db.system` MUST be set to `"couchdb"`.
 
-## Call-level attributes
+## Attributes
 
-<!-- semconv db.couchdb(full,tag=call-level-tech-specific) -->
+<!-- semconv db.couchdb(full,tag=tech-specific) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.operation`](../attributes-registry/db.md) | string | The HTTP method + the target REST route. [1] | `GET /{db}/{docid}` | Conditionally Required: If `db.statement` is not applicable. |

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -52,7 +52,7 @@ This metric is [required][MetricRequired].
 <!-- semconv metric.db.client.connections.usage(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#connection-level-attributes) should be used | `myDataSource` | Required |
+| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#common-attributes) should be used | `myDataSource` | Required |
 | `state` | string | The state of a connection in the pool | `idle` | Required |
 
 `state` MUST be one of the following:
@@ -75,7 +75,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.idle.max(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#connection-level-attributes) should be used | `myDataSource` | Required |
+| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#common-attributes) should be used | `myDataSource` | Required |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.idle.min`
@@ -91,7 +91,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.idle.min(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#connection-level-attributes) should be used | `myDataSource` | Required |
+| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#common-attributes) should be used | `myDataSource` | Required |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.max`
@@ -107,7 +107,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.max(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#connection-level-attributes) should be used | `myDataSource` | Required |
+| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#common-attributes) should be used | `myDataSource` | Required |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.pending_requests`
@@ -123,7 +123,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.pending_requests(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#connection-level-attributes) should be used | `myDataSource` | Required |
+| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#common-attributes) should be used | `myDataSource` | Required |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.timeouts`
@@ -139,7 +139,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.timeouts(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#connection-level-attributes) should be used | `myDataSource` | Required |
+| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#common-attributes) should be used | `myDataSource` | Required |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.create_time`
@@ -155,7 +155,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.create_time(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#connection-level-attributes) should be used | `myDataSource` | Required |
+| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#common-attributes) should be used | `myDataSource` | Required |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.wait_time`
@@ -171,7 +171,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.wait_time(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#connection-level-attributes) should be used | `myDataSource` | Required |
+| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#common-attributes) should be used | `myDataSource` | Required |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.use_time`
@@ -187,7 +187,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.use_time(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#connection-level-attributes) should be used | `myDataSource` | Required |
+| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the [db.connection_string](/docs/database/database-spans.md#common-attributes) should be used | `myDataSource` | Required |
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -10,9 +10,8 @@ linkTitle: Client Calls
 
 <!-- toc -->
 
-- [Connection-level attributes](#connection-level-attributes)
+- [Common attributes](#common-attributes)
   * [Notes and well-known identifiers for `db.system`](#notes-and-well-known-identifiers-for-dbsystem)
-- [Call-level attributes](#call-level-attributes)
 - [Semantic Conventions for specific database technologies](#semantic-conventions-for-specific-database-technologies)
 
 <!-- tocstop -->
@@ -62,38 +61,51 @@ It is not recommended to attempt any client-side parsing of `db.statement` just 
 they should only be used if the library being instrumented already provides them.
 When it's otherwise impossible to get any meaningful span name, `db.name` or the tech-specific database name MAY be used.
 
-## Connection-level attributes
+Span that describes database call SHOULD cover the duration of the corresponding call as if it was observed by the caller (such as client application).
+For example, if a transient issue happened and was retried within this database call, the corresponding span should cover the duration of the logical operation
+with all retries.
+
+## Common attributes
 
 These attributes will usually be the same for all operations performed over the same database connection.
 Some database systems may allow a connection to switch to a different `db.user`, for example, and other database systems may not even have the concept of a connection at all.
 
-<!-- semconv db(full,tag=connection-level) -->
+<!-- semconv db(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.connection_string`](../attributes-registry/db.md) | string | The connection string used to connect to the database. It is recommended to remove embedded credentials. | `Server=(localdb)\v11.0;Integrated Security=true;` | Recommended |
 | [`db.instance.id`](../attributes-registry/db.md) | string | An identifier (address, unique name, or any other identifier) of the database instance that is executing queries or mutations on the current connection. This is useful in cases where the database is running in a clustered environment and the instrumentation is able to record the node executing the query. The client may obtain this value in databases like MySQL using queries like `select @@hostname`. | `mysql-e26b99z.example.com` | Recommended: If different from the `server.address` |
+| [`db.name`](../attributes-registry/db.md) | string | This attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`; `main` | Conditionally Required: If applicable. |
+| [`db.operation`](../attributes-registry/db.md) | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`, or the SQL keyword. [2] | `findAndModify`; `HMSET`; `SELECT` | Conditionally Required: If `db.statement` is not applicable. |
+| [`db.statement`](../attributes-registry/db.md) | string | The database statement being executed. | `SELECT * FROM wuser_table`; `SET mykey "WuValue"` | Recommended: [3] |
 | [`db.system`](../attributes-registry/db.md) | string | An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers. | `other_sql` | Required |
 | [`db.user`](../attributes-registry/db.md) | string | Username for accessing the database. | `readonly_user`; `reporting_user` | Recommended |
 | [`network.peer.address`](../attributes-registry/network.md) | string | Peer address of the network connection - IP address or Unix domain socket name. | `10.1.2.80`; `/tmp/my.sock` | Recommended |
 | [`network.peer.port`](../attributes-registry/network.md) | int | Peer port number of the network connection. | `65123` | Recommended: If `network.peer.address` is set. |
-| [`network.transport`](../attributes-registry/network.md) | string | [OSI transport layer](https://osi-model.com/transport-layer/) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication). [1] | `tcp`; `udp` | Recommended |
-| [`network.type`](../attributes-registry/network.md) | string | [OSI network layer](https://osi-model.com/network-layer/) or non-OSI equivalent. [2] | `ipv4`; `ipv6` | Recommended |
-| [`server.address`](../attributes-registry/server.md) | string | Name of the database host. [3] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
-| [`server.port`](../attributes-registry/server.md) | int | Server port number. [4] | `80`; `8080`; `443` | Conditionally Required: [5] |
+| [`network.transport`](../attributes-registry/network.md) | string | [OSI transport layer](https://osi-model.com/transport-layer/) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication). [4] | `tcp`; `udp` | Recommended |
+| [`network.type`](../attributes-registry/network.md) | string | [OSI network layer](https://osi-model.com/network-layer/) or non-OSI equivalent. [5] | `ipv4`; `ipv6` | Recommended |
+| [`server.address`](../attributes-registry/server.md) | string | Name of the database host. [6] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Recommended |
+| [`server.port`](../attributes-registry/server.md) | int | Server port number. [7] | `80`; `8080`; `443` | Conditionally Required: [8] |
 
-**[1]:** The value SHOULD be normalized to lowercase.
+**[1]:** In some SQL databases, the database name to be used is called "schema name". In case there are multiple layers that could be considered for database name (e.g. Oracle instance name and schema name), the database name to be used is the more specific layer (e.g. Oracle schema name).
+
+**[2]:** When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
+
+**[3]:** Should be collected by default only if there is sanitization that excludes sensitive information.
+
+**[4]:** The value SHOULD be normalized to lowercase.
 
 Consider always setting the transport when setting a port number, since
 a port number is ambiguous without knowing the transport. For example
 different processes could be listening on TCP port 12345 and UDP port 12345.
 
-**[2]:** The value SHOULD be normalized to lowercase.
+**[5]:** The value SHOULD be normalized to lowercase.
 
-**[3]:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
+**[6]:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
 
-**[4]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
+**[7]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
 
-**[5]:** If using a port other than the default port for this DBMS and if `server.address` is set.
+**[8]:** If using a port other than the default port for this DBMS and if `server.address` is set.
 
 `db.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -186,25 +198,6 @@ If the concrete DBMS is known to the instrumentation, its specific identifier MU
 Back ends could, for example, use the provided identifier to determine the appropriate SQL dialect for parsing the `db.statement`.
 
 When additional attributes are added that only apply to a specific DBMS, its identifier SHOULD be used as a namespace in the attribute key as for the attributes in the sections below.
-
-## Call-level attributes
-
-These attributes may be different for each operation performed, even if the same connection is used for multiple operations.
-Usually only one `db.name` will be used per connection though.
-
-<!-- semconv db(full,tag=call-level,remove_constraints) -->
-| Attribute  | Type | Description  | Examples  | Requirement Level |
-|---|---|---|---|---|
-| [`db.name`](../attributes-registry/db.md) | string | This attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`; `main` | Conditionally Required: If applicable. |
-| [`db.operation`](../attributes-registry/db.md) | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`, or the SQL keyword. [2] | `findAndModify`; `HMSET`; `SELECT` | Conditionally Required: If `db.statement` is not applicable. |
-| [`db.statement`](../attributes-registry/db.md) | string | The database statement being executed. | `SELECT * FROM wuser_table`; `SET mykey "WuValue"` | Recommended: [3] |
-
-**[1]:** In some SQL databases, the database name to be used is called "schema name". In case there are multiple layers that could be considered for database name (e.g. Oracle instance name and schema name), the database name to be used is the more specific layer (e.g. Oracle schema name).
-
-**[2]:** When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
-
-**[3]:** Should be collected by default only if there is sanitization that excludes sensitive information.
-<!-- endsemconv -->
 
 ## Semantic Conventions for specific database technologies
 

--- a/docs/database/elasticsearch.md
+++ b/docs/database/elasticsearch.md
@@ -21,9 +21,9 @@ name, as the path could contain dynamic values. The endpoint id is the `name` fi
 [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json).
 If the endpoint id is not available, the span name SHOULD be the `http.request.method`.
 
-## Call-level attributes
+## Attributes
 
-<!-- semconv db.elasticsearch(full,tag=call-level-tech-specific) -->
+<!-- semconv db.elasticsearch(full,tag=tech-specific) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.elasticsearch.cluster.name`](../attributes-registry/db.md) | string | Represents the identifier of an Elasticsearch cluster. | `e9106fc68e3044f0b1475b04bf4ffd5f` | Recommended: [1] |

--- a/docs/database/hbase.md
+++ b/docs/database/hbase.md
@@ -12,9 +12,9 @@ described on this page.
 
 `db.system` MUST be set to `"hbase"`.
 
-## Call-level attributes
+## Attributes
 
-<!-- semconv db.hbase(full,tag=call-level-tech-specific) -->
+<!-- semconv db.hbase(full,tag=tech-specific) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.name`](../attributes-registry/db.md) | string | The HBase namespace. [1] | `mynamespace` | Conditionally Required: If applicable. |

--- a/docs/database/mongodb.md
+++ b/docs/database/mongodb.md
@@ -12,9 +12,9 @@ described on this page.
 
 `db.system` MUST be set to `"mongodb"`.
 
-## Call-level attributes
+## Attributes
 
-<!-- semconv db.mongodb(full,tag=call-level-tech-specific) -->
+<!-- semconv db.mongodb(full,tag=tech-specific) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.mongodb.collection`](../attributes-registry/db.md) | string | The MongoDB collection being accessed within the database stated in `db.name`. | `customers`; `products` | Required |

--- a/docs/database/mssql.md
+++ b/docs/database/mssql.md
@@ -19,8 +19,11 @@ described on this page.
 |---|---|---|---|---|
 | [`db.jdbc.driver_classname`](../attributes-registry/db.md) | string | The fully-qualified class name of the [Java Database Connectivity (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to connect. | `org.postgresql.Driver`; `com.microsoft.sqlserver.jdbc.SQLServerDriver` | Recommended |
 | [`db.mssql.instance_name`](../attributes-registry/db.md) | string | The Microsoft SQL Server [instance name](https://docs.microsoft.com/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15) connecting to. This name is used to determine the port of a named instance. [1] | `MSSQLSERVER` | Recommended |
+| [`db.sql.table`](../attributes-registry/db.md) | string | The name of the primary table that the operation is acting upon, including the database name (if applicable). [2] | `public.users`; `customers` | Recommended |
 
 **[1]:** If setting a `db.mssql.instance_name`, `server.port` is no longer required (but still recommended if non-standard).
+
+**[2]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md

--- a/docs/database/mssql.md
+++ b/docs/database/mssql.md
@@ -12,9 +12,9 @@ described on this page.
 
 `db.system` MUST be set to `"mssql"`.
 
-## Connection-level attributes
+## Attributes
 
-<!-- semconv db.mssql(full,tag=connection-level-tech-specific) -->
+<!-- semconv db.mssql(full,tag=tech-specific) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.jdbc.driver_classname`](../attributes-registry/db.md) | string | The fully-qualified class name of the [Java Database Connectivity (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to connect. | `org.postgresql.Driver`; `com.microsoft.sqlserver.jdbc.SQLServerDriver` | Recommended |

--- a/docs/database/redis.md
+++ b/docs/database/redis.md
@@ -12,9 +12,9 @@ described on this page.
 
 `db.system` MUST be set to `"redis"`.
 
-## Call-level attributes
+## Attributes
 
-<!-- semconv db.redis(full,tag=call-level-tech-specific) -->
+<!-- semconv db.redis(full,tag=tech-specific) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | [`db.redis.database_index`](../attributes-registry/db.md) | int | The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer. To be used instead of the generic `db.name` attribute. | `0`; `1`; `15` | Conditionally Required: If other than the default database (`0`). |

--- a/docs/database/sql.md
+++ b/docs/database/sql.md
@@ -10,11 +10,12 @@ The SQL databases Semantic Conventions extend and override the [Database Semanti
 that describe common database operations attributes in addition to the Semantic Conventions
 described on this page.
 
-## Call-level attributes
+## Attributes
 
-<!-- semconv db.sql(full,tag=call-level-tech-specific) -->
+<!-- semconv db.sql(full,tag=tech-specific) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
+| [`db.jdbc.driver_classname`](../attributes-registry/db.md) | string | The fully-qualified class name of the [Java Database Connectivity (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to connect. | `org.postgresql.Driver`; `com.microsoft.sqlserver.jdbc.SQLServerDriver` | Recommended |
 | [`db.sql.table`](../attributes-registry/db.md) | string | The name of the primary table that the operation is acting upon, including the database name (if applicable). [1] | `public.users`; `customers` | Recommended |
 
 **[1]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.

--- a/model/messaging-common.yaml
+++ b/model/messaging-common.yaml
@@ -20,6 +20,4 @@ groups:
         examples: ['amqp', 'mqtt']
         requirement_level:
           conditionally_required: Only for messaging systems and frameworks that support more than one protocol.
-        tag: connection-level
       - ref: network.protocol.version
-        tag: connection-level

--- a/model/metrics/database-metrics.yaml
+++ b/model/metrics/database-metrics.yaml
@@ -20,7 +20,7 @@ groups:
         brief: >
           The name of the connection pool; unique within the instrumented application.
           In case the connection pool implementation doesn't provide a name,
-          then the [db.connection_string](/docs/database/database-spans.md#connection-level-attributes)
+          then the [db.connection_string](/docs/database/database-spans.md#common-attributes)
           should be used
         examples: ["myDataSource"]
 

--- a/model/trace/database.yaml
+++ b/model/trace/database.yaml
@@ -38,13 +38,11 @@ groups:
 
   - id: db.mssql
     type: span
-    extends: db
+    extends: db.sql
     brief: >
       Attributes for Microsoft SQL Server
     attributes:
       - ref: db.mssql.instance_name
-        tag: tech-specific
-      - ref: db.jdbc.driver_classname
         tag: tech-specific
 
   - id: db.cassandra

--- a/model/trace/database.yaml
+++ b/model/trace/database.yaml
@@ -6,48 +6,33 @@ groups:
     span_kind: client
     attributes:
       - ref: db.system
-        tag: connection-level
         requirement_level: required
 
       - ref: db.connection_string
-        tag: connection-level
       - ref: db.user
-        tag: connection-level
-      - ref: db.jdbc.driver_classname
-        tag: connection-level-tech-specific
       - ref: db.name
-        tag: call-level
         requirement_level:
           conditionally_required: If applicable.
       - ref: db.statement
-        tag: call-level
         requirement_level:
           recommended: >
             Should be collected by default only if there is sanitization that excludes sensitive information.
       - ref: db.operation
-        tag: call-level
         requirement_level:
           conditionally_required: If `db.statement` is not applicable.
       - ref: server.address
-        tag: connection-level
         brief: >
           Name of the database host.
       - ref: server.port
-        tag: connection-level
         requirement_level:
           conditionally_required: If using a port other than the default port for this DBMS and if `server.address` is set.
       - ref: network.peer.address
-        tag: connection-level
       - ref: network.peer.port
         requirement_level:
           recommended: If `network.peer.address` is set.
-        tag: connection-level
       - ref: network.transport
-        tag: connection-level
       - ref: network.type
-        tag: connection-level
       - ref: db.instance.id
-        tag: connection-level
         requirement_level:
           recommended: If different from the `server.address`
 
@@ -55,46 +40,48 @@ groups:
     type: span
     extends: db
     brief: >
-      Connection-level attributes for Microsoft SQL Server
+      Attributes for Microsoft SQL Server
     attributes:
       - ref: db.mssql.instance_name
-        tag: connection-level-tech-specific
+        tag: tech-specific
+      - ref: db.jdbc.driver_classname
+        tag: tech-specific
 
   - id: db.cassandra
     type: span
     extends: db
     brief: >
-      Call-level attributes for Cassandra
+      Attributes for Cassandra
     attributes:
       - ref: db.name
-        tag: call-level-tech-specific-cassandra
+        tag: tech-specific
         brief: >
           The keyspace name in Cassandra.
         examples: ["mykeyspace"]
         note: For Cassandra the `db.name` should be set to the Cassandra keyspace name.
       - ref: db.cassandra.page_size
-        tag: call-level-tech-specific-cassandra
+        tag: tech-specific
       - ref: db.cassandra.consistency_level
-        tag: call-level-tech-specific-cassandra
+        tag: tech-specific
       - ref: db.cassandra.table
-        tag: call-level-tech-specific-cassandra
+        tag: tech-specific
       - ref: db.cassandra.idempotence
-        tag: call-level-tech-specific-cassandra
+        tag: tech-specific
       - ref: db.cassandra.speculative_execution_count
-        tag: call-level-tech-specific-cassandra
+        tag: tech-specific
       - ref: db.cassandra.coordinator.id
-        tag: call-level-tech-specific-cassandra
+        tag: tech-specific
       - ref: db.cassandra.coordinator.dc
-        tag: call-level-tech-specific-cassandra
+        tag: tech-specific
 
   - id: db.hbase
     type: span
     extends: db
     brief: >
-      Call-level attributes for HBase
+      Attributes for HBase
     attributes:
       - ref: db.name
-        tag: call-level-tech-specific
+        tag: tech-specific
         brief: >
           The HBase namespace.
         examples: ['mynamespace']
@@ -104,10 +91,10 @@ groups:
     type: span
     extends: db
     brief: >
-      Call-level attributes for CouchDB
+      Attributes for CouchDB
     attributes:
       - ref: db.operation
-        tag: call-level-tech-specific
+        tag: tech-specific
         brief: >
           The HTTP method + the target REST route.
         examples: ['GET /{db}/{docid}']
@@ -122,14 +109,14 @@ groups:
     type: span
     extends: db
     brief: >
-      Call-level attributes for Redis
+      Attributes for Redis
     attributes:
       - ref: db.redis.database_index
         requirement_level:
           conditionally_required: If other than the default database (`0`).
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.statement
-        tag: call-level-tech-specific
+        tag: tech-specific
         brief: >
           The full syntax of the Redis CLI command.
         examples: ["HMSET myhash field1 'Hello' field2 'World'"]
@@ -141,30 +128,30 @@ groups:
     type: span
     extends: db
     brief: >
-      Call-level attributes for MongoDB
+      Attributes for MongoDB
     attributes:
       - ref: db.mongodb.collection
         requirement_level: required
-        tag: call-level-tech-specific
+        tag: tech-specific
 
   - id: db.elasticsearch
     type: span
     extends: db
     brief: >
-      Call-level attributes for Elasticsearch
+      Attributes for Elasticsearch
     attributes:
       - ref: http.request.method
         requirement_level: required
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.operation
         requirement_level: required
         brief: The endpoint identifier for the request.
         examples: [ 'search', 'ml.close_job', 'cat.aliases' ]
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: url.full
         requirement_level: required
         examples: [ 'https://localhost:9200/index/_search?q=user.id:kimchy' ]
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.statement
         requirement_level:
           recommended: >
@@ -172,48 +159,50 @@ groups:
             sensitive information.
         brief: The request body for a [search-type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html), as a json string.
         examples: [ '"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"' ]
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: server.address
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: server.port
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.elasticsearch.cluster.name
         requirement_level:
           recommended: >
             When communicating with an Elastic Cloud deployment, this should be collected from the "X-Found-Handling-Cluster" HTTP response header.
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.elasticsearch.node.name
         requirement_level:
           recommended: >
             When communicating with an Elastic Cloud deployment, this should be collected from the "X-Found-Handling-Instance" HTTP response header.
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.elasticsearch.path_parts
         requirement_level:
           conditionally_required: when the url has dynamic values
-        tag: call-level-tech-specific
+        tag: tech-specific
 
   - id: db.sql
     type: span
     extends: 'db'
     brief: >
-      Call-level attributes for SQL databases
+      Attributes for SQL databases
     attributes:
       - ref: db.sql.table
-        tag: call-level-tech-specific
+        tag: tech-specific
+      - ref: db.jdbc.driver_classname
+        tag: tech-specific
 
   - id: db.cosmosdb
     type: span
     extends: db
     prefix: db.cosmosdb
     brief: >
-      Call-level attributes for Cosmos DB.
+      Attributes for Cosmos DB.
     attributes:
       - ref: db.cosmosdb.client_id
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.cosmosdb.operation_type
         requirement_level:
           conditionally_required: when performing one of the operations in this list
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: user_agent.original
         brief: 'Full user-agent string is generated by Cosmos DB SDK'
         note: >
@@ -228,36 +217,26 @@ groups:
              Format Reg-{D (Disabled discovery)}-S(application region)|L(List of preferred regions)|N(None, user did not configure it).
              Default value is "NS".
         examples: ['cosmos-netstandard-sdk/3.23.0\|3.23.1\|1\|X64\|Linux 5.4.0-1098-azure 104 18\|.NET Core 3.1.32\|S\|']
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.cosmosdb.connection_mode
         requirement_level:
           conditionally_required: if not `direct` (or pick gw as default)
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.cosmosdb.container
         requirement_level:
           conditionally_required: if available
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.cosmosdb.request_content_length
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.cosmosdb.status_code
         requirement_level:
           conditionally_required: if response was received
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.cosmosdb.sub_status_code
         requirement_level:
           conditionally_required: when response was received and contained sub-code.
-        tag: call-level-tech-specific
+        tag: tech-specific
       - ref: db.cosmosdb.request_charge
         requirement_level:
           conditionally_required: when available
-        tag: call-level-tech-specific
-
-  - id: db.tech
-    type: span
-    brief: "Semantic convention group for specific technologies"
-    constraints:
-      - include: 'db.cassandra'
-      - include: 'db.redis'
-      - include: 'db.mongodb'
-      - include: 'db.sql'
-      - include: 'db.cosmosdb'
+        tag: tech-specific

--- a/model/trace/messaging.yaml
+++ b/model/trace/messaging.yaml
@@ -82,15 +82,11 @@ groups:
       - ref: messaging.message.body.size
       - ref: server.address
       - ref: network.peer.address
-        tag: connection-level
       - ref: network.peer.port
         requirement_level:
           recommended: If `network.peer.address` is set.
-        tag: connection-level
       - ref: network.transport
-        tag: connection-level
       - ref: network.type
-        tag: connection-level
 
   - id: messaging.rabbitmq
     type: attribute_group


### PR DESCRIPTION
## Changes

Merges connection and call-level attributes for databases.

DB instrumentations in the general case are operating on the logical/public surface level and not always aware of connections.
Separation into connection and call level is also confusing. 

Extracted from #768, related to #690

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* ~~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~~
