### PR TITLE
BREAKING: Rename `messaging.operation` to `messaging.operation.name`

### DIFF
--- a/.chloggen/890.yaml
+++ b/.chloggen/890.yaml
@@ -1,0 +1,4 @@
+change_type: breaking
+component: messaging
+note: Rename `messaging.operation` to `messaging.operation.name`.
+issues: [ 890 ]

--- a/.chloggen/890.yaml
+++ b/.chloggen/890.yaml
@@ -1,4 +1,4 @@
 change_type: breaking
 component: messaging
-note: Rename `messaging.operation` to `messaging.operation.name`.
+note: Rename `messaging.operation` to `messaging.operation.type`, add `messaging.operation.name`.
 issues: [ 890 ]

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -34,7 +34,8 @@
 | `messaging.message.conversation_id` | string | The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `messaging.message.envelope.size` | int | The size of the message body and metadata in bytes. [6] | `2738` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `messaging.operation.name` | string | A string identifying the name of the messaging operation. [7] | `publish` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `messaging.operation.name` | string | The system-specific name of the messaging operation. | `ack`; `nack`; `send` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `messaging.operation.type` | string | A string identifying the type of the messaging operation. [7] | `publish` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `messaging.system` | string | An identifier for the messaging system being used. See below for a list of well-known identifiers. | `activemq` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 **[1]:** Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
@@ -55,7 +56,7 @@ size should be used.
 
 **[7]:** If a custom value is used, it MUST be of low cardinality.
 
-`messaging.operation.name` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`messaging.operation.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|
@@ -178,5 +179,5 @@ size should be used.
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `messaging.kafka.destination.partition` | int | Deprecated, use `messaging.destination.partition.id` instead. | `2` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `messaging.destination.partition.id`. |
-| `messaging.operation` | string | Deprecated, use `messaging.operation.name` instead. | `publish`; `create`; `process` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `messaging.operation.name`. |
+| `messaging.operation` | string | Deprecated, use `messaging.operation.type` instead. | `publish`; `create`; `process` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `messaging.operation.type`. |
 <!-- endsemconv -->

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -177,18 +177,6 @@ size should be used.
 <!-- semconv registry.messaging.deprecated(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
-| `messaging.kafka.destination.partition` | int | "Deprecated, use `messaging.destination.partition.id` instead." | `2` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `messaging.destination.partition.id`. |
-| `messaging.operation` | string | A string identifying the kind of messaging operation. [1] | `publish` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `messaging.operation.name`. |
-
-**[1]:** If a custom value is used, it MUST be of low cardinality.
-
-`messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
-
-| Value  | Description | Stability |
-|---|---|---|
-| `publish` | One or more messages are provided for publishing to an intermediary. If a single message is published, the context of the "Publish" span can be used as the creation context and no "Create" span needs to be created. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `create` | A message is created. "Create" spans always refer to a single message and are used to provide a unique creation context for messages in batch publishing scenarios. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `receive` | One or more messages are requested by a consumer. This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `process` | One or more messages are delivered to or processed by a consumer. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `settle` | One or more messages are settled. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `messaging.kafka.destination.partition` | int | Deprecated, use `messaging.destination.partition.id` instead. | `2` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `messaging.destination.partition.id`. |
+| `messaging.operation` | string | Deprecated, use `messaging.operation.name` instead. | `publish`; `create`; `process` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `messaging.operation.name`. |
 <!-- endsemconv -->

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -34,7 +34,7 @@
 | `messaging.message.conversation_id` | string | The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `messaging.message.envelope.size` | int | The size of the message body and metadata in bytes. [6] | `2738` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `messaging.operation` | string | A string identifying the kind of messaging operation. [7] | `publish` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `messaging.operation.name` | string | A string identifying the name of the messaging operation. [7] | `publish` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `messaging.system` | string | An identifier for the messaging system being used. See below for a list of well-known identifiers. | `activemq` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 **[1]:** Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
@@ -55,7 +55,7 @@ size should be used.
 
 **[7]:** If a custom value is used, it MUST be of low cardinality.
 
