### PR TITLE
Move common DB attributes

### DIFF
--- a/.chloggen/910.yaml
+++ b/.chloggen/910.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: db
+note: Reorganize DB conventions to be shared across span and metric conventions.
+issues: [ 910 ]

--- a/model/db-common.yaml
+++ b/model/db-common.yaml
@@ -1,15 +1,7 @@
 groups:
-  - id: attributes.db.common
-    type: attribute_group
-    brief: 'Describes Database attributes.'
-    attributes:
-      - ref: db.system
-        requirement_level: required
-
   - id: attributes.db.client
     type: attribute_group
     brief: 'Database Client attributes'
-    extends: attributes.db.common
     attributes:
       - ref: db.name
         requirement_level:
@@ -27,6 +19,8 @@ groups:
           conditionally_required: >
             If readily available. Otherwise, if the instrumentation library parses `db.query.text` to capture
             `db.operation.name`, then it SHOULD be the first operation name found in the query.
+      - ref: db.system
+        requirement_level: required
       - ref: network.peer.address
         brief: Peer address of the database node where the operation was performed.
         requirement_level:

--- a/model/db-common.yaml
+++ b/model/db-common.yaml
@@ -1,0 +1,47 @@
+groups:
+  - id: attributes.db.common
+    type: attribute_group
+    brief: 'Describes Database attributes.'
+    attributes:
+      - ref: db.system
+        requirement_level: required
+
+  - id: attributes.db.client
+    type: attribute_group
+    brief: 'Database Client attributes'
+    extends: attributes.db.common
+    attributes:
+      - ref: db.name
+        requirement_level:
+          conditionally_required: If applicable.
+      - ref: db.collection.name
+        requirement_level:
+          conditionally_required: >
+            If readily available. Otherwise, if the instrumentation library parses `db.query.text` to capture
+            `db.collection.name`, then it SHOULD be the first collection name found in the query.
+      - ref: db.instance.id
+        requirement_level:
+          recommended: If different from the `server.address`
+      - ref: db.operation.name
+        requirement_level:
+          conditionally_required: >
+            If readily available. Otherwise, if the instrumentation library parses `db.query.text` to capture
+            `db.operation.name`, then it SHOULD be the first operation name found in the query.
+      - ref: network.peer.address
+        brief: Peer address of the database node where the operation was performed.
+        requirement_level:
+          recommended: If applicable for this database system.
+        note: >
+          Semantic conventions for individual database systems SHOULD document whether `network.peer.*` attributes are applicable.
+          Network peer address and port are useful when the application interacts with individual database nodes directly.
+
+          If a database operation involved multiple network calls (for example retries), the address of the last contacted node SHOULD be used.
+      - ref: network.peer.port
+        requirement_level:
+          recommended: if and only if `network.peer.address` is set.
+      - ref: server.address
+        brief: >
+          Name of the database host.
+      - ref: server.port
+        requirement_level:
+          conditionally_required: If using a port other than the default port for this DBMS and if `server.address` is set.

--- a/model/trace/database.yaml
+++ b/model/trace/database.yaml
@@ -1,55 +1,20 @@
 groups:
-  - id: db.common.attributes
+  - id: trace.db.common
+    extends: attributes.db.client
     type: attribute_group
     brief: This group defines the attributes used to perform database client calls.
     attributes:
-      - ref: db.system
-        requirement_level: required
-      - ref: db.name
-        requirement_level:
-          conditionally_required: If applicable.
       - ref: db.query.text
         requirement_level:
           recommended: >
             Should be collected by default only if there is sanitization that excludes sensitive information.
       - ref: db.query.parameter
         requirement_level: opt_in
-      - ref: db.operation.name
-        requirement_level:
-          conditionally_required: >
-            If readily available. Otherwise, if the instrumentation library parses `db.query.text` to capture
-            `db.operation.name`, then it SHOULD be the first operation name found in the query.
-      - ref: server.address
-        brief: >
-          Name of the database host.
-      - ref: server.port
-        requirement_level:
-          conditionally_required: If using a port other than the default port for this DBMS and if `server.address` is set.
-      - ref: db.instance.id
-        requirement_level:
-          recommended: If different from the `server.address`
-      - ref: db.collection.name
-        requirement_level:
-          conditionally_required: >
-            If readily available. Otherwise, if the instrumentation library parses `db.query.text` to capture
-            `db.collection.name`, then it SHOULD be the first collection name found in the query.
-      - ref: network.peer.address
-        brief: Peer address of the database node where the operation was performed.
-        requirement_level:
-          recommended: If applicable for this database system.
-        note: >
-          Semantic conventions for individual database systems SHOULD document whether `network.peer.*` attributes are applicable.
-          Network peer address and port are useful when the application interacts with individual database nodes directly.
-
-          If a database operation involved multiple network calls (for example retries), the address of the last contacted node SHOULD be used.
-      - ref: network.peer.port
-        requirement_level:
-          recommended: if and only if `network.peer.address` is set.
 
   - id: db.tech_specific.network.attributes
     type: attribute_group
     brief: This group documents attributes that describe database call along with network information.
-    extends: db.common.attributes
+    extends: trace.db.common
     attributes:
       - ref: network.peer.address
         requirement_level:
@@ -64,7 +29,7 @@ groups:
     type: span
     brief: This span defines the attributes used to perform database client calls.
     span_kind: client
-    extends: db.common.attributes
+    extends: trace.db.common
 
   - id: db.mssql
     type: span
@@ -105,7 +70,7 @@ groups:
 
   - id: db.hbase
     type: span
-    extends: db.common.attributes
+    extends: trace.db.common
     brief: >
       Attributes for HBase
     attributes:
@@ -118,7 +83,7 @@ groups:
 
   - id: db.couchdb
     type: span
-    extends: db.common.attributes
+    extends: trace.db.common
     brief: >
       Attributes for CouchDB
     attributes:
@@ -155,7 +120,7 @@ groups:
 
   - id: db.mongodb
     type: span
-    extends: db.common.attributes
+    extends: trace.db.common
     brief: >
       Attributes for MongoDB
     attributes:
@@ -219,7 +184,7 @@ groups:
 
   - id: db.sql
     type: span
-    extends: db.common.attributes
+    extends: trace.db.common
     brief: >
       Attributes for SQL databases
     attributes:
@@ -236,7 +201,7 @@ groups:
 
   - id: db.cosmosdb
     type: span
-    extends: db.common.attributes
+    extends: trace.db.common
     prefix: db.cosmosdb
     brief: >
       Attributes for Cosmos DB.


### PR DESCRIPTION
Moves database attributes expected to be used for both traces and metrics to a common file.