### PR TITLE
Replace `db.statement` with `db.query.text` in examples

### DIFF
--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -57,7 +57,7 @@ Since SQL statements may have very high cardinality even without arguments, SQL 
 following way, unless the statement is known to be of low cardinality:
 `<db.operation.name> <db.name>.<db.collection.name>`, provided that `db.operation.name` and `db.collection.name` are available.
 If `db.collection.name` is not available due to its semantics, the span SHOULD be named `<db.operation.name> <db.name>`.
-It is not recommended to attempt any client-side parsing of `db.statement` just to get these properties,
+It is not recommended to attempt any client-side parsing of `db.query.text` just to get these properties,
 they should only be used if the library being instrumented already provides them.
 When it's otherwise impossible to get any meaningful span name, `db.name` or the tech-specific database name MAY be used.
 
@@ -178,7 +178,7 @@ This allows multiple instrumentations for the same database to be aligned and ea
 The value `other_sql` is intended as a fallback and MUST only be used if the DBMS is known to be SQL-compliant but the concrete product is not known to the instrumentation.
 If the concrete DBMS is known to the instrumentation, its specific identifier MUST be used.
 
-Back ends could, for example, use the provided identifier to determine the appropriate SQL dialect for parsing the `db.statement`.
+Back ends could, for example, use the provided identifier to determine the appropriate SQL dialect for parsing the `db.query.text`.
 
 When additional attributes are added that only apply to a specific DBMS, its identifier SHOULD be used as a namespace in the attribute key as for the attributes in the sections below.
 

--- a/docs/database/elasticsearch.md
+++ b/docs/database/elasticsearch.md
@@ -100,7 +100,7 @@ Tracing instrumentations that do so, MUST also set `http.request.method_original
 | `server.address`                    | `"elasticsearch.mydomain.com"`                                                                                                      |
 | `server.port`                       | `9200`                                                                                                                              |
 | `http.request.method`               | `"GET"`                                                                                                                             |
-| `db.statement`                      | `"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"`                                                                                 |
+| `db.query.text`                     | `"{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}"`                                                                                 |
 | `db.operation.name`                 | `"search"`                                                                                                                          |
 | `url.full`                          | `"https://elasticsearch.mydomain.com:9200/my-index-000001/_search?from=40&size=20"`                                                 |
 | `db.elasticsearch.path_parts.index` | `"my-index-000001"`                                                                                                                 |

--- a/docs/database/mongodb.md
+++ b/docs/database/mongodb.md
@@ -39,7 +39,7 @@ described on this page.
 | `network.peer.port`     | `27017` |
 | `network.transport`     | `"tcp"` |
 | `db.name`               | `"shopDb"` |
-| `db.statement`          | not set |
+| `db.query.text`         | not set |
 | `db.operation.name`     | `"findAndModify"` |
 | `db.mongodb.collection` | `"products"` |
 

--- a/docs/database/redis.md
+++ b/docs/database/redis.md
@@ -41,7 +41,7 @@ Furthermore, `db.name` is not specified as there is no database name in Redis an
 | `network.peer.address`    | `"/tmp/redis.sock"` |
 | `network.transport`       | `"unix"` |
 | `db.name`                 | not set |
-| `db.statement`            | `"HMSET myhash field1 'Hello' field2 'World"` |
+| `db.query.text`           | `"HMSET myhash field1 'Hello' field2 'World"` |
 | `db.operation.name`       | not set |
 | `db.redis.database_index` | `15` |
 

--- a/docs/database/sql.md
+++ b/docs/database/sql.md
@@ -42,7 +42,7 @@ This is an example of attributes for a MySQL database span:
 | `network.peer.port`    | `3306` |
 | `network.transport`    | `"tcp"` |
 | `db.name`              | `"ShopDb"` |
-| `db.statement`         | `"SELECT * FROM orders WHERE order_id = 'o4711'"` |
+| `db.query.text`        | `"SELECT * FROM orders WHERE order_id = 'o4711'"` |
 | `db.operation.name`    | `"SELECT"` |
 | `db.collection.name`   | `"orders"` |
 


### PR DESCRIPTION
Follow up for #866

`db.statement` was renamed to `db.query.text`, this PR updates examples and other mentions

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* ~~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~~
