### PR TITLE
[chore] Enable creating area labels on push to `main`

### DIFF
--- a/.github/workflows/scripts/generate-registry-area-labels.sh
+++ b/.github/workflows/scripts/generate-registry-area-labels.sh
@@ -25,8 +25,7 @@ for AREA in ${AREAS}; do
         continue
     fi
     echo "area:${LABEL_NAME}"
-
-    #  gh label create "area:${LABEL_NAME}" -c "#425cc7"
+    gh label create "area:${LABEL_NAME}" -c "#425cc7"
 done
 
 echo -e "\nLabels created successfully"


### PR DESCRIPTION
In https://github.com/open-telemetry/semantic-conventions/pull/777 I forgot to uncomment the line which invoked the GH cli to create the labels. 