### PR TITLE
BREAKING: Change `thread.id` type from integer to string

### DIFF
--- a/.chloggen/thread-id-type.yaml
+++ b/.chloggen/thread-id-type.yaml
@@ -1,4 +1,4 @@
 change_type: breaking
-component: general
+component: thread
 note: Change type of `thread.id` attribute from int to string
 issues: [546]

--- a/.chloggen/thread-id-type.yaml
+++ b/.chloggen/thread-id-type.yaml
@@ -1,0 +1,4 @@
+change_type: breaking
+component: general
+note: Change type of `thread.id` attribute from int to string
+issues: [546]

--- a/docs/attributes-registry/thread.md
+++ b/docs/attributes-registry/thread.md
@@ -10,6 +10,6 @@ These attributes may be used for any operation to store information about a thre
 <!-- semconv registry.thread(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  |
 |---|---|---|---|
-| `thread.id` | int | Current "managed" thread ID (as opposed to OS thread ID). | `42` |
+| `thread.id` | string | Current "managed" thread ID (as opposed to OS thread ID). | `42` |
 | `thread.name` | string | Current thread name. | `main` |
 <!-- endsemconv -->

--- a/docs/general/attributes.md
+++ b/docs/general/attributes.md
@@ -358,7 +358,7 @@ a thread that started a span.
 <!-- semconv thread -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`thread.id`](../attributes-registry/thread.md) | int | Current "managed" thread ID (as opposed to OS thread ID). | `42` | Recommended |
+| [`thread.id`](../attributes-registry/thread.md) | string | Current "managed" thread ID (as opposed to OS thread ID). | `42` | Recommended |
 | [`thread.name`](../attributes-registry/thread.md) | string | Current thread name. | `main` | Recommended |
 <!-- endsemconv -->
 

--- a/model/registry/thread.yaml
+++ b/model/registry/thread.yaml
@@ -6,7 +6,7 @@ groups:
       These attributes may be used for any operation to store information about a thread that started a span.
     attributes:
       - id: id
-        type: int
+        type: string
         stability: experimental
         brief: >
           Current "managed" thread ID (as opposed to OS thread ID).

--- a/model/registry/thread.yaml
+++ b/model/registry/thread.yaml
@@ -10,7 +10,7 @@ groups:
         stability: experimental
         brief: >
           Current "managed" thread ID (as opposed to OS thread ID).
-        examples: 42
+        examples: "42"
       - id: name
         type: string
         stability: experimental


### PR DESCRIPTION
Fixes #546 

## Changes

As discussed in #546, `thread.id` for managed runtimes isn't guaranteed to be an integer across all cases (C++ being the exception).

This change makes `thread.id` a string and thus makes it possible to set this value across all languages.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
