### PR TITLE
[chore] Move system metric attributes to the registry

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -60,6 +60,7 @@ body:
         - area:service
         - area:session
         - area:source
+        - area:system
         - area:telemetry
         - area:thread
         - area:tls

--- a/.github/ISSUE_TEMPLATE/change_proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/change_proposal.yaml
@@ -53,6 +53,7 @@ body:
         - area:service
         - area:session
         - area:source
+        - area:system
         - area:telemetry
         - area:thread
         - area:tls

--- a/.github/ISSUE_TEMPLATE/new-conventions.yaml
+++ b/.github/ISSUE_TEMPLATE/new-conventions.yaml
@@ -62,6 +62,7 @@ body:
         - area:service
         - area:session
         - area:source
+        - area:system
         - area:telemetry
         - area:thread
         - area:tls

--- a/docs/attributes-registry/system.md
+++ b/docs/attributes-registry/system.md
@@ -24,7 +24,7 @@
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `system.cpu.logical_number` | int | The logical CPU number [0..n-1] | `1` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.cpu.state` | string | The CPU state for this data point. A system's CPU SHOULD be characterized *either* by data points with no `state` labels, *or only* data points with `state` labels. | `idle`; `interrupt` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `system.cpu.state` | string | The state of the CPU | `idle`; `interrupt` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.cpu.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 

--- a/docs/attributes-registry/system.md
+++ b/docs/attributes-registry/system.md
@@ -1,5 +1,16 @@
 # System
 
+<!-- toc -->
+
+- [CPU attributes](#cpu-attributes)
+- [Memory attributes](#memory-attributes)
+- [Paging attributes](#paging-attributes)
+- [Filesystem attributes](#filesystem-attributes)
+- [Network attributes](#network-attributes)
+- [Process attributes](#process-attributes)
+
+<!-- tocstop -->
+
 <!-- semconv registry.system(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|

--- a/docs/attributes-registry/system.md
+++ b/docs/attributes-registry/system.md
@@ -1,0 +1,137 @@
+# System
+
+<!-- semconv registry.system(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `system.device` | string | The device identifier | `(identifier)` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->
+
+<!-- semconv registry.system.cpu(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `system.cpu.logical_number` | int | The logical CPU number [0..n-1] | `1` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `system.cpu.state` | string | The CPU state for this data point. A system's CPU SHOULD be characterized *either* by data points with no `state` labels, *or only* data points with `state` labels. | `idle`; `interrupt` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+`system.cpu.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `user` | user | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `system` | system | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `nice` | nice | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `idle` | idle | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `iowait` | iowait | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `interrupt` | interrupt | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `steal` | steal | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->
+
+<!-- semconv registry.system.memory(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `system.memory.state` | string | The memory state | `free`; `cached` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+`system.memory.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `used` | used | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `free` | free | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `shared` | shared | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `buffers` | buffers | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `cached` | cached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->
+
+<!-- semconv registry.system.paging(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `system.paging.direction` | string | The paging access direction | `in` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `system.paging.state` | string | The memory paging state | `free` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `system.paging.type` | string | The memory paging type | `minor` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+`system.paging.direction` MUST be one of the following:
+
+| Value  | Description | Stability |
+|---|---|---|
+| `in` | in | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `out` | out | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+`system.paging.state` MUST be one of the following:
+
+| Value  | Description | Stability |
+|---|---|---|
+| `used` | used | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `free` | free | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+`system.paging.type` MUST be one of the following:
+
+| Value  | Description | Stability |
+|---|---|---|
+| `major` | major | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `minor` | minor | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->
+
+<!-- semconv registry.system.filesystem(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `system.filesystem.mode` | string | The filesystem mode | `rw, ro` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `system.filesystem.mountpoint` | string | The filesystem mount path | `/mnt/data` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `system.filesystem.state` | string | The filesystem state | `used` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `system.filesystem.type` | string | The filesystem type | `ext4` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+`system.filesystem.state` MUST be one of the following:
+
+| Value  | Description | Stability |
+|---|---|---|
+| `used` | used | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `free` | free | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `reserved` | reserved | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+`system.filesystem.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `fat32` | fat32 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `exfat` | exfat | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `ntfs` | ntfs | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `refs` | refs | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `hfsplus` | hfsplus | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `ext4` | ext4 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->
+
+<!-- semconv registry.system.network(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `system.network.state` | string | A stateless protocol MUST NOT set this attribute | `close_wait` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+`system.network.state` MUST be one of the following:
+
+| Value  | Description | Stability |
+|---|---|---|
+| `close` | close | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `close_wait` | close_wait | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `closing` | closing | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `delete` | delete | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `established` | established | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `fin_wait_1` | fin_wait_1 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `fin_wait_2` | fin_wait_2 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `last_ack` | last_ack | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `listen` | listen | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `syn_recv` | syn_recv | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `syn_sent` | syn_sent | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `time_wait` | time_wait | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->
+
+<!-- semconv registry.system.process(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `system.process.status` | string | The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES) | `running` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+`system.process.status` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `running` | running | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `sleeping` | sleeping | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `stopped` | stopped | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `defunct` | defunct | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->

--- a/docs/attributes-registry/system.md
+++ b/docs/attributes-registry/system.md
@@ -8,6 +8,7 @@
 - [Filesystem attributes](#filesystem-attributes)
 - [Network attributes](#network-attributes)
 - [Process attributes](#process-attributes)
+- [Deprecated System Attributes](#deprecated-system-attributes)
 
 <!-- tocstop -->
 
@@ -150,6 +151,23 @@
 | `system.process.status` | string | The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES) | `running` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.process.status` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `running` | running | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `sleeping` | sleeping | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `stopped` | stopped | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `defunct` | defunct | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->
+
+## Deprecated System Attributes
+
+<!-- semconv registry.system.deprecated(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `system.processes.status` | string | Deprecated, use `system.process.status` instead. | `running` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `system.process.status`. |
+
+`system.processes.status` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/docs/attributes-registry/system.md
+++ b/docs/attributes-registry/system.md
@@ -6,6 +6,8 @@
 | `system.device` | string | The device identifier | `(identifier)` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
+## CPU attributes
+
 <!-- semconv registry.system.cpu(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
@@ -25,6 +27,8 @@
 | `steal` | steal | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
+## Memory attributes
+
 <!-- semconv registry.system.memory(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
@@ -40,6 +44,8 @@
 | `buffers` | buffers | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cached` | cached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
+
+## Paging attributes
 
 <!-- semconv registry.system.paging(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
@@ -70,6 +76,8 @@
 | `minor` | minor | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
+## Filesystem attributes
+
 <!-- semconv registry.system.filesystem(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
@@ -98,6 +106,8 @@
 | `ext4` | ext4 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
+## Network attributes
+
 <!-- semconv registry.system.network(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
@@ -120,6 +130,8 @@
 | `syn_sent` | syn_sent | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `time_wait` | time_wait | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
+
+## Process attributes
 
 <!-- semconv registry.system.process(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -65,7 +65,7 @@ This metric is [opt-in][MetricOptIn].
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`disk.io.direction`](../attributes-registry/disk.md) | string | The disk IO operation direction. | `read` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `disk.io.direction` MUST be one of the following:
 
@@ -91,7 +91,7 @@ This metric is [opt-in][MetricOptIn].
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`network.io.direction`](../attributes-registry/network.md) | string | The network IO operation direction. | `transmit` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `network.io.direction` MUST be one of the following:
 

--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -86,8 +86,8 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.cpu.time(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.cpu.logical_number` | int | The logical CPU number [0..n-1] | `1` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.cpu.state` | string | The CPU state for this data point. A system's CPU SHOULD be characterized *either* by data points with no `state` labels, *or only* data points with `state` labels. | `idle`; `interrupt` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.cpu.logical_number`](../attributes-registry/system.md) | int | The logical CPU number [0..n-1] | `1` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.cpu.state`](../attributes-registry/system.md) | string | The CPU state for this data point. A system's CPU SHOULD be characterized *either* by data points with no `state` labels, *or only* data points with `state` labels. | `idle`; `interrupt` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.cpu.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
@@ -115,8 +115,8 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.cpu.utilization(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.cpu.logical_number` | int | The logical CPU number [0..n-1] | `1` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.cpu.state` | string | The CPU state for this data point. A system's CPU SHOULD be characterized *either* by data points with no `state` labels, *or only* data points with `state` labels. | `idle`; `interrupt` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.cpu.logical_number`](../attributes-registry/system.md) | int | The logical CPU number [0..n-1] | `1` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.cpu.state`](../attributes-registry/system.md) | string | The CPU state for this data point. A system's CPU SHOULD be characterized *either* by data points with no `state` labels, *or only* data points with `state` labels. | `idle`; `interrupt` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.cpu.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
@@ -170,7 +170,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.cpu.frequency(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.cpu.logical_number` | int | The logical CPU number [0..n-1] | `1` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.cpu.logical_number`](../attributes-registry/system.md) | int | The logical CPU number [0..n-1] | `1` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ## Memory Metrics
@@ -194,7 +194,7 @@ available on the system, that is `system.memory.limit`.
 <!-- semconv metric.system.memory.usage(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.memory.state` | string | The memory state | `free`; `cached` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.memory.state`](../attributes-registry/system.md) | string | The memory state | `free`; `cached` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.memory.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
@@ -235,7 +235,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.memory.utilization(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.memory.state` | string | The memory state | `free`; `cached` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.memory.state`](../attributes-registry/system.md) | string | The memory state | `free`; `cached` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.memory.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
@@ -265,7 +265,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.paging.usage(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.paging.state` | string | The memory paging state | `free` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.paging.state`](../attributes-registry/system.md) | string | The memory paging state | `free` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.paging.state` MUST be one of the following:
 
@@ -288,7 +288,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.paging.utilization(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.paging.state` | string | The memory paging state | `free` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.paging.state`](../attributes-registry/system.md) | string | The memory paging state | `free` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.paging.state` MUST be one of the following:
 
@@ -311,7 +311,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.paging.faults(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.paging.type` | string | The memory paging type | `minor` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.paging.type`](../attributes-registry/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.paging.type` MUST be one of the following:
 
@@ -334,8 +334,8 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.paging.operations(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.paging.direction` | string | The paging access direction | `in` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.paging.type` | string | The memory paging type | `minor` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.paging.direction`](../attributes-registry/system.md) | string | The paging access direction | `in` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.paging.type`](../attributes-registry/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.paging.direction` MUST be one of the following:
 
@@ -370,7 +370,7 @@ This metric is [recommended][MetricRecommended].
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`disk.io.direction`](../attributes-registry/disk.md) | string | The disk IO operation direction. | `read` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `disk.io.direction` MUST be one of the following:
 
@@ -394,7 +394,7 @@ This metric is [recommended][MetricRecommended].
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`disk.io.direction`](../attributes-registry/disk.md) | string | The disk IO operation direction. | `read` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `disk.io.direction` MUST be one of the following:
 
@@ -424,7 +424,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.disk.io_time(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `system.disk.operation_time`
@@ -446,7 +446,7 @@ This metric is [recommended][MetricRecommended].
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`disk.io.direction`](../attributes-registry/disk.md) | string | The disk IO operation direction. | `read` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `disk.io.direction` MUST be one of the following:
 
@@ -470,7 +470,7 @@ This metric is [recommended][MetricRecommended].
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`disk.io.direction`](../attributes-registry/disk.md) | string | The disk IO operation direction. | `read` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `disk.io.direction` MUST be one of the following:
 
@@ -497,11 +497,11 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.filesystem.usage(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.filesystem.mode` | string | The filesystem mode | `rw, ro` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.filesystem.mountpoint` | string | The filesystem mount path | `/mnt/data` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.filesystem.state` | string | The filesystem state | `used` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.filesystem.type` | string | The filesystem type | `ext4` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.filesystem.mode`](../attributes-registry/system.md) | string | The filesystem mode | `rw, ro` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.filesystem.mountpoint`](../attributes-registry/system.md) | string | The filesystem mount path | `/mnt/data` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.filesystem.state`](../attributes-registry/system.md) | string | The filesystem state | `used` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.filesystem.type`](../attributes-registry/system.md) | string | The filesystem type | `ext4` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.filesystem.state` MUST be one of the following:
 
@@ -536,11 +536,11 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.filesystem.utilization(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.filesystem.mode` | string | The filesystem mode | `rw, ro` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.filesystem.mountpoint` | string | The filesystem mount path | `/mnt/data` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.filesystem.state` | string | The filesystem state | `used` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.filesystem.type` | string | The filesystem type | `ext4` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.filesystem.mode`](../attributes-registry/system.md) | string | The filesystem mode | `rw, ro` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.filesystem.mountpoint`](../attributes-registry/system.md) | string | The filesystem mount path | `/mnt/data` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.filesystem.state`](../attributes-registry/system.md) | string | The filesystem state | `used` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.filesystem.type`](../attributes-registry/system.md) | string | The filesystem type | `ext4` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.filesystem.state` MUST be one of the following:
 
@@ -586,7 +586,7 @@ This metric is [recommended][MetricRecommended].
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`network.io.direction`](../attributes-registry/network.md) | string | The network IO operation direction. | `transmit` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `network.io.direction` MUST be one of the following:
 
@@ -610,7 +610,7 @@ This metric is [recommended][MetricRecommended].
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`network.io.direction`](../attributes-registry/network.md) | string | The network IO operation direction. | `transmit` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `network.io.direction` MUST be one of the following:
 
@@ -640,7 +640,7 @@ This metric is [recommended][MetricRecommended].
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`network.io.direction`](../attributes-registry/network.md) | string | The network IO operation direction. | `transmit` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `network.io.direction` MUST be one of the following:
 
