### PR TITLE
[chore] change prefix for deprecated attributes

### DIFF
--- a/docs/attributes-registry/container.md
+++ b/docs/attributes-registry/container.md
@@ -3,6 +3,13 @@
 
 # Container
 
+<!-- toc -->
+
+- [Container Attributes](#container-attributes)
+- [Deprecated Container Attributes](#deprecated-container-attributes)
+
+<!-- tocstop -->
+
 ## Container Attributes
 
 <!-- semconv registry.container(omit_requirement_level) -->
@@ -36,4 +43,12 @@ The ID is assinged by the container runtime and can vary in different environmen
 | `user` | When tasks of the cgroup are in user mode (Linux). When all container processes are in user mode (Windows). | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `system` | When CPU is used by the system (host OS) | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `kernel` | When tasks of the cgroup are in kernel mode (Linux). When all container processes are in kernel mode (Windows). | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->
+
+## Deprecated Container Attributes
+
+<!-- semconv registry.container.deprecated(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `container.labels.<key>` | string | Deprecated, use `container.label` instead. | `container.label.app=nginx` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `container.label`. |
 <!-- endsemconv -->

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -213,7 +213,7 @@
 
 ## Deprecated DB Attributes
 
-<!-- semconv attributes.db.deprecated(omit_requirement_level) -->
+<!-- semconv registry.db.deprecated(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `db.connection_string` | string | Deprecated, use `server.address`, `server.port` attributes instead. | `Server=(localdb)\v11.0;Integrated Security=true;` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>"Replaced by `server.address` and `server.port`." |
@@ -224,7 +224,7 @@
 
 ### Deprecated Elasticsearch Attributes
 
-<!-- semconv attributes.db.deprecated(omit_requirement_level) -->
+<!-- semconv registry.db.deprecated(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `db.connection_string` | string | Deprecated, use `server.address`, `server.port` attributes instead. | `Server=(localdb)\v11.0;Integrated Security=true;` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>"Replaced by `server.address` and `server.port`." |

--- a/docs/attributes-registry/http.md
+++ b/docs/attributes-registry/http.md
@@ -3,6 +3,13 @@
 
 # HTTP
 
+<!-- toc -->
+
+- [HTTP Attributes](#http-attributes)
+- [Deprecated HTTP Attributes](#deprecated-http-attributes)
+
+<!-- tocstop -->
+
 ## HTTP Attributes
 
 <!-- semconv registry.http(omit_requirement_level) -->
@@ -74,7 +81,7 @@ SHOULD include the [application root](/docs/http/http-spans.md#http-server-defin
 
 ## Deprecated HTTP Attributes
 
-<!-- semconv attributes.http.deprecated(omit_requirement_level) -->
+<!-- semconv registry.http.deprecated(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `http.flavor` | string | Deprecated, use `network.protocol.name` instead. | `1.0` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `network.protocol.name`. |

--- a/docs/attributes-registry/k8s.md
+++ b/docs/attributes-registry/k8s.md
@@ -1,6 +1,13 @@
 # Kubernetes
 
-## Kubernetes Resource Attributes
+<!-- toc -->
+
+- [Kubernetes Attributes](#kubernetes-attributes)
+- [Deprecated Kubernetes Attributes](#deprecated-kubernetes-attributes)
+
+<!-- tocstop -->
+
+## Kubernetes Attributes
 
 <!-- semconv registry.k8s(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
@@ -51,4 +58,12 @@ Which states:
 
 Therefore, UIDs between clusters should be extremely unlikely to
 conflict.
+<!-- endsemconv -->
+
+## Deprecated Kubernetes Attributes
+
+<!-- semconv registry.k8s.deprecated(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `k8s.pod.labels.<key>` | string | Deprecated, use `k8s.pod.label` instead. | `k8s.pod.label.app=my-app` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `k8s.pod.label`. |
 <!-- endsemconv -->

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -174,7 +174,7 @@ size should be used.
 
 ## Deprecated Messaging Attributes
 
-<!-- semconv attributes.messaging.deprecated(omit_requirement_level) -->
+<!-- semconv registry.messaging.deprecated(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `messaging.kafka.destination.partition` | int | "Deprecated, use `messaging.destination.partition.id` instead." | `2` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `messaging.destination.partition.id`. |

--- a/docs/attributes-registry/network.md
+++ b/docs/attributes-registry/network.md
@@ -5,6 +5,13 @@
 
 These attributes may be used for any network related operation.
 
+<!-- toc -->
+
+- [Network Attributes](#network-attributes)
+- [Deprecated Network Attributes](#deprecated-network-attributes)
+
+<!-- tocstop -->
+
 ## Network Attributes
 
 <!-- semconv registry.network(omit_requirement_level) -->
@@ -100,7 +107,7 @@ different processes could be listening on TCP port 12345 and UDP port 12345.
 
 ## Deprecated Network Attributes
 
-<!-- semconv attributes.network.deprecated(omit_requirement_level) -->
+<!-- semconv registry.network.deprecated(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `net.host.name` | string | Deprecated, use `server.address`. | `example.com` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `server.address`. |

--- a/docs/attributes-registry/otel.md
+++ b/docs/attributes-registry/otel.md
@@ -3,11 +3,27 @@
 
 # OpenTelemetry
 
-## Scope Attributes
+<!-- toc -->
+
+- [OpenTelemetry Attributes](#opentelemetry-attributes)
+- [Deprecated OpenTelemetry Attributes](#deprecated-opentelemetry-attributes)
+
+<!-- tocstop -->
+
+## OpenTelemetry Attributes
 
 <!-- semconv registry.otel.scope(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `otel.scope.name` | string | The name of the instrumentation scope - (`InstrumentationScope.Name` in OTLP). | `io.opentelemetry.contrib.mongodb` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `otel.scope.version` | string | The version of the instrumentation scope - (`InstrumentationScope.Version` in OTLP). | `1.0.0` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+<!-- endsemconv -->
+
+## Deprecated OpenTelemetry Attributes
+
+<!-- semconv registry.otel.library.deprecated(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `otel.library.name` | string | None | `io.opentelemetry.contrib.mongodb` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>use the `otel.scope.name` attribute. |
+| `otel.library.version` | string | None | `1.0.0` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>use the `otel.scope.version` attribute. |
 <!-- endsemconv -->

--- a/docs/attributes-registry/rpc.md
+++ b/docs/attributes-registry/rpc.md
@@ -3,6 +3,13 @@
 
 # RPC
 
+<!-- toc -->
+
+- [RPC Attributes](#rpc-attributes)
+- [Deprecated RPC Attributes](#deprecated-rpc-attributes)
+
+<!-- tocstop -->
+
 ## RPC Attributes
 
 RPC attributes are intended to be used in the context of events related to remote procedure calls (RPC).
@@ -101,4 +108,22 @@ RPC attributes are intended to be used in the context of events related to remot
 | `dotnet_wcf` | .NET WCF | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `apache_dubbo` | Apache Dubbo | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `connect_rpc` | Connect RPC | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->
+
+## Deprecated RPC Attributes
+
+<!-- semconv registry.rpc.deprecated(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `message.compressed_size` | int | Deprecated, use `rpc.message.compressed_size` instead. |  | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `rpc.message.compressed_size`. |
+| `message.id` | int | Deprecated, use `rpc.message.id` instead. |  | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `rpc.message.id`. |
+| `message.type` | string | Deprecated, use `rpc.message.type` instead. | `SENT` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `rpc.message.type`. |
+| `message.uncompressed_size` | int | Deprecated, use `rpc.message.uncompressed_size` instead. |  | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `rpc.message.uncompressed_size`. |
+
+`message.type` MUST be one of the following:
+
+| Value  | Description | Stability |
+|---|---|---|
+| `SENT` | sent | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `RECEIVED` | received | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->

--- a/model/registry/deprecated/container.yaml
+++ b/model/registry/deprecated/container.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: attributes.container.deprecated
+  - id: registry.container.deprecated
     type: attribute_group
     brief: "Describes deprecated container attributes."
     attributes:

--- a/model/registry/deprecated/db.yaml
+++ b/model/registry/deprecated/db.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: attributes.db.deprecated
+  - id: registry.db.deprecated
     prefix: db
     type: attribute_group
     brief: >

--- a/model/registry/deprecated/http.yaml
+++ b/model/registry/deprecated/http.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: attributes.http.deprecated
+  - id: registry.http.deprecated
     type: attribute_group
     brief: "Describes deprecated HTTP attributes."
     prefix: http

--- a/model/registry/deprecated/k8s.yaml
+++ b/model/registry/deprecated/k8s.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: attributes.k8s.deprecated
+  - id: registry.k8s.deprecated
     type: attribute_group
     brief: "Describes deprecated k8s attributes."
     attributes:

--- a/model/registry/deprecated/messaging.yaml
+++ b/model/registry/deprecated/messaging.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: attributes.messaging.deprecated
+  - id: registry.messaging.deprecated
     type: attribute_group
     brief: "Describes deprecated messaging attributes."
     attributes:

--- a/model/registry/deprecated/network.yaml
+++ b/model/registry/deprecated/network.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: attributes.network.deprecated
+  - id: registry.network.deprecated
     prefix: net
     type: attribute_group
     brief: >

--- a/model/registry/deprecated/otel.yaml
+++ b/model/registry/deprecated/otel.yaml
@@ -1,9 +1,8 @@
 groups:
-  - id: otel.library
+  - id: registry.otel.library.deprecated
     prefix: otel.library
-    type: resource
-    brief: >
-      Span attributes used by non-OTLP exporters to represent OpenTelemetry Scope's concepts.
+    type: attribute_group
+    brief: "Describes deprecated otel.library attributes."
     attributes:
       - id: name
         type: string

--- a/model/registry/deprecated/rpc.yaml
+++ b/model/registry/deprecated/rpc.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: attributes.rpc.deprecated
+  - id: registry.rpc.deprecated
     type: attribute_group
     brief: 'Deprecated rpc message attributes.'
     attributes:

--- a/model/registry/deprecated/system.yaml
+++ b/model/registry/deprecated/system.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: attributes.system.deprecated
+  - id: registry.system.deprecated
     type: attribute_group
     brief: "Deprecated system attributes."
     attributes:


### PR DESCRIPTION
Fixes #896 

## Changes
- change the id from `attributes.X.deprecated` to `registry.X.deprecated`
- added all deprecated attributes to appropriate md files. Only system deprecated metrics should be added to the md file by [system registry PR](https://github.com/open-telemetry/semantic-conventions/pull/867). We might decide later if we want to have them in the main registry files or move somewhere, but this way it is at least consistent now across all namespaces.
- fixed type and description for deprecated attributes in `otel`


## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
