### PR TITLE
Clarify fully-qualified name should be used for `error.type`

### DIFF
--- a/docs/attributes-registry/error.md
+++ b/docs/attributes-registry/error.md
@@ -10,7 +10,11 @@
 |---|---|---|---|---|
 | `error.type` | string | Describes a class of error the operation ended with. [1] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
-**[1]:** The `error.type` SHOULD be predictable and SHOULD have low cardinality.
+**[1]:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
+
+When `error.type` is set to a type (e.g., an exception type), its
+fully-qualified class name SHOULD be used.
+
 Instrumentations SHOULD document the list of errors they report.
 
 The cardinality of `error.type` within one instrumentation library SHOULD be low.

--- a/docs/dotnet/dotnet-aspnetcore-metrics.md
+++ b/docs/dotnet/dotnet-aspnetcore-metrics.md
@@ -79,7 +79,11 @@ Exceptions Metric is reported by the `Microsoft.AspNetCore.Diagnostics` meter.
 | [`error.type`](../attributes-registry/error.md) | string | The full name of exception type. [1] | `System.OperationCanceledException`; `Contoso.MyException` | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `aspnetcore.diagnostics.handler.type` | string | Full type name of the [`IExceptionHandler`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.diagnostics.iexceptionhandler) implementation that handled the exception. | `Contoso.MyHandler` | `Conditionally Required` [2] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
-**[1]:** The `error.type` SHOULD be predictable and SHOULD have low cardinality.
+**[1]:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
+
+When `error.type` is set to a type (e.g., an exception type), its
+fully-qualified class name SHOULD be used.
+
 Instrumentations SHOULD document the list of errors they report.
 
 The cardinality of `error.type` within one instrumentation library SHOULD be low.

--- a/docs/messaging/messaging-metrics.md
+++ b/docs/messaging/messaging-metrics.md
@@ -40,7 +40,11 @@ All messaging metrics share the same set of attributes:
 | [`messaging.destination.partition.id`](../attributes-registry/messaging.md) | string | The identifier of the partition messages are sent to or received from, unique within the `messaging.destination.name`. | `1` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | [`server.port`](../attributes-registry/server.md) | int | Server port number. [7] | `80`; `8080`; `443` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
-**[1]:** The `error.type` SHOULD be predictable and SHOULD have low cardinality.
+**[1]:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
+
+When `error.type` is set to a type (e.g., an exception type), its
+fully-qualified class name SHOULD be used.
+
 Instrumentations SHOULD document the list of errors they report.
 
 The cardinality of `error.type` within one instrumentation library SHOULD be low.

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -308,7 +308,11 @@ as described in [Attributes specific to certain messaging systems](#attributes-s
 
 **[1]:** If a custom value is used, it MUST be of low cardinality.
 
-**[2]:** The `error.type` SHOULD be predictable and SHOULD have low cardinality.
+**[2]:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
+
+When `error.type` is set to a type (e.g., an exception type), its
+fully-qualified class name SHOULD be used.
+
 Instrumentations SHOULD document the list of errors they report.
 
 The cardinality of `error.type` within one instrumentation library SHOULD be low.

--- a/model/registry/error.yaml
+++ b/model/registry/error.yaml
@@ -19,7 +19,11 @@ groups:
                 A fallback error value to be used when the instrumentation doesn't define a custom value.
         examples: ['timeout', 'java.net.UnknownHostException', 'server_certificate_invalid', '500']
         note: |
-          The `error.type` SHOULD be predictable and SHOULD have low cardinality.
+          The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
+
+          When `error.type` is set to a type (e.g., an exception type), its
+          fully-qualified class name SHOULD be used.
+
           Instrumentations SHOULD document the list of errors they report.
 
           The cardinality of `error.type` within one instrumentation library SHOULD be low.


### PR DESCRIPTION
Fixes #855

## Changes

Add paragraph to the `error.type` notes that when an exception type is used, its fully-qualified name should be used. 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.

CC @lmolkova 