@@ -664,7 +664,7 @@ This metric is [recommended][MetricRecommended].
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`network.io.direction`](../attributes-registry/network.md) | string | The network IO operation direction. | `transmit` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `network.io.direction` MUST be one of the following:
 
@@ -688,8 +688,8 @@ This metric is [recommended][MetricRecommended].
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`network.transport`](../attributes-registry/network.md) | string | [OSI transport layer](https://osi-model.com/transport-layer/) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication). [1] | `tcp`; `udp` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `system.device` | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `system.network.state` | string | A stateless protocol MUST NOT set this attribute | `close_wait` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.device`](../attributes-registry/system.md) | string | The device identifier | `(identifier)` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.network.state`](../attributes-registry/system.md) | string | A stateless protocol MUST NOT set this attribute | `close_wait` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 **[1]:** The value SHOULD be normalized to lowercase.
 
@@ -741,7 +741,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.system.process.count(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `system.process.status` | string | The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES) | `running` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`system.process.status`](../attributes-registry/system.md) | string | The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES) | `running` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `system.process.status` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 

--- a/model/metrics/system-metrics.yaml
+++ b/model/metrics/system-metrics.yaml
@@ -9,6 +9,7 @@ groups:
     unit: "s"
     attributes:
       - ref: system.cpu.state