-`messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`messaging.operation.name` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -178,4 +178,17 @@ size should be used.
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `messaging.kafka.destination.partition` | int | "Deprecated, use `messaging.destination.partition.id` instead." | `2` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `messaging.destination.partition.id`. |
+| `messaging.operation` | string | A string identifying the kind of messaging operation. [1] | `publish` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `messaging.operation.name`. |
+
+**[1]:** If a custom value is used, it MUST be of low cardinality.
+
+`messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `publish` | One or more messages are provided for publishing to an intermediary. If a single message is published, the context of the "Publish" span can be used as the creation context and no "Create" span needs to be created. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `create` | A message is created. "Create" spans always refer to a single message and are used to provide a unique creation context for messages in batch publishing scenarios. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `receive` | One or more messages are requested by a consumer. This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `process` | One or more messages are delivered to or processed by a consumer. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `settle` | One or more messages are settled. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->

--- a/docs/messaging/azure-messaging.md
+++ b/docs/messaging/azure-messaging.md
@@ -12,15 +12,6 @@ The Semantic Conventions for [Azure Service Bus](https://learn.microsoft.com/azu
 
 `messaging.system` MUST be set to `"servicebus"`.
 
-### Span names
-
-The span name SHOULD follow [the general messaging span name pattern](../messaging/azure-messaging.md): it SHOULD start with the messaging destination name (Event Hubs queue or topic name) and contain a low-cardinality name of the operation the span describes:
-
-- Spans names for `settle` operations SHOULD follow the `<destination name> {messaging.servicebus.disposition_status}` pattern.
-  For example, `my-queue complete` or `my-queue abandon`.
-- Spans names for `publish` operations SHOULD follow the `<destination name> send` pattern.
-- Spans for `create`, `receive`, and `publish` operations SHOULD follow the general `<destination name> <operation name>` pattern.
-
 ### Span attributes
 
 The following additional attributes are defined:
@@ -38,15 +29,6 @@ The following additional attributes are defined:
 ## Azure Event Hubs
 
 `messaging.system` MUST be set to `"eventhubs"`.
-
-### Span names
-
-The span name SHOULD follow the [general messaging span name pattern](../messaging/azure-messaging.md): it SHOULD start with the messaging destination name (Event Hubs namespace) and
-contain a low-cardinality name of an operation the span describes:
-
-- Spans for `settle` operations SHOULD follow the `<destination name> checkpoint` pattern (matching Event Hubs terminology).
-- Spans names for `publish` operations SHOULD follow the `<destination name> send` pattern.
-- Spans for `create`, `receive`, and `publish` operations SHOULD follow the general `<destination name> <operation name>` pattern.
 
 ### Span attributes
 

--- a/docs/messaging/gcp-pubsub.md
+++ b/docs/messaging/gcp-pubsub.md
@@ -53,7 +53,7 @@ flowchart LR;
 | Status | `Ok` | `Ok` | `Ok` |
 | `messaging.batch.message_count` |  |  | 2 |
 | `messaging.destination.name` | `"T"` | `"T"` | `"T"` |
-| `messaging.operation.name` | `"create"` | `"create"` | `"publish"` |
+| `messaging.operation.type` | `"create"` | `"create"` | `"publish"` |
 | `messaging.message.id` | `"a1"` | `"a2"` | |
 | `messaging.message.envelope.size` | `1` | `1` | |
 | `messaging.system` | `"gcp_pubsub"` | `"gcp_pubsub"` | `"gcp_pubsub"` |

--- a/docs/messaging/gcp-pubsub.md
+++ b/docs/messaging/gcp-pubsub.md
@@ -53,7 +53,7 @@ flowchart LR;
 | Status | `Ok` | `Ok` | `Ok` |
 | `messaging.batch.message_count` |  |  | 2 |
 | `messaging.destination.name` | `"T"` | `"T"` | `"T"` |
-| `messaging.operation` | `"create"` | `"create"` | `"publish"` |
+| `messaging.operation.name` | `"create"` | `"create"` | `"publish"` |
 | `messaging.message.id` | `"a1"` | `"a2"` | |
 | `messaging.message.envelope.size` | `1` | `1` | |
 | `messaging.system` | `"gcp_pubsub"` | `"gcp_pubsub"` | `"gcp_pubsub"` |

--- a/docs/messaging/kafka.md
+++ b/docs/messaging/kafka.md
@@ -53,7 +53,7 @@ One process, CA, receives the message and publishes a new message to a topic T2 
 
 Frameworks such as Quarkus and Spring Boot separate processing of a received message from producing subsequent messages out.
 For this reason, receiving (Span Rcv1) is the parent of both processing (Span Proc1) and producing a new message (Span Prod2).
-The span representing message receiving (Span Rcv1) should not set `messaging.operation` to `receive`,
+The span representing message receiving (Span Rcv1) should not set `messaging.operation.name` to `receive`,
 as it does not only receive the message but also converts the input message to something suitable for the processing operation to consume and creates the output message from the result of processing.
 
 ```
@@ -77,7 +77,7 @@ Process CB:                           | Span Rcv2 |
 | `service.name` |  | `"myConsumer1"` | `"myConsumer1"` |  | `"myConsumer2"` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` |
 | `messaging.destination.name` | `"T1"` | `"T1"` | `"T1"` | `"T2"` | `"T2"` |
-| `messaging.operation` |  |  | `"process"` |  | `"receive"` |
+| `messaging.operation.name` |  |  | `"process"` |  | `"receive"` |
 | `messaging.client_id` |  | `"5"` | `"5"` | `"5"` | `"8"` |
 | `messaging.kafka.message.key` | `"myKey"` | `"myKey"` | `"myKey"` | `"anotherKey"` | `"anotherKey"` |
 | `messaging.kafka.consumer.group` |  | `"my-group"` | `"my-group"` |  | `"another-group"` |

--- a/docs/messaging/kafka.md
+++ b/docs/messaging/kafka.md
@@ -53,7 +53,7 @@ One process, CA, receives the message and publishes a new message to a topic T2 
 
 Frameworks such as Quarkus and Spring Boot separate processing of a received message from producing subsequent messages out.
 For this reason, receiving (Span Rcv1) is the parent of both processing (Span Proc1) and producing a new message (Span Prod2).
-The span representing message receiving (Span Rcv1) should not set `messaging.operation.name` to `receive`,
+The span representing message receiving (Span Rcv1) should not set `messaging.operation.type` to `receive`,
 as it does not only receive the message but also converts the input message to something suitable for the processing operation to consume and creates the output message from the result of processing.
 
 ```
@@ -77,7 +77,7 @@ Process CB:                           | Span Rcv2 |
 | `service.name` |  | `"myConsumer1"` | `"myConsumer1"` |  | `"myConsumer2"` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` |
 | `messaging.destination.name` | `"T1"` | `"T1"` | `"T1"` | `"T2"` | `"T2"` |
-| `messaging.operation.name` |  |  | `"process"` |  | `"receive"` |
+| `messaging.operation.type` |  |  | `"process"` |  | `"receive"` |
 | `messaging.client_id` |  | `"5"` | `"5"` | `"5"` | `"8"` |
 | `messaging.kafka.message.key` | `"myKey"` | `"myKey"` | `"myKey"` | `"anotherKey"` | `"anotherKey"` |
 | `messaging.kafka.consumer.group` |  | `"my-group"` | `"my-group"` |  | `"another-group"` |

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -281,7 +281,7 @@ as described in [Attributes specific to certain messaging systems](#attributes-s
 <!-- semconv messaging(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`messaging.operation`](../attributes-registry/messaging.md) | string | A string identifying the kind of messaging operation. [1] | `publish` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`messaging.operation.name`](../attributes-registry/messaging.md) | string | A string identifying the name of the messaging operation. [1] | `publish` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | [`messaging.system`](../attributes-registry/messaging.md) | string | An identifier for the messaging system being used. See below for a list of well-known identifiers. | `activemq` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [2] | `amqp:decode-error`; `KAFKA_STORAGE_ERROR`; `channel-error` | `Conditionally Required` [3] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`messaging.batch.message_count`](../attributes-registry/messaging.md) | int | The number of messages sent, received, or processed in the scope of the batching operation. [4] | `0`; `1`; `2` | `Conditionally Required` [5] | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -351,7 +351,7 @@ If a messaging operation involved multiple network calls (for example retries), 
 
 **[16]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
 
