### PR TITLE
[chore] Move Feature Flag attributes to the registry

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -33,6 +33,7 @@ body:
         - area:error
         - area:exception
         - area:faas
+        - area:feature-flag
         - area:host
         - area:http
         - area:k8s

--- a/.github/ISSUE_TEMPLATE/change_proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/change_proposal.yaml
@@ -26,6 +26,7 @@ body:
         - area:error
         - area:exception
         - area:faas
+        - area:feature-flag
         - area:host
         - area:http
         - area:k8s

--- a/.github/ISSUE_TEMPLATE/new-conventions.yaml
+++ b/.github/ISSUE_TEMPLATE/new-conventions.yaml
@@ -35,6 +35,7 @@ body:
         - area:error
         - area:exception
         - area:faas
+        - area:feature-flag
         - area:host
         - area:http
         - area:k8s

--- a/docs/attributes-registry/README.md
+++ b/docs/attributes-registry/README.md
@@ -40,6 +40,7 @@ Currently, the following namespaces exist:
 * [Error](error.md)
 * [Exception](exception.md)
 * [FaaS](faas.md)
+* [Feature Flag](feature-flag.md)
 * [Host](host.md)
 * [HTTP](http.md)
 * [K8s](k8s.md)

--- a/docs/attributes-registry/feature-flag.md
+++ b/docs/attributes-registry/feature-flag.md
@@ -1,0 +1,19 @@
+# Feature Flag
+
+## Feature Flag Attributes
+<!-- semconv registry.feature_flag(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  |
+|---|---|---|---|
+| `feature_flag.key` | string | The unique identifier of the feature flag. | `logo-color` |
+| `feature_flag.provider_name` | string | The name of the service provider that performs the flag evaluation. | `Flag Manager` |
+| `feature_flag.variant` | string | SHOULD be a semantic identifier for a value. If one is unavailable, a stringified version of the value can be used. [1] | `red`; `true`; `on` |
+
+**[1]:** A semantic identifier, commonly referred to as a variant, provides a means
+for referring to a value without including the value itself. This can
+provide additional context for understanding the meaning behind a value.
+For example, the variant `red` maybe be used for the value `#c05543`.
+
+A stringified version of the value can be used in situations where a
+semantic identifier is unavailable. String representation of the value
+should be determined by the implementer.
+<!-- endsemconv -->

--- a/docs/feature-flags/feature-flags-logs.md
+++ b/docs/feature-flags/feature-flags-logs.md
@@ -42,9 +42,9 @@ The event name MUST be `feature_flag`.
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`feature_flag.key`](feature-flags-spans.md) | string | The unique identifier of the feature flag. | `logo-color` | Required |
-| [`feature_flag.provider_name`](feature-flags-spans.md) | string | The name of the service provider that performs the flag evaluation. | `Flag Manager` | Recommended |
-| [`feature_flag.variant`](feature-flags-spans.md) | string | SHOULD be a semantic identifier for a value. If one is unavailable, a stringified version of the value can be used. [1] | `red`; `true`; `on` | Recommended |
+| [`feature_flag.key`](../attributes-registry/feature-flag.md) | string | The unique identifier of the feature flag. | `logo-color` | Recommended |
+| [`feature_flag.provider_name`](../attributes-registry/feature-flag.md) | string | The name of the service provider that performs the flag evaluation. | `Flag Manager` | Recommended |
+| [`feature_flag.variant`](../attributes-registry/feature-flag.md) | string | SHOULD be a semantic identifier for a value. If one is unavailable, a stringified version of the value can be used. [1] | `red`; `true`; `on` | Recommended |
 
 **[1]:** A semantic identifier, commonly referred to as a variant, provides a means
 for referring to a value without including the value itself. This can