+        brief: "The CPU state for this data point. A system's CPU SHOULD be characterized *either* by data points with no `state` labels, *or only* data points with `state` labels."
       - ref: system.cpu.logical_number
 
   - id: metric.system.cpu.utilization
@@ -20,6 +21,7 @@ groups:
     unit: "1"
     attributes:
       - ref: system.cpu.state
+        brief: "The CPU state for this data point. A system's CPU SHOULD be characterized *either* by data points with no `state` labels, *or only* data points with `state` labels."
       - ref: system.cpu.logical_number
 
   - id: metric.system.cpu.frequency

--- a/model/metrics/system-metrics.yaml
+++ b/model/metrics/system-metrics.yaml
@@ -1,56 +1,5 @@
 groups:
-  # General system attributes
-  - id: attributes.system
-    prefix: system
-    type: attribute_group
-    brief: "Describes System metric attributes"
-    attributes:
-      - id: device
-        type: string
-        stability: experimental
-        brief: "The device identifier"
-        examples: ["(identifier)"]
-
-  # system.cpu.* metrics and attribute group
-  - id: attributes.system.cpu
-    prefix: system.cpu
-    type: attribute_group
-    brief: "Describes System CPU metric attributes"
-    attributes:
-      - id: state
-        type:
-          allow_custom_values: true
-          members:
-            - id: user
-              value: 'user'
-              stability: experimental
-            - id: system
-              value: 'system'
-              stability: experimental
-            - id: nice
-              value: 'nice'
-              stability: experimental
-            - id: idle
-              value: 'idle'
-              stability: experimental
-            - id: iowait
-              value: 'iowait'
-              stability: experimental
-            - id: interrupt
-              value: 'interrupt'
-              stability: experimental
-            - id: steal
-              value: 'steal'
-              stability: experimental
-        brief: "The CPU state for this data point. A system's CPU SHOULD be characterized *either* by data points with no `state` labels, *or only* data points with `state` labels."
-        stability: experimental
-        examples: ["idle", "interrupt"]
-      - id: logical_number
-        type: int
-        stability: experimental
-        brief: "The logical CPU number [0..n-1]"
-        examples: [1]
-
+  # system.cpu.* metrics
   - id: metric.system.cpu.time
     type: metric
     metric_name: system.cpu.time