-`messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`messaging.operation.name` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|
@@ -469,7 +469,7 @@ flowchart LR;
 | `server.port` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` |
 | `messaging.destination.name` | `"T"` | `"T"` | `"T"` |
-| `messaging.operation` | `"publish"` | `"process"` | `"process"` |
+| `messaging.operation.name` | `"publish"` | `"process"` | `"process"` |
 | `messaging.message.id` | `"a"` | `"a"`| `"a"` |
 
 ### Batch receiving
@@ -507,7 +507,7 @@ flowchart LR;
 | `server.port` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` |
 | `messaging.destination.name` | `"Q"` | `"Q"` | `"Q"` |
-| `messaging.operation` | `"publish"` | `"publish"` | `"receive"` |
+| `messaging.operation.name` | `"publish"` | `"publish"` | `"receive"` |
 | `messaging.message.id` | `"a1"` | `"a2"` | |
 | `messaging.batch.message_count` |  |  | 2 |
 
@@ -552,7 +552,7 @@ flowchart LR;
 | `server.port` | `1234` | `1234` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` |
 | `messaging.destination.name` | `"Q"` | `"Q"` | `"Q"` | `"Q"` | `"Q"` |
-| `messaging.operation` | `"create"` | `"create"` | `"publish"` | `"receive"` | `"receive"` |
+| `messaging.operation.name` | `"create"` | `"create"` | `"publish"` | `"receive"` | `"receive"` |
 | `messaging.message.id` | `"a1"` | `"a2"` | | `"a1"` | `"a2"` |
 | `messaging.batch.message_count` | | | 2 | | |
 

