### PR TITLE
[chore] Move metric requirement levels doc from spec

### DIFF
--- a/docs/general/metric-requirement-level.md
+++ b/docs/general/metric-requirement-level.md
@@ -1,6 +1,6 @@
 # Metric Requirement Levels for Semantic Conventions
 
-**Status**: [Stable](../document-status.md)
+**Status**: [Stable][DocumentStatus]
 
 <details>
 <summary>Table of Contents</summary>
@@ -38,3 +38,6 @@ Instrumentations SHOULD emit the metric if and only if the user configures the i
 Instrumentation that doesn't support configuration MUST NOT emit `Opt-In` metrics.
 
 This attribute requirement level is recommended for metrics that are particularly expensive to retrieve or might pose a security or privacy risk. These should therefore only be enabled deliberately by a user making an informed decision.
+
+[DocumentStatus]:
+  https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/document-status.md


### PR DESCRIPTION
Fixes #822

## Changes

Moves the [metric requirement levels](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/metric-requirement-level.md) document to the semconv repo. 

I think I managed to get the git history correct. 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