@@ -101,35 +50,7 @@ groups:
     unit: "{cpu}"
     attributes: []
 
-  # sytem.memory.* metrics and attribute group
-  - id: attributes.system.memory
-    prefix: system.memory
-    type: attribute_group
-    brief: "Describes System Memory metric attributes"
-    attributes:
-      - id: state
-        type:
-          allow_custom_values: true
-          members:
-            - id: used
-              value: 'used'
-              stability: experimental
-            - id: free
-              value: 'free'
-              stability: experimental
-            - id: shared
-              value: 'shared'
-              stability: experimental
-            - id: buffers
-              value: 'buffers'
-              stability: experimental
-            - id: cached
-              value: 'cached'
-              stability: experimental
-        stability: experimental
-        brief: "The memory state"
-        examples: ["free", "cached"]
-
+  # sytem.memory.* metrics
   - id: metric.system.memory.usage
     type: metric
     metric_name: system.memory.usage
@@ -152,6 +73,7 @@ groups:
       Its value SHOULD equal the sum of `system.memory.state` over all states.
     instrument: updowncounter
     unit: "By"
+    attributes: []
 
   - id: metric.system.memory.utilization
     type: metric
@@ -163,51 +85,7 @@ groups:
     attributes:
       - ref: system.memory.state
 
