### PR TITLE
[chore] move event to registry

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -35,6 +35,7 @@ body:
         - area:dns
         - area:enduser
         - area:error
+        - area:event
         - area:exception
         - area:faas
         - area:feature-flag

--- a/.github/ISSUE_TEMPLATE/change_proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/change_proposal.yaml
@@ -28,6 +28,7 @@ body:
         - area:dns
         - area:enduser
         - area:error
+        - area:event
         - area:exception
         - area:faas
         - area:feature-flag

--- a/.github/ISSUE_TEMPLATE/new-conventions.yaml
+++ b/.github/ISSUE_TEMPLATE/new-conventions.yaml
@@ -37,6 +37,7 @@ body:
         - area:dns
         - area:enduser
         - area:error
+        - area:event
         - area:exception
         - area:faas
         - area:feature-flag

--- a/docs/attributes-registry/README.md
+++ b/docs/attributes-registry/README.md
@@ -43,6 +43,7 @@ Currently, the following namespaces exist:
 * [Disk](disk.md)
 * [End user](enduser.md)
 * [Error](error.md)
+* [Event](event.md)
 * [Exception](exception.md)
 * [FaaS](faas.md)
 * [Feature Flag](feature-flag.md)

--- a/docs/attributes-registry/event.md
+++ b/docs/attributes-registry/event.md
@@ -1,0 +1,15 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Events
+--->
+
+# Event
+
+## Event Attributes
+
+<!-- semconv registry.event(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `event.name` | string | Identifies the class / type of event. [1] | `browser.mouse.click`; `device.app.lifecycle` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+**[1]:** Event names are subject to the same rules as [attribute names](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/common/attribute-naming.md). Notably, event names are namespaced to avoid collisions and provide a clean separation of semantics for events in separate domains like browser, mobile, and kubernetes.
+<!-- endsemconv -->

--- a/docs/general/events.md
+++ b/docs/general/events.md
@@ -55,7 +55,7 @@ that identify the class of Events but not the instance of the Event.
 <!-- semconv event -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `event.name` | string | Identifies the class / type of event. [1] | `browser.mouse.click`; `device.app.lifecycle` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`event.name`](../attributes-registry/event.md) | string | Identifies the class / type of event. [1] | `browser.mouse.click`; `device.app.lifecycle` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 **[1]:** Event names are subject to the same rules as [attribute names](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/common/attribute-naming.md). Notably, event names are namespaced to avoid collisions and provide a clean separation of semantics for events in separate domains like browser, mobile, and kubernetes.
 <!-- endsemconv -->

--- a/model/logs/events.yaml
+++ b/model/logs/events.yaml
@@ -1,7 +1,6 @@
 groups:
   - id: event
     type: attribute_group
-    prefix: event
     brief: >
         This document defines attributes for Events represented using Log Records.
     attributes:

--- a/model/logs/events.yaml
+++ b/model/logs/events.yaml
@@ -5,15 +5,5 @@ groups:
     brief: >
         This document defines attributes for Events represented using Log Records.
     attributes:
-      - id: name
-        type: string
-        stability: experimental
+      - ref: event.name
         requirement_level: required
-        brief: >
-          Identifies the class / type of event.
-        note: >
-          Event names are subject to the same rules as [attribute names](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/common/attribute-naming.md).
-          Notably, event names are namespaced to avoid collisions and provide a clean
-          separation of semantics for events in separate domains like browser, mobile, and
-          kubernetes.
-        examples: ['browser.mouse.click', 'device.app.lifecycle']

--- a/model/registry/event.yaml
+++ b/model/registry/event.yaml
@@ -1,0 +1,18 @@
+groups:
+  - id: registry.event
+    prefix: event
+    type: attribute_group
+    brief: >
+      Attributes for Events represented using Log Records.
+    attributes:
+      - id: name
+        type: string
+        stability: experimental
+        brief: >
+          Identifies the class / type of event.
+        note: >
+          Event names are subject to the same rules as [attribute names](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/common/attribute-naming.md).
+          Notably, event names are namespaced to avoid collisions and provide a clean
+          separation of semantics for events in separate domains like browser, mobile, and
+          kubernetes.
+        examples: ['browser.mouse.click', 'device.app.lifecycle']


### PR DESCRIPTION
I have moved it to the registry as part of schema clean up but we can decide later if it should stay in this form based on outcome of https://github.com/open-telemetry/semantic-conventions/pull/880

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
