### PR TITLE
[chore] adapt lambda examples to current conventions

### DIFF
--- a/docs/faas/aws-lambda.md
+++ b/docs/faas/aws-lambda.md
@@ -13,21 +13,20 @@ use cases.
 
 <!-- toc -->
 
-- [Instrumenting AWS Lambda](#instrumenting-aws-lambda)
-  - [All triggers](#all-triggers)
-    - [AWS X-Ray Active Tracing Considerations](#aws-x-ray-active-tracing-considerations)
-      - [`xray-lambda` Propagator Functionality](#xray-lambda-propagator-functionality)
-      - [`xray-lambda` Propagator Configuration](#xray-lambda-propagator-configuration)
-  - [API Gateway](#api-gateway)
-  - [SQS](#sqs)
-    - [SQS Event](#sqs-event)
-    - [SQS Message](#sqs-message)
-  - [Examples](#examples)
-    - [API Gateway Request Proxy (Lambda tracing passive)](#api-gateway-request-proxy-lambda-tracing-passive)
-    - [API Gateway Request Proxy (Lambda tracing active)](#api-gateway-request-proxy-lambda-tracing-active)
-    - [SQS (Lambda tracing passive)](#sqs-lambda-tracing-passive)
-    - [SQS (Lambda tracing active)](#sqs-lambda-tracing-active)
-  - [Resource Detector](#resource-detector)
+- [All triggers](#all-triggers)
+  - [AWS X-Ray Active Tracing Considerations](#aws-x-ray-active-tracing-considerations)
+    - [`xray-lambda` Propagator Functionality](#xray-lambda-propagator-functionality)
+    - [`xray-lambda` Propagator Configuration](#xray-lambda-propagator-configuration)
+- [API Gateway](#api-gateway)
+- [SQS](#sqs)
+  - [SQS Event](#sqs-event)
+  - [SQS Message](#sqs-message)
+- [Examples](#examples)
+  - [API Gateway Request Proxy (Lambda tracing passive)](#api-gateway-request-proxy-lambda-tracing-passive)
+  - [API Gateway Request Proxy (Lambda tracing active)](#api-gateway-request-proxy-lambda-tracing-active)
+  - [SQS (Lambda tracing passive)](#sqs-lambda-tracing-passive)
+  - [SQS (Lambda tracing active)](#sqs-lambda-tracing-active)
+- [Resource Detector](#resource-detector)
 
 <!-- tocstop -->
 

--- a/docs/faas/aws-lambda.md
+++ b/docs/faas/aws-lambda.md
@@ -13,20 +13,21 @@ use cases.
 
 <!-- toc -->
 
-- [All triggers](#all-triggers)
-  - [AWS X-Ray Active Tracing Considerations](#aws-x-ray-active-tracing-considerations)
-    - [`xray-lambda` Propagator Functionality](#xray-lambda-propagator-functionality)
-    - [`xray-lambda` Propagator Configuration](#xray-lambda-propagator-configuration)
-- [API Gateway](#api-gateway)
-- [SQS](#sqs)
-  - [SQS Event](#sqs-event)
-  - [SQS Message](#sqs-message)
-- [Examples](#examples)
-  - [API Gateway Request Proxy (Lambda tracing passive)](#api-gateway-request-proxy-lambda-tracing-passive)
-  - [API Gateway Request Proxy (Lambda tracing active)](#api-gateway-request-proxy-lambda-tracing-active)
-  - [SQS (Lambda tracing passive)](#sqs-lambda-tracing-passive)
-  - [SQS (Lambda tracing active)](#sqs-lambda-tracing-active)
-- [Resource Detector](#resource-detector)
+- [Instrumenting AWS Lambda](#instrumenting-aws-lambda)
+  - [All triggers](#all-triggers)
+    - [AWS X-Ray Active Tracing Considerations](#aws-x-ray-active-tracing-considerations)
+      - [`xray-lambda` Propagator Functionality](#xray-lambda-propagator-functionality)
+      - [`xray-lambda` Propagator Configuration](#xray-lambda-propagator-configuration)
+  - [API Gateway](#api-gateway)
+  - [SQS](#sqs)
+    - [SQS Event](#sqs-event)
+    - [SQS Message](#sqs-message)
+  - [Examples](#examples)
+    - [API Gateway Request Proxy (Lambda tracing passive)](#api-gateway-request-proxy-lambda-tracing-passive)
+    - [API Gateway Request Proxy (Lambda tracing active)](#api-gateway-request-proxy-lambda-tracing-active)
+    - [SQS (Lambda tracing passive)](#sqs-lambda-tracing-passive)
+    - [SQS (Lambda tracing active)](#sqs-lambda-tracing-active)
+  - [Resource Detector](#resource-detector)
 
 <!-- tocstop -->
 
@@ -158,8 +159,8 @@ added as a link to the span. This means the span may have as many links as messa
 See [compatibility](../../supplementary-guidelines/compatibility/aws.md#context-propagation) for more info.
 
 - [`faas.trigger`][faas] MUST be set to `pubsub`.
-- [`messaging.operation`](/docs/messaging/messaging-spans.md) MUST be set to `process`.
-- [`messaging.system`](/docs/messaging/messaging-spans.md) MUST be set to `AmazonSQS`.
+- [`messaging.operation.type`](/docs/messaging/messaging-spans.md) MUST be set to `process`.
+- [`messaging.system`](/docs/messaging/messaging-spans.md) MUST be set to `aws_sqs`.
 
 ### SQS Message
 
@@ -171,8 +172,8 @@ added as a link to the span.
 See [compatibility](../../supplementary-guidelines/compatibility/aws.md#context-propagation) for more info.
 
 - [`faas.trigger`][faas] MUST be set to `pubsub`.
-- [`messaging.operation`](/docs/messaging/messaging-spans.md#messaging-attributes) MUST be set to `process`.
-- [`messaging.system`](/docs/messaging/messaging-spans.md#messaging-attributes) MUST be set to `AmazonSQS`.
+- [`messaging.operation.type`](/docs/messaging/messaging-spans.md#messaging-attributes) MUST be set to `process`.
+- [`messaging.system`](/docs/messaging/messaging-spans.md#messaging-attributes) MUST be set to `aws_sqs`.
 
 Other [Messaging attributes](/docs/messaging/messaging-spans.md#messaging-attributes) SHOULD be set based on the available information in the SQS message
 event.
@@ -251,9 +252,9 @@ Function F:                      | Span ProcBatch |
 | Links |  |  |  | Span Prod1 | Span Prod2 |
 | SpanKind | `PRODUCER` | `PRODUCER` | `CONSUMER` | `CONSUMER` | `CONSUMER` |
 | Status | `Ok` | `Ok` | `Ok` | `Ok` | `Ok` |
-| `messaging.system` | `AmazonSQS` | `AmazonSQS` | `AmazonSQS` | `AmazonSQS` | `AmazonSQS` |
+| `messaging.system` | `aws_sqs` | `aws_sqs` | `aws_sqs` | `aws_sqs` | `aws_sqs` |
 | `messaging.destination.name` | `Q` | `Q` | `Q` | `Q` | `Q` |
-| `messaging.operation` |  |  | `process` | `process` | `process` |
+| `messaging.operation.type` |  |  | `process` | `process` | `process` |
 | `messaging.message.id` | | | | `"a1"` | `"a2"` |
 
 Note that if Span Prod1 and Span Prod2 were sent to different queues, Span ProcBatch would not have


### PR DESCRIPTION
## Changes

Seems like lambda SQS part was not adapted to recent messaging conventions changes.

Refs: #517, #913

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
