### PR TITLE
[metrics/system] Remove shared from system.memory.state values

### DIFF
--- a/.chloggen/decouple_shared_memory_metric.yaml
+++ b/.chloggen/decouple_shared_memory_metric.yaml
@@ -10,7 +10,7 @@ change_type: 'breaking'
 component: system
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Remove `shared` from `system.memory.state` values and make it a standalone metric
+note: Deprecate `shared` from `system.memory.state` values and make it a standalone metric
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/.chloggen/decouple_shared_memory_metric.yaml
+++ b/.chloggen/decouple_shared_memory_metric.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'breaking'
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: system
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `shared` from `system.memory.state` values and make it a standalone metric
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [522]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/attributes-registry/system.md
+++ b/docs/attributes-registry/system.md
@@ -52,9 +52,9 @@
 |---|---|---|
 | `used` | used | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `free` | free | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `shared` | shared | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, report shared memory usage with `metric.system.memory.shared` metric |
 | `buffers` | buffers | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cached` | cached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `shared` | shared | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, report shared memory usage with `metric.system.memory.shared` metric |
 <!-- endsemconv -->
 
 ## Paging attributes

--- a/docs/attributes-registry/system.md
+++ b/docs/attributes-registry/system.md
@@ -54,6 +54,7 @@
 | `free` | free | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `buffers` | buffers | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cached` | cached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `shared` | shared | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, report shared memory usage with `metric.system.memory.shared` metric |
 <!-- endsemconv -->
 
 ## Paging attributes

--- a/docs/attributes-registry/system.md
+++ b/docs/attributes-registry/system.md
@@ -52,7 +52,6 @@
 |---|---|---|
 | `used` | used | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `free` | free | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `shared` | shared | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `buffers` | buffers | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cached` | cached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->

--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -30,6 +30,7 @@ Resource attributes related to a host, SHOULD be reported under the `host.*` nam
 - [Memory Metrics](#memory-metrics)
   - [Metric: `system.memory.usage`](#metric-systemmemoryusage)
   - [Metric: `system.memory.limit`](#metric-systemmemorylimit)
+  - [Metric: `system.memory.shared`](#metric-systemmemoryshared)
   - [Metric: `system.memory.utilization`](#metric-systemmemoryutilization)
 - [Paging/Swap Metrics](#pagingswap-metrics)
   - [Metric: `system.paging.usage`](#metric-systempagingusage)
@@ -204,6 +205,7 @@ available on the system, that is `system.memory.limit`.
 | `free` | free | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `buffers` | buffers | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cached` | cached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `shared` | shared | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, report shared memory usage with `metric.system.memory.shared` metric |
 <!-- endsemconv -->
 
 ### Metric: `system.memory.limit`
