### PR TITLE
[chore] URL attributes: consistently use code font for URLs and URL parts

### DIFF
--- a/docs/attributes-registry/url.md
+++ b/docs/attributes-registry/url.md
@@ -35,9 +35,9 @@ linkTitle: URL
 
 **[5]:** Sensitive content provided in query string SHOULD be scrubbed when instrumentations can identify it.
 
-**[6]:** This value can be determined precisely with the [public suffix list](http://publicsuffix.org). For example, the registered domain for "foo.example.com" is "example.com". Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+**[6]:** This value can be determined precisely with the [public suffix list](http://publicsuffix.org). For example, the registered domain for `foo.example.com` is `example.com`. Trying to approximate this by simply taking the last two labels will not work well for TLDs such as `co.uk`.
 
-**[7]:** The subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.
+**[7]:** The subdomain portion of `www.east.mydomain.co.uk` is `east`. If the domain has multiple levels of subdomain, such as `sub2.sub1.example.com`, the subdomain field should contain `sub2.sub1`, with no trailing period.
 
 **[8]:** This value can be determined precisely with the [public suffix list](http://publicsuffix.org).
 <!-- endsemconv -->

--- a/model/registry/url.yaml
+++ b/model/registry/url.yaml
@@ -79,8 +79,8 @@ groups:
         examples: ["example.com", "foo.co.uk"]
         note: >
           This value can be determined precisely with the [public suffix list](http://publicsuffix.org).
-          For example, the registered domain for "foo.example.com" is "example.com".
-          Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+          For example, the registered domain for `foo.example.com` is `example.com`.
+          Trying to approximate this by simply taking the last two labels will not work well for TLDs such as `co.uk`.
       - id: scheme
         stability: stable
         type: string
@@ -95,8 +95,8 @@ groups:
           full name cannot be determined, subdomain contains all of the names below the registered domain.
         examples: ["east", "sub2.sub1"]
         note: >
-           The subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain,
-           such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.
+           The subdomain portion of `www.east.mydomain.co.uk` is `east`. If the domain has multiple levels of subdomain,
+           such as `sub2.sub1.example.com`, the subdomain field should contain `sub2.sub1`, with no trailing period.
       - id: top_level_domain
         type: string
         brief: >


### PR DESCRIPTION
Switches to using code-font for URLs and URL parts in recently added attributes to be consistent across entries in this table: e.g., the table example value is shown as `east` not "east" -- so, this PR switches to using `east` in the footnote too.