-  # system.paging.* metrics and attribute group
-  - id: attributes.system.paging
-    prefix: system.paging
-    type: attribute_group
-    brief: "Describes System Memory Paging metric attributes"
-    attributes:
-      - id: state
-        type:
-          allow_custom_values: false
-          members:
-            - id: used
-              value: 'used'
-              stability: experimental
-            - id: free
-              value: 'free'
-              stability: experimental
-        stability: experimental
-        brief: "The memory paging state"
-        examples: ["free"]
-      - id: type
-        type:
-          allow_custom_values: false
-          members:
-            - id: major
-              value: 'major'
-              stability: experimental
-            - id: minor
-              value: 'minor'
-              stability: experimental
-        stability: experimental
-        brief: "The memory paging type"
-        examples: ["minor"]
-      - id: direction
-        type:
-          allow_custom_values: false
-          members:
-            - id: in
-              value: 'in'
-              stability: experimental
-            - id: out
-              value: 'out'
-              stability: experimental
-        stability: experimental
-        brief: "The paging access direction"
-        examples: ["in"]
+  # system.paging.* metrics
   - id: metric.system.paging.usage
     type: metric
     metric_name: system.paging.usage
@@ -249,7 +127,7 @@ groups:
       - ref: system.paging.type
       - ref: system.paging.direction
 
-  # system.disk.* metrics and attribute group
+  # system.disk.* metrics
   - id: metric.system.disk.io
     type: metric
     metric_name: system.disk.io
@@ -316,64 +194,7 @@ groups:
       - ref: system.device
       - ref: disk.io.direction
 
-  # system.filesystem.* metrics and attribute group
-  - id: attributes.system.filesystem
-    prefix: system.filesystem
-    type: attribute_group
-    brief: "Describes Filesystem metric attributes"
-    attributes:
-      - id: state
-        brief: "The filesystem state"
-        type:
-          allow_custom_values: false
-          members:
-            - id: used
-              value: 'used'
-              stability: experimental
-            - id: free
-              value: 'free'
-              stability: experimental
-            - id: reserved
-              value: 'reserved'
-              stability: experimental
-        stability: experimental
-        examples: ["used"]
-      - id: type
-        type:
-          allow_custom_values: true
-          members:
-            - id: fat32
-              value: 'fat32'
-              stability: experimental
-            - id: exfat
-              value: 'exfat'
-              stability: experimental
-            - id: ntfs
-              value: 'ntfs'
-              stability: experimental
-            - id: refs
-              value: 'refs'
-              stability: experimental
-            - id: hfsplus
-              value: 'hfsplus'
-              stability: experimental
-            - id: ext4
-              value: 'ext4'
-              stability: experimental
-        stability: experimental
-        brief: "The filesystem type"
-        examples: ["ext4"]
-      - id: mode
-        type: string
-        stability: experimental
-        brief: "The filesystem mode"
-        examples: ["rw, ro"]
-      - id: mountpoint
-        type: string
-        stability: experimental
-        brief: "The filesystem mount path"
-        examples: ["/mnt/data"]
-
+  # system.filesystem.* metrics
   - id: metric.system.filesystem.usage
     type: metric
     metric_name: system.filesystem.usage