--- a/model/registry/deprecated/messaging.yaml
+++ b/model/registry/deprecated/messaging.yaml
@@ -14,6 +14,6 @@ groups:
         type: string
         stability: experimental
         brief: >
-          Deprecated, use `messaging.operation.name` instead.
+          Deprecated, use `messaging.operation.type` instead.
         examples: ["publish", "create", "process"]
-        deprecated: "Replaced by `messaging.operation.name`."
+        deprecated: "Replaced by `messaging.operation.type`."

--- a/model/registry/deprecated/messaging.yaml
+++ b/model/registry/deprecated/messaging.yaml
@@ -10,3 +10,40 @@ groups:
         examples: 2
         deprecated: "Replaced by `messaging.destination.partition.id`."
         stability: experimental
+      - id: messaging.operation
+        type:
+          allow_custom_values: true
+          members:
+            - id: publish
+              value: "publish"
+              brief: >
+                One or more messages are provided for publishing to an intermediary.
+                If a single message is published, the context of the "Publish" span can be used as the creation context and no "Create" span needs to be created.
+              stability: experimental
+            - id: create
+              value: "create"
+              brief: >
+                A message is created.
+                "Create" spans always refer to a single message and are used to provide a unique creation context for messages in batch publishing scenarios.
+              stability: experimental
+            - id: receive
+              value: "receive"
+              brief: >
+                One or more messages are requested by a consumer.
+                This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages.
+              stability: experimental
+            - id: deliver
+              value: "process"
+              brief: >
+                One or more messages are delivered to or processed by a consumer.
+              stability: experimental
+            - id: settle
+              value: "settle"
+              brief: >
+                One or more messages are settled.
+              stability: experimental
+        stability: experimental
+        brief: >
+          A string identifying the kind of messaging operation.
+        note: If a custom value is used, it MUST be of low cardinality.
+        deprecated: "Replaced by `messaging.operation.name`."

--- a/model/registry/deprecated/messaging.yaml
+++ b/model/registry/deprecated/messaging.yaml
@@ -6,44 +6,14 @@ groups:
       - id: messaging.kafka.destination.partition
         type: int
         brief: >
-          "Deprecated, use `messaging.destination.partition.id` instead."
+          Deprecated, use `messaging.destination.partition.id` instead.
         examples: 2
         deprecated: "Replaced by `messaging.destination.partition.id`."
         stability: experimental
       - id: messaging.operation
