### PR TITLE
[chore] fix typo in resource attributes docs

### DIFF
--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -192,7 +192,7 @@ All custom identifiers SHOULD be stable across different versions of an implemen
 
 **type:** `telemetry.distro`
 
-**Description:** Additions to the telemetry SDK.
+**Description:** The telemetry distribution (distro) used to capture data recorded by the instrumentation libraries.
 
 <!-- semconv telemetry_experimental -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -24,7 +24,7 @@ This document defines standard attributes for resources. These attributes are ty
 - [Service](#service)
 - [Service (Experimental)](#service-experimental)
 - [Telemetry SDK](#telemetry-sdk)
-- [Telemetry SDK (Experimental)](#telemetry-sdk-experimental)
+- [Telemetry Distribution (Experimental)](#telemetry-distribution-experimental)
 - [Compute Unit](#compute-unit)
 - [Compute Instance](#compute-instance)
 - [Environment](#environment)

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -186,11 +186,11 @@ All custom identifiers SHOULD be stable across different versions of an implemen
 | `webjs` | webjs | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 <!-- endsemconv -->
 
-## Telemetry SDK (Experimental)
+## Telemetry Distribution (Experimental)
 
 **Status**: [Experimental][DocumentStatus]
 
-**type:** `telemetry.sdk`
+**type:** `telemetry.distro`
 
 **Description:** Additions to the telemetry SDK.
 


### PR DESCRIPTION
## Changes

This fixes what looks like a typo in resource attributes documentation for the `telemetry.distro.*` group.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] ~~Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).~~ changelog entry not needed
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] ~~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~~ not needed.