@@ -402,58 +223,7 @@ groups:
       - ref: system.filesystem.mode
       - ref: system.filesystem.mountpoint
 
-  # system.network.* metrics and attribute group
-
-  # System-specific network attributes
-  - id: attributes.system.network
-    prefix: system.network
-    type: attribute_group
-    brief: "Describes Network metric attributes"
-    attributes:
-      - id: state
-        type:
-          allow_custom_values: false
-          members:
-            - id: close
-              value: 'close'
-              stability: experimental
-            - id: close_wait
-              value: 'close_wait'
-              stability: experimental
-            - id: closing
-              value: 'closing'
-              stability: experimental
-            - id: delete
-              value: 'delete'
-              stability: experimental
-            - id: established
-              value: 'established'
-              stability: experimental
-            - id: fin_wait_1
-              value: 'fin_wait_1'
-              stability: experimental
-            - id: fin_wait_2
-              value: 'fin_wait_2'
-              stability: experimental
-            - id: last_ack
-              value: 'last_ack'
-              stability: experimental
-            - id: listen
-              value: 'listen'
-              stability: experimental
-            - id: syn_recv
-              value: 'syn_recv'
-              stability: experimental
-            - id: syn_sent
-              value: 'syn_sent'
-              stability: experimental
-            - id: time_wait
-              value: 'time_wait'
-              stability: experimental
-        stability: experimental
-        brief: "A stateless protocol MUST NOT set this attribute"
-        examples: ["close_wait"]
-
+  # system.network.* metrics
   - id: metric.system.network.dropped
     type: metric
     metric_name: system.network.dropped
@@ -522,34 +292,7 @@ groups:
       - ref: system.network.state
       - ref: network.transport
 
-  # system.process.* metrics and attribute group
-  - id: attributes.system.process
-    prefix: system.process
-    type: attribute_group
-    brief: "Describes System Process metric attributes"
-    attributes:
-      - id: status
-        type:
-          allow_custom_values: true
-          members:
-            - id: running
-              value: 'running'
-              stability: experimental
-            - id: sleeping
-              value: 'sleeping'
-              stability: experimental
-            - id: stopped
-              value: 'stopped'
-              stability: experimental
-            - id: defunct
-              value: 'defunct'
-              stability: experimental
-        stability: experimental
-        brief: >
-          The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES)
-        examples: ["running"]
-
-
+  # system.process.* metrics
   - id: metric.system.process.count
     type: metric
     metric_name: system.process.count
@@ -567,6 +310,7 @@ groups:
     brief: "Total number of processes created over uptime of the host"
     instrument: counter
     unit: "{process}"
+    attributes: []
 
   # system.linux.* metrics
   - id: metric.system.linux.memory.available
