### PR TITLE
[chore] Force create labels in workflow

### DIFF
--- a/.github/workflows/scripts/generate-registry-area-labels.sh
+++ b/.github/workflows/scripts/generate-registry-area-labels.sh
@@ -25,7 +25,7 @@ for AREA in ${AREAS}; do
         continue
     fi
     echo "area:${LABEL_NAME}"
-    gh label create "area:${LABEL_NAME}" -c "#425cc7"
+    gh label create "area:${LABEL_NAME}" -c "#425cc7" --force
 done
 
 echo -e "\nLabels created successfully"


### PR DESCRIPTION
## Changes

The workflow that is supposed to create the labels for new areas https://github.com/open-telemetry/semantic-conventions/actions/runs/8455605243/job/23163472895 is failing because the label already exists. 

I thought it would just skip the ones that already exist, but it seems not. The task fails. So I'm just using `--force` to re-create them. Nothing changes so we should be all good with existing labels.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
