### PR TITLE
Add `event.data` attribute to provide mapping from span events to events

### DIFF
--- a/.chloggen/954.yaml
+++ b/.chloggen/954.yaml
@@ -1,4 +1,4 @@
 change_type: enhancement
 component: event
-note: Add event.body attribute to provide mapping from span events to events.
+note: Add event.data attribute to provide mapping from span events to events.
 issues: [954]

--- a/.chloggen/954.yaml
+++ b/.chloggen/954.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: event
+note: Add event.body attribute to provide mapping from span events to events.
+issues: [954]

--- a/docs/attributes-registry/event.md
+++ b/docs/attributes-registry/event.md
@@ -9,10 +9,10 @@ linkTitle: Events
 <!-- semconv registry.event(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
-| `event.body` | string | The body of the event serialized into JSON string. [1] | `{"role":"user","content":"how to use Events API?"}`; `"plain string"` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `event.data` | string | The event payload serialized into JSON string. [1] | `{"role":"user","content":"how to use OTel Event API?"}`; `"plain string"` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `event.name` | string | Identifies the class / type of event. [2] | `browser.mouse.click`; `device.app.lifecycle` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
-**[1]:** The `event.body` MAY be used only on Span Events to capture the body (payload) and MUST NOT be used when emitting Log Records or Events.
+**[1]:** The `event.data` MAY be used only on Span Events to capture the event payload (body) and MUST NOT be used on `LogRecord`s or `Event`s.
 
 **[2]:** Event names are subject to the same rules as [attribute names](https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/).
 Notably, event names are namespaced to avoid collisions and provide a clean

--- a/docs/attributes-registry/event.md
+++ b/docs/attributes-registry/event.md
@@ -9,7 +9,23 @@ linkTitle: Events
 <!-- semconv registry.event(omit_requirement_level) -->
 | Attribute  | Type | Description  | Examples  | Stability |
 |---|---|---|---|---|
-| `event.name` | string | Identifies the class / type of event. [1] | `browser.mouse.click`; `device.app.lifecycle` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `event.body` | string | The body of the event serialized into JSON string. [1] | `{"role":"user","content":"how to use Events API?"}`; `"plain string"` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `event.name` | string | Identifies the class / type of event. [2] | `browser.mouse.click`; `device.app.lifecycle` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
-**[1]:** Event names are subject to the same rules as [attribute names](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/common/attribute-naming.md). Notably, event names are namespaced to avoid collisions and provide a clean separation of semantics for events in separate domains like browser, mobile, and kubernetes.
+**[1]:** The `event.body` MAY be used only on Span Events to capture the body (payload) and MUST NOT be used when emitting Log Records or Events.
+
+**[2]:** Event names are subject to the same rules as [attribute names](https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/).
+Notably, event names are namespaced to avoid collisions and provide a clean
+separation of semantics for events in separate domains like browser, mobile, and
+kubernetes.
+
+Events with the same `event.name` are structurally similar to one another.
+
+When recording events from an existing system as OpenTelemetry Events, it is
+possible that the existing system does not have the equivalent of a name or
+requires multiple fields to identify the structure of the events. In such cases,
+OpenTelemetry recommends using a combination of one or more fields as the name
+such that the name identifies the event structurally. It is also recommended that
+the event names have low-cardinality, so care must be taken to use fields
+that identify the class of Events but not the instance of the Event.
 <!-- endsemconv -->

--- a/docs/general/events.md
+++ b/docs/general/events.md
@@ -37,12 +37,27 @@ The following semantic conventions for events are defined:
 * **[General](#general-event-attributes): General semantic attributes that may be used in describing Events.**
 * [Exceptions](/docs/exceptions/exceptions-logs.md): Semantic attributes that may be used in describing exceptions as events.
 
-## General event attributes
+## Mapping Log Records or Span Events to Events
 
-Events are recorded as LogRecords that are shaped in a special way: Event
-LogRecords MUST have the attribute `event.name` that uniquely identifies the event.
-Events with the same `event.name` are structurally similar to one another. Events
-may also have other LogRecord attributes.
+<!--TODO: update or remove this section once Event API is stable and supported by majority of languages-->
+
+Telemetry producers such as instrumentation libraries SHOULD use Event API to emit events.
+
+When it's not possible, they MAY emit Log Records or Span Events and use the following attributes to
+provide missing properties.
+
+<!-- semconv event -->
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
+|---|---|---|---|---|---|
+| [`event.name`](../attributes-registry/event.md) | string | Identifies the class / type of event. [1] | `browser.mouse.click`; `device.app.lifecycle` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`event.body`](../attributes-registry/event.md) | string | The body of the event serialized into JSON string. [2] | `{"role":"user","content":"how to use Events API?"}`; `"plain string"` | `Conditionally Required` [3] | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+**[1]:** Event names are subject to the same rules as [attribute names](https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/).
+Notably, event names are namespaced to avoid collisions and provide a clean
+separation of semantics for events in separate domains like browser, mobile, and
+kubernetes.
+
+Events with the same `event.name` are structurally similar to one another.
 
 When recording events from an existing system as OpenTelemetry Events, it is
 possible that the existing system does not have the equivalent of a name or
@@ -52,12 +67,9 @@ such that the name identifies the event structurally. It is also recommended tha
 the event names have low-cardinality, so care must be taken to use fields
 that identify the class of Events but not the instance of the Event.
 
-<!-- semconv event -->
-| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
-|---|---|---|---|---|---|
-| [`event.name`](../attributes-registry/event.md) | string | Identifies the class / type of event. [1] | `browser.mouse.click`; `device.app.lifecycle` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+**[2]:** The `event.body` MAY be used only on Span Events to capture the body (payload) and MUST NOT be used when emitting Log Records or Events.
 
-**[1]:** Event names are subject to the same rules as [attribute names](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/common/attribute-naming.md). Notably, event names are namespaced to avoid collisions and provide a clean separation of semantics for events in separate domains like browser, mobile, and kubernetes.
+**[3]:** If and only if the event has a body and is reported using Span Event API.
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/document-status.md

--- a/docs/general/events.md
+++ b/docs/general/events.md
@@ -74,27 +74,11 @@ The following table describes attributes used to translate a Span Event to `Even
 <!-- semconv span_event.event -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`event.name`](../attributes-registry/event.md) | string | Identifies the class / type of event. [1] | `browser.mouse.click`; `device.app.lifecycle` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| [`event.data`](../attributes-registry/event.md) | string | The event payload serialized into JSON string. [2] | `{"role":"user","content":"how to use OTel Event API?"}`; `"plain string"` | `Conditionally Required` [3] | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`event.data`](../attributes-registry/event.md) | string | The event payload serialized into JSON string. [1] | `{"role":"user","content":"how to use OTel Event API?"}`; `"plain string"` | `Conditionally Required` [2] | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
-**[1]:** Event names are subject to the same rules as [attribute names](https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/).
-Notably, event names are namespaced to avoid collisions and provide a clean
-separation of semantics for events in separate domains like browser, mobile, and
-kubernetes.
+**[1]:** The `event.data` MAY be used only on Span Events to capture the event payload (body) and MUST NOT be used on `LogRecord`s or `Event`s.
 
-Events with the same `event.name` are structurally similar to one another.
-
-When recording events from an existing system as OpenTelemetry Events, it is
-possible that the existing system does not have the equivalent of a name or
-requires multiple fields to identify the structure of the events. In such cases,
-OpenTelemetry recommends using a combination of one or more fields as the name
-such that the name identifies the event structurally. It is also recommended that
-the event names have low-cardinality, so care must be taken to use fields
-that identify the class of Events but not the instance of the Event.
-
-**[2]:** The `event.data` MAY be used only on Span Events to capture the event payload (body) and MUST NOT be used on `LogRecord`s or `Event`s.
-
-**[3]:** If and only if the event has a body and is reported as a Span Event.
+**[2]:** If and only if the event has a body and is reported as a Span Event.
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/document-status.md

--- a/docs/general/events.md
+++ b/docs/general/events.md
@@ -34,10 +34,9 @@ structure and semantics will also be defined.
 
 The following semantic conventions for events are defined:
 
-* **[General](#general-event-attributes): General semantic attributes that may be used in describing Events.**
 * [Exceptions](/docs/exceptions/exceptions-logs.md): Semantic attributes that may be used in describing exceptions as events.
 
-## Mapping Log Records or Span Events to Events
+## Mapping Log Records and Span Events to Events
 
 <!--TODO: update or remove this section once Event API is stable and supported by majority of languages-->
 
@@ -69,7 +68,7 @@ that identify the class of Events but not the instance of the Event.
 
 **[2]:** The `event.body` MAY be used only on Span Events to capture the body (payload) and MUST NOT be used when emitting Log Records or Events.
 
-**[3]:** If and only if the event has a body and is reported using Span Event API.
+**[3]:** If and only if the event has a body and is reported as a Span Event.
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/document-status.md

--- a/docs/general/events.md
+++ b/docs/general/events.md
@@ -98,4 +98,3 @@ that identify the class of Events but not the instance of the Event.
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/document-status.md
-

--- a/docs/general/events.md
+++ b/docs/general/events.md
@@ -36,20 +36,46 @@ The following semantic conventions for events are defined:
 
 * [Exceptions](/docs/exceptions/exceptions-logs.md): Semantic attributes that may be used in describing exceptions as events.
 
-## Mapping Log Records and Span Events to Events
+## Mapping `LogRecord`s to Events
 
 <!--TODO: update or remove this section once Event API is stable and supported by majority of languages-->
 
-Telemetry producers such as instrumentation libraries SHOULD use Event API to emit events.
+An `Event` MAY be reported as a `LogRecord`.
+The following table describes attributes used to translate a `LogRecord` to `Event`.
 
-When it's not possible, they MAY emit Log Records or Span Events and use the following attributes to
-provide missing properties.
-
-<!-- semconv event -->
+<!-- semconv log_record.event -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`event.name`](../attributes-registry/event.md) | string | Identifies the class / type of event. [1] | `browser.mouse.click`; `device.app.lifecycle` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| [`event.body`](../attributes-registry/event.md) | string | The body of the event serialized into JSON string. [2] | `{"role":"user","content":"how to use Events API?"}`; `"plain string"` | `Conditionally Required` [3] | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+**[1]:** Event names are subject to the same rules as [attribute names](https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/).
+Notably, event names are namespaced to avoid collisions and provide a clean
+separation of semantics for events in separate domains like browser, mobile, and
+kubernetes.
+
+Events with the same `event.name` are structurally similar to one another.
+
+When recording events from an existing system as OpenTelemetry Events, it is
+possible that the existing system does not have the equivalent of a name or
+requires multiple fields to identify the structure of the events. In such cases,
+OpenTelemetry recommends using a combination of one or more fields as the name
+such that the name identifies the event structurally. It is also recommended that
+the event names have low-cardinality, so care must be taken to use fields
+that identify the class of Events but not the instance of the Event.
+<!-- endsemconv -->
+
+## Mapping Span Events to Events
+
+<!--TODO: update or remove this section once Event API is stable and supported by majority of languages-->
+
+Telemetry producers SHOULD use Event API to emit events. When it's not possible, they MAY emit Span Events.
+The following table describes attributes used to translate a Span Event to `Event`.
+
+<!-- semconv span_event.event -->
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
+|---|---|---|---|---|---|
+| [`event.name`](../attributes-registry/event.md) | string | Identifies the class / type of event. [1] | `browser.mouse.click`; `device.app.lifecycle` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`event.data`](../attributes-registry/event.md) | string | The event payload serialized into JSON string. [2] | `{"role":"user","content":"how to use OTel Event API?"}`; `"plain string"` | `Conditionally Required` [3] | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 **[1]:** Event names are subject to the same rules as [attribute names](https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/).
 Notably, event names are namespaced to avoid collisions and provide a clean
@@ -66,9 +92,10 @@ such that the name identifies the event structurally. It is also recommended tha
 the event names have low-cardinality, so care must be taken to use fields
 that identify the class of Events but not the instance of the Event.
 
-**[2]:** The `event.body` MAY be used only on Span Events to capture the body (payload) and MUST NOT be used when emitting Log Records or Events.
+**[2]:** The `event.data` MAY be used only on Span Events to capture the event payload (body) and MUST NOT be used on `LogRecord`s or `Event`s.
 
 **[3]:** If and only if the event has a body and is reported as a Span Event.
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/document-status.md
+

--- a/model/logs/events.yaml
+++ b/model/logs/events.yaml
@@ -11,8 +11,6 @@ groups:
     brief: >
         This document defines attributes that are used to map Span Events to Events.
     attributes:
-      - ref: event.name
-        requirement_level: required
       - ref: event.data
         requirement_level:
           conditionally_required: If and only if the event has a body and is reported as a Span Event.

--- a/model/logs/events.yaml
+++ b/model/logs/events.yaml
@@ -1,11 +1,18 @@
 groups:
-  - id: event
+  - id: log_record.event
     type: attribute_group
     brief: >
-        This document defines attributes for Events represented using Span Events or Log Records.
+        This document defines attributes that are used to map `LogRecord`` to Events.
     attributes:
       - ref: event.name
         requirement_level: required
-      - ref: event.body
+  - id: span_event.event
+    type: attribute_group
+    brief: >
+        This document defines attributes that are used to map Span Events to Events.
+    attributes:
+      - ref: event.name
+        requirement_level: required
+      - ref: event.data
         requirement_level:
           conditionally_required: If and only if the event has a body and is reported as a Span Event.

--- a/model/logs/events.yaml
+++ b/model/logs/events.yaml
@@ -2,7 +2,7 @@ groups:
   - id: log_record.event
     type: attribute_group
     brief: >
-        This document defines attributes that are used to map `LogRecord`` to Events.
+        This document defines attributes that are used to map `LogRecord` to Events.
     attributes:
       - ref: event.name
         requirement_level: required

--- a/model/logs/events.yaml
+++ b/model/logs/events.yaml
@@ -8,5 +8,4 @@ groups:
         requirement_level: required
       - ref: event.body
         requirement_level:
-          conditionally_required: If and only if the event has a body and is reported using Span Event API.
-
+          conditionally_required: If and only if the event has a body and is reported as a Span Event.

--- a/model/logs/events.yaml
+++ b/model/logs/events.yaml
@@ -2,7 +2,11 @@ groups:
   - id: event
     type: attribute_group
     brief: >
-        This document defines attributes for Events represented using Log Records.
+        This document defines attributes for Events represented using Span Events or Log Records.
     attributes:
       - ref: event.name
         requirement_level: required
+      - ref: event.body
+        requirement_level:
+          conditionally_required: If and only if the event has a body and is reported using Span Event API.
+

--- a/model/registry/event.yaml
+++ b/model/registry/event.yaml
@@ -26,12 +26,12 @@ groups:
           the event names have low-cardinality, so care must be taken to use fields
           that identify the class of Events but not the instance of the Event.
         examples: ['browser.mouse.click', 'device.app.lifecycle']
-      - id: body
+      - id: data
         type: string
         stability: experimental
         brief: >
-          The body of the event serialized into JSON string.
+          The event payload serialized into JSON string.
         note: >
-          The `event.body` MAY be used only on Span Events to capture the body (payload) and MUST NOT be used
-          when emitting Log Records or Events.
-        examples: ['{"role":"user","content":"how to use Events API?"}', '"plain string"']
+          The `event.data` MAY be used only on Span Events to capture the event payload (body) and MUST NOT be used
+          on `LogRecord`s or `Event`s.
+        examples: ['{"role":"user","content":"how to use OTel Event API?"}', '"plain string"']

--- a/model/registry/event.yaml
+++ b/model/registry/event.yaml
@@ -3,16 +3,35 @@ groups:
     prefix: event
     type: attribute_group
     brief: >
-      Attributes for Events represented using Log Records.
+      Attributes for Events represented using Span Events or Log Records.
     attributes:
       - id: name
         type: string
         stability: experimental
         brief: >
           Identifies the class / type of event.
-        note: >
-          Event names are subject to the same rules as [attribute names](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/common/attribute-naming.md).
+        note: |
+          Event names are subject to the same rules as [attribute names](https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/).
           Notably, event names are namespaced to avoid collisions and provide a clean
           separation of semantics for events in separate domains like browser, mobile, and
           kubernetes.
+
+          Events with the same `event.name` are structurally similar to one another.
+
+          When recording events from an existing system as OpenTelemetry Events, it is
+          possible that the existing system does not have the equivalent of a name or
+          requires multiple fields to identify the structure of the events. In such cases,
+          OpenTelemetry recommends using a combination of one or more fields as the name
+          such that the name identifies the event structurally. It is also recommended that
+          the event names have low-cardinality, so care must be taken to use fields
+          that identify the class of Events but not the instance of the Event.
         examples: ['browser.mouse.click', 'device.app.lifecycle']
+      - id: body
+        type: string
+        stability: experimental
+        brief: >
+          The body of the event serialized into JSON string.
+        note: >
+          The `event.body` MAY be used only on Span Events to capture the body (payload) and MUST NOT be used
+          when emitting Log Records or Events.
+        examples: ['{"role":"user","content":"how to use Events API?"}', '"plain string"']


### PR DESCRIPTION
Related to #829, #695, https://github.com/open-telemetry/opentelemetry-specification/issues/3406

## Changes

In GenAI WG, we'd like to be able to document semantic conventions for events, prototype and ship instrumentation libraries that emit them.

Event API is not available in the majority of languages yet, log are also still in development in many of them and the instrumentation libraries should not use logging bridge and produce log records anyway.

As explained in #829, we'd like to record events payload as if they were reported with Event API, but record them as span events until Event API is widely available.

This PR introduces `event.body` attribute that can be used to report event payload on a span event (available and stable everywhere).

The attribute records the payload as a JSON string.
Note that a `"plain string"` is a valid JSON  - see [RFC 7159](https://datatracker.ietf.org/doc/html/rfc7159#appendix-A)

>    o  Changed the definition of "JSON text" so that it can be any JSON
      value, removing the constraint that it be an object or array.

TODO
- [ ] Send spec PR to introduce mapping to transform span events to events. 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* ~~[schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~~
