### PR TITLE
[chore] Split db and messaging registry groups

### DIFF
--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -18,7 +18,7 @@
 
 ## Generic Database Attributes
 
-<!-- semconv registry.db(omit_requirement_level,tag=db-generic) -->
+<!-- semconv registry.db(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `db.client.connections.pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -105,7 +105,7 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 
 ## Cassandra Attributes
 
-<!-- semconv registry.db(omit_requirement_level,tag=tech-specific-cassandra) -->
+<!-- semconv registry.db.cassandra(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `db.cassandra.consistency_level` | string | The consistency level of the query. Based on consistency values from [CQL](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html). | `all` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -134,7 +134,7 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 
 ## CosmosDB Attributes
 
-<!-- semconv registry.db(omit_requirement_level,tag=tech-specific-cosmosdb) -->
+<!-- semconv registry.db.cosmosdb(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `db.cosmosdb.client_id` | string | Unique Cosmos client instance id. | `3ba4827d-4422-483f-b59f-85b74211c11d` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -175,7 +175,7 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 
 ## Elasticsearch Attributes
 
-<!-- semconv registry.db(omit_requirement_level,tag=tech-specific-elasticsearch) -->
+<!-- semconv registry.db.elasticsearch(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `db.elasticsearch.cluster.name` | string | Represents the identifier of an Elasticsearch cluster. | `e9106fc68e3044f0b1475b04bf4ffd5f` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -186,7 +186,7 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 
 ## MSSQL Attributes
 
-<!-- semconv registry.db(omit_requirement_level,tag=tech-specific-mssql) -->
+<!-- semconv registry.db.mssql(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `db.mssql.instance_name` | string | The Microsoft SQL Server [instance name](https://docs.microsoft.com/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15) connecting to. This name is used to determine the port of a named instance. [1] | `MSSQLSERVER` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -196,7 +196,7 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 
 ## Redis Attributes
 
-<!-- semconv registry.db(omit_requirement_level,tag=tech-specific-redis) -->
+<!-- semconv registry.db.redis(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `db.redis.database_index` | int | The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer. To be used instead of the generic `db.name` attribute. | `0`; `1`; `15` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |

--- a/docs/attributes-registry/messaging.md
+++ b/docs/attributes-registry/messaging.md
@@ -18,7 +18,7 @@
 
 ## Generic Messaging Attributes
 
-<!-- semconv registry.messaging(omit_requirement_level,tag=messaging-generic) -->
+<!-- semconv registry.messaging(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `messaging.batch.message_count` | int | The number of messages sent, received, or processed in the scope of the batching operation. [1] | `0`; `1`; `2` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -84,7 +84,7 @@ size should be used.
 
 ## GCP Pub/Sub Attributes
 
-<!-- semconv registry.messaging(omit_requirement_level,tag=tech-specific-gcp-pubsub) -->
+<!-- semconv registry.messaging.gcp_pubsub(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `messaging.gcp_pubsub.message.ordering_key` | string | The ordering key for a given message. If the attribute is not present, the message does not have an ordering key. | `ordering_key` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -92,7 +92,7 @@ size should be used.
 
 ## Kafka Attributes
 
-<!-- semconv registry.messaging(omit_requirement_level,tag=tech-specific-kafka) -->
+<!-- semconv registry.messaging.kafka(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `messaging.kafka.consumer.group` | string | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. | `my-group` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -105,7 +105,7 @@ size should be used.
 
 ## RabbitMQ Attributes
 
-<!-- semconv registry.messaging(omit_requirement_level,tag=tech-specific-rabbitmq) -->
+<!-- semconv registry.messaging.rabbitmq(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `messaging.rabbitmq.destination.routing_key` | string | RabbitMQ message routing key. | `myKey` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -114,7 +114,7 @@ size should be used.
 
 ## RocketMQ Attributes
 
-<!-- semconv registry.messaging(omit_requirement_level,tag=tech-specific-rocketmq) -->
+<!-- semconv registry.messaging.rocketmq(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `messaging.rocketmq.client_group` | string | Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind. | `myConsumerGroup` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -146,7 +146,7 @@ size should be used.
 
 ## Azure Event Hubs Attributes
 
-<!-- semconv registry.messaging(omit_requirement_level,tag=tech-specific-eventhubs) -->
+<!-- semconv registry.messaging.eventhubs(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `messaging.eventhubs.consumer.group` | string | The name of the consumer group the event consumer is associated with. | `indexer` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -155,7 +155,7 @@ size should be used.
 
 ## Azure Service Bus Attributes
 
-<!-- semconv registry.messaging(omit_requirement_level,tag=tech-specific-servicebus) -->
+<!-- semconv registry.messaging.servicebus(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `messaging.servicebus.destination.subscription_name` | string | The name of the subscription in the topic messages are received from. | `mySubscription` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -175,7 +175,7 @@ size should be used.
 
 ## Deprecated Messaging Attributes
 
-<!-- semconv registry.messaging.deprecated(omit_requirement_level) -->
+<!-- semconv registry.messaging.deprecated(omit_requirement_level,full) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
 | `messaging.kafka.destination.partition` | int | Deprecated, use `messaging.destination.partition.id` instead. | `2` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `messaging.destination.partition.id`. |

--- a/model/registry/db.yaml
+++ b/model/registry/db.yaml
@@ -3,82 +3,8 @@ groups:
     prefix: db
     type: attribute_group
     brief: >
-      This document defines the attributes used to describe telemetry in the context of databases.
+      This group defines the attributes used to describe telemetry in the context of databases.
     attributes:
-      - id: cassandra.coordinator.dc
-        type: string
-        stability: experimental
-        brief: >
-          The data center of the coordinating node for a query.
-        examples: 'us-west-2'
-        tag: tech-specific-cassandra
-      - id: cassandra.coordinator.id
-        type: string
-        stability: experimental
-        brief: >
-          The ID of the coordinating node for a query.
-        examples: 'be13faa2-8574-4d71-926d-27f16cf8a7af'
-        tag: tech-specific-cassandra
-      - id: cassandra.consistency_level
-        brief: >
-          The consistency level of the query. Based on consistency values from [CQL](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html).
-        type:
-          members:
-            - id: all
-              value: 'all'
-              stability: experimental
-            - id: each_quorum
-              value: 'each_quorum'
-              stability: experimental
-            - id: quorum
-              value: 'quorum'
-              stability: experimental
-            - id: local_quorum
-              value: 'local_quorum'
-              stability: experimental
-            - id: one
-              value: 'one'
-              stability: experimental
-            - id: two
-              value: 'two'
-              stability: experimental
-            - id: three
-              value: 'three'
-              stability: experimental
-            - id: local_one
-              value: 'local_one'
-              stability: experimental
-            - id: any
-              value: 'any'
-              stability: experimental
-            - id: serial
-              value: 'serial'
-              stability: experimental
-            - id: local_serial
-              value: 'local_serial'
-              stability: experimental
-        stability: experimental
-        tag: tech-specific-cassandra
-      - id: cassandra.idempotence
-        type: boolean
-        stability: experimental
-        brief: >
-          Whether or not the query is idempotent.
-        tag: tech-specific-cassandra
-      - id: cassandra.page_size
-        type: int
-        stability: experimental
-        brief: >
-          The fetch size used for paging, i.e. how many rows will be returned at once.
-        examples: [5000]
-        tag: tech-specific-cassandra
-      - id: cassandra.speculative_execution_count
-        type: int
-        stability: experimental
-        brief: >
-          The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
-        examples: [0, 2]
-        tag: tech-specific-cassandra
       - id: collection.name
         type: string
         stability: experimental
@@ -86,134 +12,7 @@ groups:
         note: >
             If the collection name is parsed from the query, it SHOULD match the value provided
             in the query and may be qualified with the schema and database name.
-        tag: db-generic
         examples: ['public.users', 'customers']
-      - id: cosmosdb.client_id
-        type: string
-        stability: experimental
-        brief: Unique Cosmos client instance id.
-        examples: '3ba4827d-4422-483f-b59f-85b74211c11d'
-        tag: tech-specific-cosmosdb
-      - id: cosmosdb.connection_mode
-        type:
-          allow_custom_values: false
-          members:
-            - id: gateway
-              value: 'gateway'
-              brief: Gateway (HTTP) connections mode
-              stability: experimental
-            - id: direct
-              value: 'direct'
-              brief: Direct connection.
-              stability: experimental
-        stability: experimental
-        brief: Cosmos client connection mode.
-        tag: tech-specific-cosmosdb
-      - id: cosmosdb.operation_type
-        type:
-          allow_custom_values: true
-          members:
-            - id: invalid
-              value: 'Invalid'
-              stability: experimental
-            - id: create
-              value: 'Create'
-              stability: experimental
-            - id: patch
-              value: 'Patch'
-              stability: experimental
-            - id: read
-              value: 'Read'
-              stability: experimental
-            - id: read_feed
-              value: 'ReadFeed'
-              stability: experimental
-            - id: delete
-              value: 'Delete'
-              stability: experimental
-            - id: replace
-              value: 'Replace'
-              stability: experimental
-            - id: execute
-              value: 'Execute'
-              stability: experimental
-            - id: query
-              value: 'Query'
-              stability: experimental
-            - id: head
-              value: 'Head'
-              stability: experimental
-            - id: head_feed
-              value: 'HeadFeed'
-              stability: experimental
-            - id: upsert
-              value: 'Upsert'
-              stability: experimental
-            - id: batch
-              value: 'Batch'
-              stability: experimental
-            - id: query_plan
-              value: 'QueryPlan'
-              stability: experimental
-            - id: execute_javascript
-              value: 'ExecuteJavaScript'
-              stability: experimental
-        stability: experimental
-        brief: CosmosDB Operation Type.
-        tag: tech-specific-cosmosdb
-      - id: cosmosdb.request_charge
-        type: double
-        stability: experimental
-        brief: RU consumed for that operation
-        examples: [46.18, 1.0]
-        tag: tech-specific-cosmosdb
-      - id: cosmosdb.request_content_length
-        type: int
-        stability: experimental
-        brief: Request payload size in bytes
-        tag: tech-specific-cosmosdb
-      - id: cosmosdb.status_code
-        type: int
-        stability: experimental
-        brief: Cosmos DB status code.
-        examples: [200, 201]
-        tag: tech-specific-cosmosdb
-      - id: cosmosdb.sub_status_code
-        type: int
-        stability: experimental
-        brief: Cosmos DB sub status code.
-        examples: [1000, 1002]
-        tag: tech-specific-cosmosdb
-      - id: elasticsearch.cluster.name
-        type: string
-        stability: experimental
-        brief: >
-          Represents the identifier of an Elasticsearch cluster.
-        examples: ["e9106fc68e3044f0b1475b04bf4ffd5f"]
-        tag: tech-specific-elasticsearch
-      - id: elasticsearch.path_parts
-        type: template[string]
-        stability: experimental
-        brief: >
-          A dynamic value in the url path.
-        note: >
-          Many Elasticsearch url paths allow dynamic values. These SHOULD be recorded in span attributes in the format
-          `db.elasticsearch.path_parts.<key>`, where `<key>` is the url path part name. The implementation SHOULD
-          reference the [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json)
-          in order to map the path part values to their names.
-        examples: ['db.elasticsearch.path_parts.index=test-index', 'db.elasticsearch.path_parts.doc_id=123']
-        tag: tech-specific-elasticsearch
-      - id: mssql.instance_name
-        type: string
-        stability: experimental
-        note: >
-          If setting a `db.mssql.instance_name`, `server.port` is no longer
-          required (but still recommended if non-standard).
-        brief: >
-          The Microsoft SQL Server [instance name](https://docs.microsoft.com/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15)
-          connecting to. This name is used to determine the port of a named instance.
-        examples: 'MSSQLSERVER'
-        tag: tech-specific-mssql
       - id: name
         type: string
         stability: experimental
@@ -227,29 +26,18 @@ groups:
           (e.g. Oracle instance name and schema name),
           the database name to be used is the more specific layer (e.g. Oracle schema name).
         examples: [ 'customers', 'main' ]
-        tag: db-generic
       - id: operation.name
         type: string
         stability: experimental
         brief: >
           The name of the operation or command being executed.
         examples: ['findAndModify', 'HMSET', 'SELECT']
-        tag: db-generic
-      - id: redis.database_index
-        type: int
-        stability: experimental
-        brief: >
-          The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer.
-          To be used instead of the generic `db.name` attribute.
-        examples: [0, 1, 15]
-        tag: tech-specific-redis
       - id: query.text
         type: string
         stability: experimental
         brief: >
           The database query being executed.
         examples: ['SELECT * FROM wuser_table where username = ?', 'SET mykey "WuValue"']
-        tag: db-generic
       - id: query.parameter
         type: template[string]
         stability: experimental
@@ -262,7 +50,6 @@ groups:
           If a parameter has no name and instead is referenced only by index,
           then `<key>` SHOULD be the 0-based index.
         examples: ['someval', '55']
-        tag: db-generic
       - id: system
         brief: An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers.
         type:
@@ -477,9 +264,7 @@ groups:
               brief: 'Trino'
               stability: experimental
         stability: experimental
-        tag: db-generic
       - id: instance.id
-        tag: db-generic
         type: string
         stability: experimental
         brief: >
@@ -488,7 +273,6 @@ groups:
           The client may obtain this value in databases like MySQL using queries like `select @@hostname`.
         examples: 'mysql-e26b99z.example.com'
       - id: client.connections.state
-        tag: db-generic
         stability: experimental
         type:
           allow_custom_values: true
@@ -502,7 +286,6 @@ groups:
         brief: "The state of a connection in the pool"
         examples: ["idle"]
       - id: client.connections.pool.name
-        tag: db-generic
         type: string
         stability: experimental
         brief: >
@@ -511,3 +294,224 @@ groups:
           instrumentation should use a combination of `server.address` and `server.port` attributes
           formatted as `server.address:server.port`.
         examples: ["myDataSource"]
+  - id: registry.db.cassandra
+    prefix: db
+    type: attribute_group
+    brief: >
+      This group defines attributes for Cassandra.
+    attributes:
+      - id: cassandra.coordinator.dc
+        type: string
+        stability: experimental
+        brief: >
+          The data center of the coordinating node for a query.
+        examples: 'us-west-2'
+      - id: cassandra.coordinator.id
+        type: string
+        stability: experimental
+        brief: >
+          The ID of the coordinating node for a query.
+        examples: 'be13faa2-8574-4d71-926d-27f16cf8a7af'
+      - id: cassandra.consistency_level
+        brief: >
+          The consistency level of the query. Based on consistency values from [CQL](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html).
+        type:
+          members:
+            - id: all
+              value: 'all'
+              stability: experimental
+            - id: each_quorum
+              value: 'each_quorum'
+              stability: experimental
+            - id: quorum
+              value: 'quorum'
+              stability: experimental
+            - id: local_quorum
+              value: 'local_quorum'
+              stability: experimental
+            - id: one
+              value: 'one'
+              stability: experimental
+            - id: two
+              value: 'two'
+              stability: experimental
+            - id: three
+              value: 'three'
+              stability: experimental
+            - id: local_one
+              value: 'local_one'
+              stability: experimental
+            - id: any
+              value: 'any'
+              stability: experimental
+            - id: serial
+              value: 'serial'
+              stability: experimental
+            - id: local_serial
+              value: 'local_serial'
+              stability: experimental
+        stability: experimental
+      - id: cassandra.idempotence
+        type: boolean
+        stability: experimental
+        brief: >
+          Whether or not the query is idempotent.
+      - id: cassandra.page_size
+        type: int
+        stability: experimental
+        brief: >
+          The fetch size used for paging, i.e. how many rows will be returned at once.
+        examples: [5000]
+      - id: cassandra.speculative_execution_count
+        type: int
+        stability: experimental
+        brief: >
+          The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
+        examples: [0, 2]
+  - id: registry.db.cosmosdb
+    prefix: db
+    type: attribute_group
+    brief: >
+      This group defines attributes for Azure Cosmos DB.
+    attributes:
+      - id: cosmosdb.client_id
+        type: string
+        stability: experimental
+        brief: Unique Cosmos client instance id.
+        examples: '3ba4827d-4422-483f-b59f-85b74211c11d'
+      - id: cosmosdb.connection_mode
+        type:
+          allow_custom_values: false
+          members:
+            - id: gateway
+              value: 'gateway'
+              brief: Gateway (HTTP) connections mode
+              stability: experimental
+            - id: direct
+              value: 'direct'
+              brief: Direct connection.
+              stability: experimental
+        stability: experimental
+        brief: Cosmos client connection mode.
+      - id: cosmosdb.operation_type
+        type:
+          allow_custom_values: true
+          members:
+            - id: invalid
+              value: 'Invalid'
+              stability: experimental
+            - id: create
+              value: 'Create'
+              stability: experimental
+            - id: patch
+              value: 'Patch'
+              stability: experimental
+            - id: read
+              value: 'Read'
+              stability: experimental
+            - id: read_feed
+              value: 'ReadFeed'
+              stability: experimental
+            - id: delete
+              value: 'Delete'
+              stability: experimental
+            - id: replace
+              value: 'Replace'
+              stability: experimental
+            - id: execute
+              value: 'Execute'
+              stability: experimental
+            - id: query
+              value: 'Query'
+              stability: experimental
+            - id: head
+              value: 'Head'
+              stability: experimental
+            - id: head_feed
+              value: 'HeadFeed'
+              stability: experimental
+            - id: upsert
+              value: 'Upsert'
+              stability: experimental
+            - id: batch
+              value: 'Batch'
+              stability: experimental
+            - id: query_plan
+              value: 'QueryPlan'
+              stability: experimental
+            - id: execute_javascript
+              value: 'ExecuteJavaScript'
+              stability: experimental
+        stability: experimental
+        brief: CosmosDB Operation Type.
+      - id: cosmosdb.request_charge
+        type: double
+        stability: experimental
+        brief: RU consumed for that operation
+        examples: [46.18, 1.0]
+      - id: cosmosdb.request_content_length
+        type: int
+        stability: experimental
+        brief: Request payload size in bytes
+      - id: cosmosdb.status_code
+        type: int
+        stability: experimental
+        brief: Cosmos DB status code.
+        examples: [200, 201]
+      - id: cosmosdb.sub_status_code
+        type: int
+        stability: experimental
+        brief: Cosmos DB sub status code.
+        examples: [1000, 1002]
+  - id: registry.db.elasticsearch
+    prefix: db
+    type: attribute_group
+    brief: >
+      This group defines attributes for Elasticsearch.
+    attributes:
+      - id: elasticsearch.cluster.name
+        type: string
+        stability: experimental
+        brief: >
+          Represents the identifier of an Elasticsearch cluster.
+        examples: ["e9106fc68e3044f0b1475b04bf4ffd5f"]
+      - id: elasticsearch.path_parts
+        type: template[string]
+        stability: experimental
+        brief: >
+          A dynamic value in the url path.
+        note: >
+          Many Elasticsearch url paths allow dynamic values. These SHOULD be recorded in span attributes in the format
+          `db.elasticsearch.path_parts.<key>`, where `<key>` is the url path part name. The implementation SHOULD
+          reference the [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json)
+          in order to map the path part values to their names.
+        examples: ['db.elasticsearch.path_parts.index=test-index', 'db.elasticsearch.path_parts.doc_id=123']
+  - id: registry.db.mssql
+    prefix: db
+    type: attribute_group
+    brief: >
+      This group defines attributes for Microsoft SQL Server.
+    attributes:
+      - id: mssql.instance_name
+        type: string
+        stability: experimental
+        note: >
+          If setting a `db.mssql.instance_name`, `server.port` is no longer
+          required (but still recommended if non-standard).
+        brief: >
+          The Microsoft SQL Server [instance name](https://docs.microsoft.com/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15)
+          connecting to. This name is used to determine the port of a named instance.
+        examples: 'MSSQLSERVER'
+  - id: registry.db.redis
+    prefix: db
+    type: attribute_group
+    brief: >
+      This group defines attributes for Redis.
+    attributes:
+      - id: redis.database_index
+        type: int
+        stability: experimental
+        brief: >
+          The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer.
+          To be used instead of the generic `db.name` attribute.
+        examples: [0, 1, 15]

--- a/model/registry/messaging.yaml
+++ b/model/registry/messaging.yaml
@@ -13,14 +13,12 @@ groups:
             When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD
             use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
         examples: [0, 1, 2]
-        tag: messaging-generic
       - id: client_id
         type: string
         stability: experimental
         brief: >
           A unique identifier for the client that consumes or produces a message.
         examples: ['client-5', 'myhost@8742@s8083jm']
-        tag: messaging-generic
       - id: destination.name
         type: string
         stability: experimental
@@ -29,7 +27,6 @@ groups:
           Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
           the broker doesn't have such notion, the destination name SHOULD uniquely identify the broker.
         examples: ['MyQueue', 'MyTopic']
-        tag: messaging-generic
       - id: destination.template
         type: string
         stability: experimental
@@ -41,22 +38,18 @@ groups:
           the underlying template is of low cardinality and can be effectively
           used for grouping and aggregation.
         examples: ['/customers/{customerId}']
-        tag: messaging-generic
       - id: destination.anonymous
         type: boolean
         stability: experimental
         brief: 'A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).'
-        tag: messaging-generic
       - id: destination.temporary
         type: boolean
         stability: experimental
         brief: 'A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed.'
-        tag: messaging-generic
       - id: destination_publish.anonymous
         type: boolean
         stability: experimental
         brief: 'A boolean that is true if the publish message destination is anonymous (could be unnamed or have auto-generated name).'
-        tag: messaging-generic
       - id: destination_publish.name
         type: string
         stability: experimental
@@ -65,46 +58,12 @@ groups:
           The name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
           the broker doesn't have such notion, the original destination name SHOULD uniquely identify the broker.
         examples: ['MyQueue', 'MyTopic']
-        tag: messaging-generic
       - id: destination.partition.id
         type: string
         stability: experimental
         brief: >
           The identifier of the partition messages are sent to or received from, unique within the `messaging.destination.name`.
         examples: '1'
-        tag: messaging-generic
-      - id: kafka.consumer.group
-        type: string
-        stability: experimental
-        brief: >
-          Name of the Kafka Consumer Group that is handling the message.
-          Only applies to consumers, not producers.
-        examples: 'my-group'
-        tag: tech-specific-kafka
-      - id: kafka.message.key
-        type: string
-        stability: experimental
-        brief: >
-          Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition.
-          They differ from `messaging.message.id` in that they're not unique.
-          If the key is `null`, the attribute MUST NOT be set.
-        note: >
-          If the key type is not string, it's string representation has to be supplied for the attribute.
-          If the key has no unambiguous, canonical string form, don't include its value.
-        examples: 'myKey'
-        tag: tech-specific-kafka
-      - id: kafka.message.offset
-        type: int
-        stability: experimental
-        brief: >
-          The offset of a record in the corresponding Kafka partition.
-        examples: 42
-        tag: tech-specific-kafka
-      - id: kafka.message.tombstone
-        type: boolean
-        stability: experimental
-        brief: 'A boolean that is true if the message is a tombstone.'
-        tag: tech-specific-kafka
       - id: message.conversation_id
         type: string
         stability: experimental
@@ -112,7 +71,6 @@ groups:
           The conversation ID identifying the conversation to which the message belongs,
           represented as a string. Sometimes called "Correlation ID".
         examples: 'MyConversationId'
-        tag: messaging-generic
       - id: message.envelope.size
         type: int
         stability: experimental
@@ -122,13 +80,11 @@ groups:
           This can refer to both the compressed or uncompressed size. If both sizes are known, the uncompressed
           size should be used.
         examples: 2738
-        tag: messaging-generic
       - id: message.id
         type: string
         stability: experimental
         brief: 'A value used by the messaging system as an identifier for the message, represented as a string.'
         examples: '452a7c7c7c7048c2f887f61572b18fc2'
-        tag: messaging-generic
       - id: message.body.size
         type: int
         stability: experimental
@@ -138,7 +94,6 @@ groups:
           This can refer to both the compressed or uncompressed body size. If both sizes are known, the uncompressed
           body size should be used.
         examples: 1439
-        tag: messaging-generic
       - id: operation.type
         type:
           allow_custom_values: true
@@ -175,125 +130,12 @@ groups:
         brief: >
           A string identifying the type of the messaging operation.
         note: If a custom value is used, it MUST be of low cardinality.
-        tag: messaging-generic
       - id: operation.name
         type: string
         stability: experimental
         brief: >
           The system-specific name of the messaging operation.
         examples: [ "ack", "nack", "send" ]
-        tag: messaging-generic
-      - id: rabbitmq.destination.routing_key
-        type: string
-        stability: experimental
-        brief: >
-          RabbitMQ message routing key.
-        examples: 'myKey'
-        tag: tech-specific-rabbitmq
-      - id: rabbitmq.message.delivery_tag
-        type: int
-        stability: experimental
-        brief: >
-          RabbitMQ message delivery tag
-        examples: 123
-        tag: tech-specific-rabbitmq
-
-      - id: rocketmq.client_group
-        type: string
-        stability: experimental
-        brief: >
-          Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind.
-        examples: 'myConsumerGroup'
-        tag: tech-specific-rocketmq
-      - id: rocketmq.consumption_model
-        type:
-          allow_custom_values: false
-          members:
-            - id: clustering
-              value: 'clustering'
-              brief: 'Clustering consumption model'
-              stability: experimental
-            - id: broadcasting
-              value: 'broadcasting'
-              brief: 'Broadcasting consumption model'
-              stability: experimental
-        stability: experimental
-        brief: >
-          Model of message consumption. This only applies to consumer spans.
-        tag: tech-specific-rocketmq
-      - id: rocketmq.message.delay_time_level
-        type: int
-        stability: experimental
-        brief: >
-          The delay time level for delay message, which determines the message delay time.
-        examples: 3
-        tag: tech-specific-rocketmq
-      - id: rocketmq.message.delivery_timestamp
-        type: int
-        stability: experimental
-        brief: >
-          The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
-        examples: 1665987217045
-        tag: tech-specific-rocketmq
-      - id: rocketmq.message.group
-        type: string
-        stability: experimental
-        brief: >
-          It is essential for FIFO message. Messages that belong to the same message group are always processed one by one within the same consumer group.
-        examples: 'myMessageGroup'
-        tag: tech-specific-rocketmq
-      - id: rocketmq.message.keys
-        type: string[]
-        stability: experimental
-        brief: >
-          Key(s) of message, another way to mark message besides message id.
-        examples: ['keyA', 'keyB']
-        tag: tech-specific-rocketmq
-      - id: rocketmq.message.tag
-        type: string
-        stability: experimental
-        brief: >
-          The secondary classifier of message besides topic.
-        examples: tagA
-        tag: tech-specific-rocketmq
-      - id: rocketmq.message.type
-        type:
-          allow_custom_values: false
-          members:
-            - id: normal
-              value: 'normal'
-              brief: "Normal message"
-              stability: experimental
-            - id: fifo
-              value: 'fifo'
-              brief: 'FIFO message'
-              stability: experimental
-            - id: delay
-              value: 'delay'
-              brief: 'Delay message'
-              stability: experimental
-            - id: transaction
-              value: 'transaction'
-              brief: 'Transaction message'
-              stability: experimental
-        stability: experimental
-        brief: >
-          Type of message.
-        tag: tech-specific-rocketmq
-      - id: rocketmq.namespace
-        type: string
-        stability: experimental
-        brief: >
-          Namespace of RocketMQ resources, resources in different namespaces are individual.
-        examples: 'myNamespace'
-        tag: tech-specific-rocketmq
-      - id: gcp_pubsub.message.ordering_key
-        type: string
-        stability: experimental
-        brief: >
-          The ordering key for a given message. If the attribute is not present, the message does not have an ordering key.
-        examples: 'ordering_key'
-        tag: tech-specific-gcp-pubsub
       - id: system
         brief: >
           An identifier for the messaging system being used. See below for a list of well-known identifiers.
@@ -341,28 +183,180 @@ groups:
               brief: 'Apache RocketMQ'
               stability: experimental
         stability: experimental
-        tag: messaging-generic
+  - id: registry.messaging.kafka
+    prefix: messaging
+    type: attribute_group
+    brief: >
+      This group describes attributes specific to Apache Kafka.
+    attributes:
+      - id: kafka.consumer.group
+        type: string
+        stability: experimental
+        brief: >
+          Name of the Kafka Consumer Group that is handling the message.
+          Only applies to consumers, not producers.
+        examples: 'my-group'
+      - id: kafka.message.key
+        type: string
+        stability: experimental
+        brief: >
+          Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition.
+          They differ from `messaging.message.id` in that they're not unique.
+          If the key is `null`, the attribute MUST NOT be set.
+        note: >
+          If the key type is not string, it's string representation has to be supplied for the attribute.
+          If the key has no unambiguous, canonical string form, don't include its value.
+        examples: 'myKey'
+      - id: kafka.message.offset
+        type: int
+        stability: experimental
+        brief: >
+          The offset of a record in the corresponding Kafka partition.
+        examples: 42
+      - id: kafka.message.tombstone
+        type: boolean
+        stability: experimental
+        brief: 'A boolean that is true if the message is a tombstone.'
+  - id: registry.messaging.rabbitmq
+    prefix: messaging
+    type: attribute_group
+    brief: >
+      This group describes attributes specific to RabbitMQ.
+    attributes:
+      - id: rabbitmq.destination.routing_key
+        type: string
+        stability: experimental
+        brief: >
+          RabbitMQ message routing key.
+        examples: 'myKey'
+      - id: rabbitmq.message.delivery_tag
+        type: int
+        stability: experimental
+        brief: >
+          RabbitMQ message delivery tag
+        examples: 123
+  - id: registry.messaging.rocketmq
+    prefix: messaging
+    type: attribute_group
+    brief: >
+      This group describes attributes specific to RocketMQ.
+    attributes:
+      - id: rocketmq.client_group
+        type: string
+        stability: experimental
+        brief: >
+          Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind.
+        examples: 'myConsumerGroup'
+      - id: rocketmq.consumption_model
+        type:
+          allow_custom_values: false
+          members:
+            - id: clustering
+              value: 'clustering'
+              brief: 'Clustering consumption model'
+              stability: experimental
+            - id: broadcasting
+              value: 'broadcasting'
+              brief: 'Broadcasting consumption model'
+              stability: experimental
+        stability: experimental
+        brief: >
+          Model of message consumption. This only applies to consumer spans.
+      - id: rocketmq.message.delay_time_level
+        type: int
+        stability: experimental
+        brief: >
+          The delay time level for delay message, which determines the message delay time.
+        examples: 3
+      - id: rocketmq.message.delivery_timestamp
+        type: int
+        stability: experimental
+        brief: >
+          The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
+        examples: 1665987217045
+      - id: rocketmq.message.group
+        type: string
+        stability: experimental
+        brief: >
+          It is essential for FIFO message. Messages that belong to the same message group are always processed one by one within the same consumer group.
+        examples: 'myMessageGroup'
+      - id: rocketmq.message.keys
+        type: string[]
+        stability: experimental
+        brief: >
+          Key(s) of message, another way to mark message besides message id.
+        examples: ['keyA', 'keyB']
+      - id: rocketmq.message.tag
+        type: string
+        stability: experimental
+        brief: >
+          The secondary classifier of message besides topic.
+        examples: tagA
+      - id: rocketmq.message.type
+        type:
+          allow_custom_values: false
+          members:
+            - id: normal
+              value: 'normal'
+              brief: "Normal message"
+              stability: experimental
+            - id: fifo
+              value: 'fifo'
+              brief: 'FIFO message'
+              stability: experimental
+            - id: delay
+              value: 'delay'
+              brief: 'Delay message'
+              stability: experimental
+            - id: transaction
+              value: 'transaction'
+              brief: 'Transaction message'
+              stability: experimental
+        stability: experimental
+        brief: >
+          Type of message.
+      - id: rocketmq.namespace
+        type: string
+        stability: experimental
+        brief: >
+          Namespace of RocketMQ resources, resources in different namespaces are individual.
+        examples: 'myNamespace'
+  - id: registry.messaging.gcp_pubsub
+    prefix: messaging
+    type: attribute_group
+    brief: >
+      This group describes attributes specific to GCP Pub/Sub.
+    attributes:
+      - id: gcp_pubsub.message.ordering_key
+        type: string
+        stability: experimental
+        brief: >
+          The ordering key for a given message. If the attribute is not present, the message does not have an ordering key.
+        examples: 'ordering_key'
+  - id: registry.messaging.servicebus
+    prefix: messaging
+    type: attribute_group
+    brief: >
+      This group describes attributes specific to Azure Service Bus.
+    attributes:
       - id: servicebus.message.delivery_count
         type: int
         stability: experimental
         brief: >
           Number of deliveries that have been attempted for this message.
         examples: 2
-        tag: tech-specific-servicebus
       - id: servicebus.message.enqueued_time
         type: int
         stability: experimental
         brief: >
           The UTC epoch seconds at which the message has been accepted and stored in the entity.
         examples: 1701393730
-        tag: tech-specific-servicebus
       - id: servicebus.destination.subscription_name
         type: string
         stability: experimental
         brief: >
           The name of the subscription in the topic messages are received from.
         examples: "mySubscription"
-        tag: tech-specific-servicebus
       - id: servicebus.disposition_status
         brief: >
           Describes the [settlement type](https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock).
@@ -386,18 +380,21 @@ groups:
               brief: 'Message is deferred'
               stability: experimental
         stability: experimental
-        tag: tech-specific-servicebus
+  - id: registry.messaging.eventhubs
+    prefix: messaging
+    type: attribute_group
+    brief: >
+      This group describes attributes specific to Azure Event Hubs.
+    attributes:
       - id: eventhubs.message.enqueued_time
         type: int
         stability: experimental
         brief: >
           The UTC epoch seconds at which the message has been accepted and stored in the entity.
         examples: 1701393730
-        tag: tech-specific-eventhubs
       - id: eventhubs.consumer.group
         type: string
         stability: experimental
         brief: >
           The name of the consumer group the event consumer is associated with.
         examples: 'indexer'
-        tag: tech-specific-eventhubs


### PR DESCRIPTION
## Changes

Related: #887, #917

Moved system-specific attributes in messaging and db registry to their own attribute group, removes tags. 
It provides better auto-generated MD grouping in #917 and simplifies yaml.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* ~~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~~