@@ -582,3 +326,4 @@ groups:
       See also `MemAvailable` in [/proc/meminfo](https://man7.org/linux/man-pages/man5/proc.5.html).
     instrument: updowncounter
     unit: "By"
+    attributes: []

--- a/model/registry/system.yaml
+++ b/model/registry/system.yaml
@@ -1,0 +1,255 @@
+groups:
+  # General system attributes
+  - id: registry.system
+    prefix: system
+    type: attribute_group
+    brief: "Describes System metric attributes"
+    attributes:
+      - id: device
+        type: string
+        stability: experimental
+        brief: "The device identifier"
+        examples: ["(identifier)"]
+  # system.cpu.* attribute group
+  - id: registry.system.cpu
+    prefix: system.cpu
+    type: attribute_group
+    brief: "Describes System CPU metric attributes"
+    attributes:
+      - id: state
+        type:
+          allow_custom_values: true
+          members:
+            - id: user
+              value: 'user'
+              stability: experimental
+            - id: system
+              value: 'system'
+              stability: experimental
+            - id: nice
+              value: 'nice'
+              stability: experimental
+            - id: idle
+              value: 'idle'
+              stability: experimental
+            - id: iowait
+              value: 'iowait'
+              stability: experimental
+            - id: interrupt
+              value: 'interrupt'
+              stability: experimental
+            - id: steal
+              value: 'steal'
+              stability: experimental
+        brief: "The CPU state for this data point. A system's CPU SHOULD be characterized *either* by data points with no `state` labels, *or only* data points with `state` labels."
+        stability: experimental
+        examples: ["idle", "interrupt"]
+      - id: logical_number
+        type: int
+        stability: experimental
+        brief: "The logical CPU number [0..n-1]"
+        examples: [1]
+  # sytem.memory.* attribute group
+  - id: registry.system.memory
+    prefix: system.memory
+    type: attribute_group
+    brief: "Describes System Memory metric attributes"
+    attributes:
+      - id: state
+        type:
+          allow_custom_values: true
+          members:
+            - id: used
+              value: 'used'
+              stability: experimental
+            - id: free
+              value: 'free'
+              stability: experimental
+            - id: shared
+              value: 'shared'
+              stability: experimental
+            - id: buffers
+              value: 'buffers'
+              stability: experimental
+            - id: cached
+              value: 'cached'
+              stability: experimental
+        stability: experimental
+        brief: "The memory state"
+        examples: ["free", "cached"]
+  # system.paging.* attribute group
+  - id: registry.system.paging
+    prefix: system.paging
+    type: attribute_group
+    brief: "Describes System Memory Paging metric attributes"
+    attributes:
+      - id: state
+        type:
+          allow_custom_values: false
+          members:
+            - id: used
+              value: 'used'
+              stability: experimental
+            - id: free
+              value: 'free'
+              stability: experimental
+        stability: experimental
+        brief: "The memory paging state"
+        examples: ["free"]
+      - id: type
+        type:
+          allow_custom_values: false
+          members:
+            - id: major
+              value: 'major'
+              stability: experimental
+            - id: minor
+              value: 'minor'
+              stability: experimental
+        stability: experimental
+        brief: "The memory paging type"
+        examples: ["minor"]
+      - id: direction
+        type:
+          allow_custom_values: false
+          members:
+            - id: in
+              value: 'in'
+              stability: experimental
+            - id: out
+              value: 'out'
+              stability: experimental
+        stability: experimental
+        brief: "The paging access direction"
+        examples: ["in"]
+  - id: registry.system.filesystem
+    prefix: system.filesystem
+    type: attribute_group
+    brief: "Describes Filesystem metric attributes"
+    attributes:
+      - id: state
+        brief: "The filesystem state"
+        type:
+          allow_custom_values: false
+          members:
+            - id: used
+              value: 'used'
+              stability: experimental
+            - id: free
+              value: 'free'
+              stability: experimental
+            - id: reserved
+              value: 'reserved'
+              stability: experimental
+        stability: experimental
+        examples: ["used"]
+      - id: type
+        type:
+          allow_custom_values: true
+          members:
+            - id: fat32
+              value: 'fat32'
+              stability: experimental
+            - id: exfat
+              value: 'exfat'
+              stability: experimental
+            - id: ntfs
+              value: 'ntfs'
+              stability: experimental
+            - id: refs
+              value: 'refs'
+              stability: experimental
+            - id: hfsplus
+              value: 'hfsplus'
+              stability: experimental
+            - id: ext4
+              value: 'ext4'
+              stability: experimental
+        stability: experimental
+        brief: "The filesystem type"
+        examples: ["ext4"]
+      - id: mode
+        type: string
+        stability: experimental
+        brief: "The filesystem mode"
+        examples: ["rw, ro"]
+      - id: mountpoint
+        type: string
+        stability: experimental
+        brief: "The filesystem mount path"
+        examples: ["/mnt/data"]
+  # System-specific network attributes
+  - id: registry.system.network
+    prefix: system.network
+    type: attribute_group
+    brief: "Describes Network metric attributes"
+    attributes:
+      - id: state
+        type:
+          allow_custom_values: false
+          members:
+            - id: close
+              value: 'close'
+              stability: experimental
+            - id: close_wait
+              value: 'close_wait'
+              stability: experimental
+            - id: closing
+              value: 'closing'
+              stability: experimental
+            - id: delete
+              value: 'delete'
+              stability: experimental
+            - id: established
+              value: 'established'
+              stability: experimental
+            - id: fin_wait_1
+              value: 'fin_wait_1'
+              stability: experimental
+            - id: fin_wait_2
+              value: 'fin_wait_2'
+              stability: experimental
+            - id: last_ack
+              value: 'last_ack'
+              stability: experimental
+            - id: listen
+              value: 'listen'
+              stability: experimental
+            - id: syn_recv
+              value: 'syn_recv'
+              stability: experimental
+            - id: syn_sent
+              value: 'syn_sent'
+              stability: experimental
+            - id: time_wait
+              value: 'time_wait'
+              stability: experimental
+        stability: experimental
+        brief: "A stateless protocol MUST NOT set this attribute"
+        examples: ["close_wait"]
+  # system.process.* attribute group
+  - id: registry.system.process
+    prefix: system.process
+    type: attribute_group
+    brief: "Describes System Process metric attributes"
+    attributes:
+      - id: status
+        type:
+          allow_custom_values: true
+          members:
+            - id: running
+              value: 'running'
+              stability: experimental
+            - id: sleeping
+              value: 'sleeping'
+              stability: experimental
+            - id: stopped
+              value: 'stopped'
+              stability: experimental
+            - id: defunct
+              value: 'defunct'
+              stability: experimental
+        stability: experimental
+        brief: >
+          The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES)
+        examples: ["running"]

