### PR TITLE
Fix title for the JVM docs page

### DIFF
--- a/docs/runtime/jvm-metrics.md
+++ b/docs/runtime/jvm-metrics.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: Runtime Environment
+linkTitle: JVM
 --->
 
 # Semantic Conventions for JVM Metrics


### PR DESCRIPTION
Fixes the navigation title for the JVM docs page:

<img width="1044" alt="image" src="https://github.com/open-telemetry/semantic-conventions/assets/866830/29217796-6753-47fa-b436-c6b272b6b3d7">