@@ -228,7 +230,7 @@ This metric is [opt-in][MetricOptIn].
 <!-- semconv metric.system.memory.shared(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
 | -------- | --------------- | ----------- | -------------- | --------- |
-| `system.memory.shared` | UpDownCounter | `By` | Reports shared memory. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `system.memory.shared` | UpDownCounter | `By` | Reports shared memory. Memory used (mostly) by tmpfs. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 <!-- semconv metric.system.memory.shared(full) -->
@@ -257,6 +259,7 @@ This metric is [recommended][MetricRecommended].
 | `free` | free | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `buffers` | buffers | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cached` | cached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `shared` | shared | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, report shared memory usage with `metric.system.memory.shared` metric |
 <!-- endsemconv -->
 
 ## Paging/Swap Metrics

--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -230,7 +230,10 @@ This metric is [opt-in][MetricOptIn].
 <!-- semconv metric.system.memory.shared(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
 | -------- | --------------- | ----------- | -------------- | --------- |
-| `system.memory.shared` | UpDownCounter | `By` | Reports shared memory. Memory used (mostly) by tmpfs. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `system.memory.shared` | UpDownCounter | `By` | Shared memory used (mostly by tmpfs). [1] | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+**[1]:** Equivalent of `shared` from [`free` command](https://man7.org/linux/man-pages/man1/free.1.html) or
+`Shmem` from [`/proc/meminfo`](https://man7.org/linux/man-pages/man5/proc.5.html)"
 <!-- endsemconv -->
 
 <!-- semconv metric.system.memory.shared(full) -->

--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -203,9 +203,9 @@ available on the system, that is `system.memory.limit`.
 |---|---|---|
 | `used` | used | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `free` | free | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `shared` | shared | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, report shared memory usage with `metric.system.memory.shared` metric |
 | `buffers` | buffers | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cached` | cached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `shared` | shared | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, report shared memory usage with `metric.system.memory.shared` metric |
 <!-- endsemconv -->
 
 ### Metric: `system.memory.limit`
@@ -257,9 +257,9 @@ This metric is [recommended][MetricRecommended].
 |---|---|---|
 | `used` | used | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `free` | free | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `shared` | shared | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, report shared memory usage with `metric.system.memory.shared` metric |
 | `buffers` | buffers | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cached` | cached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `shared` | shared | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, report shared memory usage with `metric.system.memory.shared` metric |
 <!-- endsemconv -->
 
 ## Paging/Swap Metrics

--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -202,7 +202,6 @@ available on the system, that is `system.memory.limit`.
 |---|---|---|
 | `used` | used | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `free` | free | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `shared` | shared | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `buffers` | buffers | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cached` | cached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
@@ -220,6 +219,19 @@ This metric is [opt-in][MetricOptIn].
 <!-- endsemconv -->
 
 <!-- semconv metric.system.memory.limit(full) -->
+<!-- endsemconv -->
+
+### Metric: `system.memory.shared`
+
+This metric is [opt-in][MetricOptIn].
+
+<!-- semconv metric.system.memory.shared(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
+| -------- | --------------- | ----------- | -------------- | --------- |
+| `system.memory.shared` | UpDownCounter | `By` | Reports shared memory. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->
+
+<!-- semconv metric.system.memory.shared(full) -->
 <!-- endsemconv -->
 
 ### Metric: `system.memory.utilization`
@@ -243,7 +255,6 @@ This metric is [recommended][MetricRecommended].
 |---|---|---|
 | `used` | used | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `free` | free | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `shared` | shared | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `buffers` | buffers | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cached` | cached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->

--- a/model/metrics/system-metrics.yaml
+++ b/model/metrics/system-metrics.yaml
@@ -81,7 +81,7 @@ groups:
     type: metric
     metric_name: system.memory.shared
     stability: experimental
-    brief: "Reports shared memory."
+    brief: "Reports shared memory. Memory used (mostly) by tmpfs."
     instrument: updowncounter
     unit: "By"
 

--- a/model/metrics/system-metrics.yaml
+++ b/model/metrics/system-metrics.yaml
@@ -77,6 +77,14 @@ groups:
     unit: "By"
     attributes: []
 
+  - id: metric.system.memory.shared
+    type: metric
+    metric_name: system.memory.shared
+    stability: experimental
+    brief: "Reports shared memory."
+    instrument: updowncounter
+    unit: "By"
+
   - id: metric.system.memory.utilization
     type: metric
     metric_name: system.memory.utilization

--- a/model/metrics/system-metrics.yaml
+++ b/model/metrics/system-metrics.yaml
@@ -81,7 +81,10 @@ groups:
     type: metric
     metric_name: system.memory.shared
     stability: experimental
-    brief: "Reports shared memory. Memory used (mostly) by tmpfs."
+    brief: "Shared memory used (mostly by tmpfs)."
+    note: |
+      Equivalent of `shared` from [`free` command](https://man7.org/linux/man-pages/man1/free.1.html) or
+      `Shmem` from [`/proc/meminfo`](https://man7.org/linux/man-pages/man5/proc.5.html)"
     instrument: updowncounter
     unit: "By"
 

--- a/model/registry/system.yaml
+++ b/model/registry/system.yaml
@@ -65,9 +65,6 @@ groups:
             - id: free
               value: 'free'
               stability: experimental
-            - id: shared
-              value: 'shared'
-              stability: experimental
             - id: buffers
               value: 'buffers'
               stability: experimental

--- a/model/registry/system.yaml
+++ b/model/registry/system.yaml
@@ -65,16 +65,16 @@ groups:
             - id: free
               value: 'free'
               stability: experimental
+            - id: shared
+              value: 'shared'
+              stability: experimental
+              deprecated: 'Removed, report shared memory usage with `metric.system.memory.shared` metric'
             - id: buffers
               value: 'buffers'
               stability: experimental
             - id: cached
               value: 'cached'
               stability: experimental
-            - id: shared
-              value: 'shared'
-              stability: experimental
-              deprecated: 'Removed, report shared memory usage with `metric.system.memory.shared` metric'
         stability: experimental
         brief: "The memory state"
         examples: ["free", "cached"]

--- a/model/registry/system.yaml
+++ b/model/registry/system.yaml
@@ -71,6 +71,10 @@ groups:
             - id: cached
               value: 'cached'
               stability: experimental
+            - id: shared
+              value: 'shared'
+              stability: experimental
+              deprecated: 'Removed, report shared memory usage with `metric.system.memory.shared` metric'
         stability: experimental
         brief: "The memory state"
         examples: ["free", "cached"]


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/522

## Changes

This PR removes the `shared` state from the possible values of the `system.memory.state` metric since it does not contribute to the total. The attribute guidelines mention though:

>  the sum of usage over all attribute values SHOULD be equal to the limit

Hence, we need to remove this state and make it standalone metric.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.


Note: I'm not sure if [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) needs to be updated since the PR only touches the values' set 🤔 