--- a/model/registry/system.yaml
+++ b/model/registry/system.yaml
@@ -3,7 +3,7 @@ groups:
   - id: registry.system
     prefix: system
     type: attribute_group
-    brief: "Describes System metric attributes"
+    brief: "Describes System attributes"
     attributes:
       - id: device
         type: string
@@ -14,7 +14,7 @@ groups:
   - id: registry.system.cpu
     prefix: system.cpu
     type: attribute_group
-    brief: "Describes System CPU metric attributes"
+    brief: "Describes System CPU attributes"
     attributes:
       - id: state
         type:
@@ -41,7 +41,7 @@ groups:
             - id: steal
               value: 'steal'
               stability: experimental
-        brief: "The CPU state for this data point. A system's CPU SHOULD be characterized *either* by data points with no `state` labels, *or only* data points with `state` labels."
+        brief: "The state of the CPU"
         stability: experimental
         examples: ["idle", "interrupt"]
       - id: logical_number
@@ -53,7 +53,7 @@ groups:
   - id: registry.system.memory
     prefix: system.memory
     type: attribute_group
-    brief: "Describes System Memory metric attributes"
+    brief: "Describes System Memory attributes"
     attributes:
       - id: state
         type:
@@ -81,7 +81,7 @@ groups:
   - id: registry.system.paging
     prefix: system.paging
     type: attribute_group
-    brief: "Describes System Memory Paging metric attributes"
+    brief: "Describes System Memory Paging attributes"
     attributes:
       - id: state
         type:
@@ -125,7 +125,7 @@ groups:
   - id: registry.system.filesystem
     prefix: system.filesystem
     type: attribute_group
-    brief: "Describes Filesystem metric attributes"
+    brief: "Describes Filesystem attributes"
     attributes:
       - id: state
         brief: "The filesystem state"
@@ -182,7 +182,7 @@ groups:
   - id: registry.system.network
     prefix: system.network
     type: attribute_group
-    brief: "Describes Network metric attributes"
+    brief: "Describes Network attributes"
     attributes:
       - id: state
         type:
@@ -231,7 +231,7 @@ groups:
   - id: registry.system.process
     prefix: system.process
     type: attribute_group
-    brief: "Describes System Process metric attributes"
+    brief: "Describes System Process attributes"
     attributes:
       - id: status
         type:


### PR DESCRIPTION
## Changes

Moves `system.*` attributes to the registry from system metrics. 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