--- a/docs/feature-flags/feature-flags-spans.md
+++ b/docs/feature-flags/feature-flags-spans.md
@@ -46,9 +46,9 @@ The event name MUST be `feature_flag`.
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `feature_flag.key` | string | The unique identifier of the feature flag. | `logo-color` | Required |
-| `feature_flag.provider_name` | string | The name of the service provider that performs the flag evaluation. | `Flag Manager` | Recommended |
-| `feature_flag.variant` | string | SHOULD be a semantic identifier for a value. If one is unavailable, a stringified version of the value can be used. [1] | `red`; `true`; `on` | Recommended |
+| [`feature_flag.key`](../attributes-registry/feature-flag.md) | string | The unique identifier of the feature flag. | `logo-color` | Required |
+| [`feature_flag.provider_name`](../attributes-registry/feature-flag.md) | string | The name of the service provider that performs the flag evaluation. | `Flag Manager` | Recommended |
+| [`feature_flag.variant`](../attributes-registry/feature-flag.md) | string | SHOULD be a semantic identifier for a value. If one is unavailable, a stringified version of the value can be used. [1] | `red`; `true`; `on` | Recommended |
 
 **[1]:** A semantic identifier, commonly referred to as a variant, provides a means
 for referring to a value without including the value itself. This can

--- a/model/logs/log-feature_flag.yaml
+++ b/model/logs/log-feature_flag.yaml
@@ -1,7 +1,7 @@
 groups:
   - id: log-feature_flag
     type: event
-    prefix: feature_flag
+    name: feature_flag
     brief: >
       This document defines attributes for feature flag evaluations
       represented using Log Records.

--- a/model/registry/feature-flag.yaml
+++ b/model/registry/feature-flag.yaml
@@ -1,0 +1,33 @@
+groups:
+  - id: registry.feature_flag
+    prefix: feature_flag
+    type: attribute_group
+    brief: >
+        This document defines attributes for Feature Flags.
+    attributes:
+      - id: key
+        type: string
+        stability: experimental
+        brief: The unique identifier of the feature flag.
+        examples: ["logo-color"]
+      - id: provider_name
+        type: string
+        stability: experimental
+        brief: The name of the service provider that performs the flag evaluation.
+        examples: ["Flag Manager"]
+      - id: variant
+        type: string
+        stability: experimental
+        examples: ["red", "true", "on"]
+        brief: >
+          SHOULD be a semantic identifier for a value. If one is unavailable, a
+          stringified version of the value can be used.
+        note: |-
+          A semantic identifier, commonly referred to as a variant, provides a means
+          for referring to a value without including the value itself. This can
+          provide additional context for understanding the meaning behind a value.
+          For example, the variant `red` maybe be used for the value `#c05543`.
+
+          A stringified version of the value can be used in situations where a
+          semantic identifier is unavailable. String representation of the value
+          should be determined by the implementer.

--- a/model/trace/feature-flag.yaml
+++ b/model/trace/feature-flag.yaml
@@ -1,37 +1,14 @@
 groups:
   - id: feature_flag
-    prefix: feature_flag
     type: event
+    name: feature_flag
     brief: >
       This semantic convention defines the attributes used to represent a
       feature flag evaluation as an event.
     attributes:
-      - id: key
-        type: string
-        stability: experimental
+      - ref: feature_flag.key
         requirement_level: required
-        brief: The unique identifier of the feature flag.
-        examples: ["logo-color"]
-      - id: provider_name
-        type: string
-        stability: experimental
+      - ref: feature_flag.provider_name
         requirement_level: recommended
-        brief: The name of the service provider that performs the flag evaluation.
-        examples: ["Flag Manager"]
-      - id: variant
-        type: string
-        stability: experimental
+      - ref: feature_flag.variant
         requirement_level: recommended
-        examples: ["red", "true", "on"]
-        brief: >
-          SHOULD be a semantic identifier for a value. If one is unavailable, a
-          stringified version of the value can be used.
-        note: |-
-          A semantic identifier, commonly referred to as a variant, provides a means
-          for referring to a value without including the value itself. This can
-          provide additional context for understanding the meaning behind a value.
-          For example, the variant `red` maybe be used for the value `#c05543`.
-
-          A stringified version of the value can be used in situations where a
-          semantic identifier is unavailable. String representation of the value
-          should be determined by the implementer.


### PR DESCRIPTION
Related to https://github.com/open-telemetry/semantic-conventions/issues/407

## Changes

Move Feature Flags to the attributes registry

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
