### PR TITLE
[BREAKING] move attributes from db metrics to the registry

### DIFF
--- a/.chloggen/db_metrics.yaml
+++ b/.chloggen/db_metrics.yaml
@@ -10,7 +10,7 @@ change_type: breaking
 component: db
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Rename `pool.name` to `db.pool.name` and `state` to `db.state`.
+note: Rename `pool.name` to `db.client.connections.pool.name` and `state` to `db.client.connections.state`.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/.chloggen/db_metrics.yaml
+++ b/.chloggen/db_metrics.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: db
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename `pool.name` to `db.pool.name` and `state` to `db.state`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [909]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -223,8 +223,8 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 <!-- semconv registry.db.metrics.deprecated(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
-| `pool.name` | string | Deprecated, use `db.pool.name` instead. | `myDataSource` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `db.pool.name`. |
-| `state` | string | Deprecated, use `db.state` instead. | `idle` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `db.state`. |
+| `pool.name` | string | Deprecated, use `db.client.connections.pool.name` instead. | `myDataSource` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `db.client.connections.pool.name`. |
+| `state` | string | Deprecated, use `db.client.connections.state` instead. | `idle` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `db.client.connections.state`. |
 
 `state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -24,8 +24,10 @@
 | `db.instance.id` | string | An identifier (address, unique name, or any other identifier) of the database instance that is executing queries or mutations on the current connection. This is useful in cases where the database is running in a clustered environment and the instrumentation is able to record the node executing the query. The client may obtain this value in databases like MySQL using queries like `select @@hostname`. | `mysql-e26b99z.example.com` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `db.name` | string | This attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [2] | `customers`; `main` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `db.operation.name` | string | The name of the operation or command being executed. | `findAndModify`; `HMSET`; `SELECT` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `db.pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `db.query.parameter.<key>` | string | The query parameters used in `db.query.text`, with `<key>` being the parameter name, and the attribute value being the parameter value. [3] | `someval`; `55` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `db.query.text` | string | The database query being executed. | `SELECT * FROM wuser_table where username = ?`; `SET mykey "WuValue"` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `db.state` | string | The state of a connection in the pool | `idle` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `db.system` | string | An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers. | `other_sql` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 **[1]:** If the collection name is parsed from the query, it SHOULD match the value provided in the query and may be qualified with the schema and database name.
@@ -34,6 +36,13 @@
 
 **[3]:** Query parameters should only be captured when `db.query.text` is parameterized with placeholders.
 If a parameter has no name and instead is referenced only by index, then `<key>` SHOULD be the 0-based index.
+
+`db.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `idle` | idle | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `used` | used | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `db.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -12,6 +12,7 @@
 - [MSSQL Attributes](#mssql-attributes)
 - [Redis Attributes](#redis-attributes)
 - [Deprecated DB Attributes](#deprecated-db-attributes)
+- [Deprecated DB Metrics Attributes](#deprecated-db-metrics-attributes)
 
 <!-- tocstop -->
 

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -217,3 +217,18 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 | `db.statement` | string | The database statement being executed. | `SELECT * FROM wuser_table`; `SET mykey "WuValue"` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `db.query.text`. |
 | `db.user` | string | Deprecated, no replacement at this time. | `readonly_user`; `reporting_user` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>No replacement at this time. |
 <!-- endsemconv -->
+
+## Deprecated DB Metrics Attributes
+<!-- semconv registry.db.metrics.deprecated(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `pool.name` | string | Deprecated, use `db.pool.name` instead. | `myDataSource` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `db.pool.name`. |
+| `state` | string | Deprecated, use `db.state` instead. | `idle` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `db.state`. |
+
+`state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `idle` | idle | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `used` | used | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -21,14 +21,14 @@
 <!-- semconv registry.db(omit_requirement_level,tag=db-generic) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
+| `db.client.connections.pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `db.client.connections.state` | string | The state of a connection in the pool | `idle` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `db.collection.name` | string | The name of a collection (table, container) within the database. [1] | `public.users`; `customers` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `db.instance.id` | string | An identifier (address, unique name, or any other identifier) of the database instance that is executing queries or mutations on the current connection. This is useful in cases where the database is running in a clustered environment and the instrumentation is able to record the node executing the query. The client may obtain this value in databases like MySQL using queries like `select @@hostname`. | `mysql-e26b99z.example.com` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `db.name` | string | This attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [2] | `customers`; `main` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `db.operation.name` | string | The name of the operation or command being executed. | `findAndModify`; `HMSET`; `SELECT` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `db.pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `db.query.parameter.<key>` | string | The query parameters used in `db.query.text`, with `<key>` being the parameter name, and the attribute value being the parameter value. [3] | `someval`; `55` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `db.query.text` | string | The database query being executed. | `SELECT * FROM wuser_table where username = ?`; `SET mykey "WuValue"` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `db.state` | string | The state of a connection in the pool | `idle` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `db.system` | string | An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers. | `other_sql` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 **[1]:** If the collection name is parsed from the query, it SHOULD match the value provided in the query and may be qualified with the schema and database name.
@@ -38,7 +38,7 @@
 **[3]:** Query parameters should only be captured when `db.query.text` is parameterized with placeholders.
 If a parameter has no name and instead is referenced only by index, then `<key>` SHOULD be the 0-based index.
 
-`db.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`db.client.connections.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -52,10 +52,10 @@ This metric is [required][MetricRequired].
 <!-- semconv metric.db.client.connections.usage(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `state` | string | The state of a connection in the pool | `idle` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.state`](../attributes-registry/db.md) | string | The state of a connection in the pool | `idle` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
-`state` MUST be one of the following:
+`db.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|
@@ -75,7 +75,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.idle.max(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.idle.min`
@@ -91,7 +91,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.idle.min(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.max`
@@ -107,7 +107,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.max(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.pending_requests`
@@ -123,7 +123,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.pending_requests(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.timeouts`
@@ -139,7 +139,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.timeouts(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.create_time`
@@ -155,7 +155,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.create_time(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.wait_time`
@@ -171,7 +171,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.wait_time(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.use_time`
@@ -187,7 +187,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.use_time(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/document-status.md

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -52,10 +52,10 @@ This metric is [required][MetricRequired].
 <!-- semconv metric.db.client.connections.usage(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| [`db.state`](../attributes-registry/db.md) | string | The state of a connection in the pool | `idle` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.client.connections.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.client.connections.state`](../attributes-registry/db.md) | string | The state of a connection in the pool | `idle` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
-`db.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`db.client.connections.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|
@@ -75,7 +75,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.idle.max(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.client.connections.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.idle.min`
@@ -91,7 +91,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.idle.min(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.client.connections.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.max`
@@ -107,7 +107,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.max(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.client.connections.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.pending_requests`
@@ -123,7 +123,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.pending_requests(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.client.connections.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.timeouts`
@@ -139,7 +139,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.timeouts(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.client.connections.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.create_time`
@@ -155,7 +155,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.create_time(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.client.connections.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.wait_time`
@@ -171,7 +171,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.wait_time(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.client.connections.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ### Metric: `db.client.connections.use_time`
@@ -187,7 +187,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.db.client.connections.use_time(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`db.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.client.connections.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/document-status.md

--- a/model/metrics/database-metrics.yaml
+++ b/model/metrics/database-metrics.yaml
@@ -1,33 +1,4 @@
 groups:
-  - id: attributes.db
-    type: attribute_group
-    brief: Describes Database attributes
-    attributes:
-      - id: state
-        stability: experimental
-        type:
-          allow_custom_values: false
-          members:
-            - id: idle
-              value: 'idle'
-              stability: experimental
-            - id: used
-              value: 'used'
-              stability: experimental
-        requirement_level: required
-        brief: "The state of a connection in the pool"
-        examples: ["idle"]
-      - id: pool.name
-        type: string
-        stability: experimental
-        requirement_level: required
-        brief: >
-          The name of the connection pool; unique within the instrumented application.
-          In case the connection pool implementation doesn't provide a name,
-          instrumentation should use a combination of `server.address` and `server.port` attributes
-          formatted as `server.address:server.port`.
-        examples: ["myDataSource"]
-
   - id: metric.db.client.connections.usage
     type: metric
     metric_name: db.client.connections.usage
@@ -36,8 +7,10 @@ groups:
     instrument: updowncounter
     unit: "{connection}"
     attributes:
-      - ref: state
-      - ref: pool.name
+      - ref: db.state
+        requirement_level: required
+      - ref: db.pool.name
+        requirement_level: required
 
   - id: metric.db.client.connections.idle.max
     type: metric
@@ -47,7 +20,8 @@ groups:
     instrument: updowncounter
     unit: "{connection}"
     attributes:
-      - ref: pool.name
+      - ref: db.pool.name
+        requirement_level: required
 
   - id: metric.db.client.connections.idle.min
     type: metric
@@ -57,7 +31,8 @@ groups:
     instrument: updowncounter
     unit: "{connection}"
     attributes:
-      - ref: pool.name
+      - ref: db.pool.name
+        requirement_level: required
 
   - id: metric.db.client.connections.max
     type: metric
@@ -67,7 +42,8 @@ groups:
     instrument: updowncounter
     unit: "{connection}"
     attributes:
-      - ref: pool.name
+      - ref: db.pool.name
+        requirement_level: required
 
   - id: metric.db.client.connections.pending_requests
     type: metric
@@ -77,7 +53,8 @@ groups:
     instrument: updowncounter
     unit: "{request}"
     attributes:
-      - ref: pool.name
+      - ref: db.pool.name
+        requirement_level: required
 
   - id: metric.db.client.connections.timeouts
     type: metric
@@ -87,7 +64,8 @@ groups:
     instrument: counter
     unit: "{timeout}"
     attributes:
-      - ref: pool.name
+      - ref: db.pool.name
+        requirement_level: required
 
   - id: metric.db.client.connections.create_time
     type: metric
@@ -97,7 +75,8 @@ groups:
     instrument: histogram
     unit: "ms"
     attributes:
-      - ref: pool.name
+      - ref: db.pool.name
+        requirement_level: required
 
   - id: metric.db.client.connections.wait_time
     type: metric
@@ -107,7 +86,8 @@ groups:
     instrument: histogram
     unit: "ms"
     attributes:
-      - ref: pool.name
+      - ref: db.pool.name
+        requirement_level: required
 
   - id: metric.db.client.connections.use_time
     type: metric
@@ -117,4 +97,5 @@ groups:
     instrument: histogram
     unit: "ms"
     attributes:
-      - ref: pool.name
+      - ref: db.pool.name
+        requirement_level: required

--- a/model/metrics/database-metrics.yaml
+++ b/model/metrics/database-metrics.yaml
@@ -7,9 +7,9 @@ groups:
     instrument: updowncounter
     unit: "{connection}"
     attributes:
-      - ref: db.state
+      - ref: db.client.connections.state
         requirement_level: required
-      - ref: db.pool.name
+      - ref: db.client.connections.pool.name
         requirement_level: required
 
   - id: metric.db.client.connections.idle.max
@@ -20,7 +20,7 @@ groups:
     instrument: updowncounter
     unit: "{connection}"
     attributes:
-      - ref: db.pool.name
+      - ref: db.client.connections.pool.name
         requirement_level: required
 
   - id: metric.db.client.connections.idle.min
@@ -31,7 +31,7 @@ groups:
     instrument: updowncounter
     unit: "{connection}"
     attributes:
-      - ref: db.pool.name
+      - ref: db.client.connections.pool.name
         requirement_level: required
 
   - id: metric.db.client.connections.max
@@ -42,7 +42,7 @@ groups:
     instrument: updowncounter
     unit: "{connection}"
     attributes:
-      - ref: db.pool.name
+      - ref: db.client.connections.pool.name
         requirement_level: required
 
   - id: metric.db.client.connections.pending_requests
@@ -53,7 +53,7 @@ groups:
     instrument: updowncounter
     unit: "{request}"
     attributes:
-      - ref: db.pool.name
+      - ref: db.client.connections.pool.name
         requirement_level: required
 
   - id: metric.db.client.connections.timeouts
@@ -64,7 +64,7 @@ groups:
     instrument: counter
     unit: "{timeout}"
     attributes:
-      - ref: db.pool.name
+      - ref: db.client.connections.pool.name
         requirement_level: required
 
   - id: metric.db.client.connections.create_time
@@ -75,7 +75,7 @@ groups:
     instrument: histogram
     unit: "ms"
     attributes:
-      - ref: db.pool.name
+      - ref: db.client.connections.pool.name
         requirement_level: required
 
   - id: metric.db.client.connections.wait_time
@@ -86,7 +86,7 @@ groups:
     instrument: histogram
     unit: "ms"
     attributes:
-      - ref: db.pool.name
+      - ref: db.client.connections.pool.name
         requirement_level: required
 
   - id: metric.db.client.connections.use_time
@@ -97,5 +97,5 @@ groups:
     instrument: histogram
     unit: "ms"
     attributes:
-      - ref: db.pool.name
+      - ref: db.client.connections.pool.name
         requirement_level: required

--- a/model/registry/db.yaml
+++ b/model/registry/db.yaml
@@ -487,3 +487,27 @@ groups:
           This is useful in cases where the database is running in a clustered environment and the instrumentation is able to record the node executing the query.
           The client may obtain this value in databases like MySQL using queries like `select @@hostname`.
         examples: 'mysql-e26b99z.example.com'
+      - id: state
+        tag: db-generic
+        stability: experimental
+        type:
+          allow_custom_values: true
+          members:
+            - id: idle
+              value: 'idle'
+              stability: experimental
+            - id: used
+              value: 'used'
+              stability: experimental
+        brief: "The state of a connection in the pool"
+        examples: ["idle"]
+      - id: pool.name
+        tag: db-generic
+        type: string
+        stability: experimental
+        brief: >
+          The name of the connection pool; unique within the instrumented application.
+          In case the connection pool implementation doesn't provide a name,
+          instrumentation should use a combination of `server.address` and `server.port` attributes
+          formatted as `server.address:server.port`.
+        examples: ["myDataSource"]

--- a/model/registry/db.yaml
+++ b/model/registry/db.yaml
@@ -487,7 +487,7 @@ groups:
           This is useful in cases where the database is running in a clustered environment and the instrumentation is able to record the node executing the query.
           The client may obtain this value in databases like MySQL using queries like `select @@hostname`.
         examples: 'mysql-e26b99z.example.com'
-      - id: state
+      - id: client.connections.state
         tag: db-generic
         stability: experimental
         type:
@@ -501,7 +501,7 @@ groups:
               stability: experimental
         brief: "The state of a connection in the pool"
         examples: ["idle"]
-      - id: pool.name
+      - id: client.connections.pool.name
         tag: db-generic
         type: string
         stability: experimental

--- a/model/registry/deprecated/db.yaml
+++ b/model/registry/deprecated/db.yaml
@@ -66,3 +66,29 @@ groups:
         brief: 'Deprecated, use `db.collection.name` instead.'
         deprecated: "Replaced by `db.collection.name`."
         examples: 'mytable'
+
+  - id: registry.db.metrics.deprecated
+    type: attribute_group
+    brief: >
+      "Describes deprecated db metrics attributes."
+    attributes:
+      - id: state
+        stability: experimental
+        type:
+          allow_custom_values: true
+          members:
+            - id: idle
+              value: 'idle'
+              stability: experimental
+            - id: used
+              value: 'used'
+              stability: experimental
+        brief: "Deprecated, use `db.state` instead."
+        deprecated: "Replaced by `db.state`."
+        examples: ["idle"]
+      - id: pool.name
+        type: string
+        stability: experimental
+        brief: "Deprecated, use `db.pool.name` instead."
+        deprecated: "Replaced by `db.pool.name`."
+        examples: ["myDataSource"]

--- a/model/registry/deprecated/db.yaml
+++ b/model/registry/deprecated/db.yaml
@@ -83,12 +83,12 @@ groups:
             - id: used
               value: 'used'
               stability: experimental
-        brief: "Deprecated, use `db.state` instead."
-        deprecated: "Replaced by `db.state`."
+        brief: "Deprecated, use `db.client.connections.state` instead."
+        deprecated: "Replaced by `db.client.connections.state`."
         examples: ["idle"]
       - id: pool.name
         type: string
         stability: experimental
-        brief: "Deprecated, use `db.pool.name` instead."
-        deprecated: "Replaced by `db.pool.name`."
+        brief: "Deprecated, use `db.client.connections.pool.name` instead."
+        deprecated: "Replaced by `db.client.connections.pool.name`."
         examples: ["myDataSource"]

--- a/schema-next.yaml
+++ b/schema-next.yaml
@@ -2,6 +2,27 @@ file_format: 1.1.0
 schema_url: https://opentelemetry.io/schemas/next
 versions:
   next:
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/semantic-conventions/pull/909
+        - rename_attributes:
+            attribute_map:
+              state: db.state
+            apply_to_metrics:
+              - db.client.connections.usage
+        - rename_attributes:
+            attribute_map:
+              pool.name: db.pool.name
+            apply_to_metrics:
+              - db.client.connections.usage
+              - db.client.connections.idle.max
+              - db.client.connections.idle.min
+              - db.client.connections.max
+              - db.client.connections.pending_requests
+              - db.client.connections.timeouts
+              - db.client.connections.create_time
+              - db.client.connections.wait_time
+              - db.client.connections.use_time
 
   1.25.0:
     spans:

--- a/schema-next.yaml
+++ b/schema-next.yaml
@@ -7,12 +7,12 @@ versions:
         # https://github.com/open-telemetry/semantic-conventions/pull/909
         - rename_attributes:
             attribute_map:
-              state: db.state
+              state: db.client.connections.state
             apply_to_metrics:
               - db.client.connections.usage
         - rename_attributes:
             attribute_map:
-              pool.name: db.pool.name
+              pool.name: db.client.connections.pool.name
             apply_to_metrics:
               - db.client.connections.usage
               - db.client.connections.idle.max


### PR DESCRIPTION
Using tags for now (added moved attributes to the db-generic tag)

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