-        type:
-          allow_custom_values: true
-          members:
-            - id: publish
-              value: "publish"
-              brief: >
-                One or more messages are provided for publishing to an intermediary.
-                If a single message is published, the context of the "Publish" span can be used as the creation context and no "Create" span needs to be created.
-              stability: experimental
-            - id: create
-              value: "create"
-              brief: >
-                A message is created.
-                "Create" spans always refer to a single message and are used to provide a unique creation context for messages in batch publishing scenarios.
-              stability: experimental
-            - id: receive
-              value: "receive"
-              brief: >
-                One or more messages are requested by a consumer.
-                This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages.
-              stability: experimental
-            - id: deliver
-              value: "process"
-              brief: >
-                One or more messages are delivered to or processed by a consumer.
-              stability: experimental
-            - id: settle
-              value: "settle"
-              brief: >
-                One or more messages are settled.
-              stability: experimental
+        type: string
         stability: experimental
         brief: >
-          A string identifying the kind of messaging operation.
-        note: If a custom value is used, it MUST be of low cardinality.
+          Deprecated, use `messaging.operation.name` instead.
+        examples: ["publish", "create", "process"]
         deprecated: "Replaced by `messaging.operation.name`."

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -139,7 +139,7 @@ groups:
           body size should be used.
         examples: 1439
         tag: messaging-generic
-      - id: operation
+      - id: operation.name
         type:
           allow_custom_values: true
           members:
@@ -173,7 +173,7 @@ groups:
               stability: experimental
         stability: experimental
         brief: >
-          A string identifying the kind of messaging operation.
+          A string identifying the name of the messaging operation.
         note: If a custom value is used, it MUST be of low cardinality.
         tag: messaging-generic
       - id: rabbitmq.destination.routing_key

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -139,7 +139,7 @@ groups:
           body size should be used.
         examples: 1439
         tag: messaging-generic
-      - id: operation.name
+      - id: operation.type
         type:
           allow_custom_values: true
           members:
@@ -173,8 +173,15 @@ groups:
               stability: experimental
         stability: experimental
         brief: >
-          A string identifying the name of the messaging operation.
+          A string identifying the type of the messaging operation.
         note: If a custom value is used, it MUST be of low cardinality.
+        tag: messaging-generic
+      - id: operation.name
+        type: string
+        stability: experimental
+        brief: >
+          The system-specific name of the messaging operation.
+        examples: [ "ack", "nack", "send" ]
         tag: messaging-generic
       - id: rabbitmq.destination.routing_key
         type: string

--- a/model/trace/messaging.yaml
+++ b/model/trace/messaging.yaml
@@ -54,7 +54,7 @@ groups:
         messaging systems.
     extends: messaging.attributes.common
     attributes:
-      - ref: messaging.operation
+      - ref: messaging.operation.name
         requirement_level: required
       - ref: messaging.batch.message_count
         requirement_level:

--- a/model/trace/messaging.yaml
+++ b/model/trace/messaging.yaml
@@ -54,8 +54,11 @@ groups:
         messaging systems.
     extends: messaging.attributes.common
     attributes:
-      - ref: messaging.operation.name
+      - ref: messaging.operation.type
         requirement_level: required
+      - ref: messaging.operation.name
+        requirement_level:
+          recommended: If the operation is not sufficiently described by `messaging.operation.type`.
       - ref: messaging.batch.message_count
         requirement_level:
           conditionally_required: If the span describes an operation on a batch of messages.

--- a/schema-next.yaml
+++ b/schema-next.yaml
@@ -24,7 +24,7 @@ versions:
         # https://github.com/open-telemetry/semantic-conventions/pull/913
         - rename_attributes:
             attribute_map:
-              messaging.operation: messaging.operation.name
+              messaging.operation: messaging.operation.type
         # https://github.com/open-telemetry/semantic-conventions/pull/866
         - rename_attributes:
             attribute_map:

--- a/schema-next.yaml
+++ b/schema-next.yaml
@@ -21,6 +21,10 @@ versions:
         - rename_attributes:
             attribute_map:
               db.operation: db.operation.name
+        # https://github.com/open-telemetry/semantic-conventions/pull/913
+        - rename_attributes:
+            attribute_map:
+              messaging.operation: messaging.operation.name
         # https://github.com/open-telemetry/semantic-conventions/pull/866
         - rename_attributes:
             attribute_map:


### PR DESCRIPTION
Fixes #890

## Changes

Related to changes made fpr database semantic conventions in #875, this PR ensures consistency and symmetry between `db.operation.name` and `messaging.operation.name`.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
