### PR TITLE
Rename `db.client.connections.usage` to `db.client.connections.count`

### DIFF
--- a/.chloggen/db_client_connection_metric.yaml
+++ b/.chloggen/db_client_connection_metric.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: db
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename `db.client.connections.usage` to `db.client.connections.count`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [201]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -154,13 +154,13 @@ The following metric instruments describe database client connection pool operat
 
 This metric is [required][MetricRequired].
 
-<!-- semconv metric.db.client.connections.usage(metric_table) -->
+<!-- semconv metric.db.client.connections.count(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
 | -------- | --------------- | ----------- | -------------- | --------- |
-| `db.client.connections.usage` | UpDownCounter | `{connection}` | The number of connections that are currently in state described by the `state` attribute | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `db.client.connections.count` | UpDownCounter | `{connection}` | The number of connections that are currently in state described by the `state` attribute | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
-<!-- semconv metric.db.client.connections.usage(full) -->
+<!-- semconv metric.db.client.connections.count(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`db.client.connections.pool.name`](../attributes-registry/db.md) | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`. | `myDataSource` | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -18,7 +18,7 @@ and attributes but more may be added in the future.
 - [Database operation](#database-operation)
   - [Metric: `db.client.operation.duration`](#metric-dbclientoperationduration)
 - [Connection pools](#connection-pools)
-  - [Metric: `db.client.connections.usage`](#metric-dbclientconnectionsusage)
+  - [Metric: `db.client.connections.count`](#metric-dbclientconnectionscount)
   - [Metric: `db.client.connections.idle.max`](#metric-dbclientconnectionsidlemax)
   - [Metric: `db.client.connections.idle.min`](#metric-dbclientconnectionsidlemin)
   - [Metric: `db.client.connections.max`](#metric-dbclientconnectionsmax)
@@ -150,7 +150,7 @@ If a database operation involved multiple network calls (for example retries), t
 
 The following metric instruments describe database client connection pool operations.
 
-### Metric: `db.client.connections.usage`
+### Metric: `db.client.connections.count`
 
 This metric is [required][MetricRequired].
 

--- a/model/metrics/database-metrics.yaml
+++ b/model/metrics/database-metrics.yaml
@@ -8,9 +8,9 @@ groups:
     stability: experimental
     extends: attributes.db.client
 
-  - id: metric.db.client.connections.usage
+  - id: metric.db.client.connections.count
     type: metric
-    metric_name: db.client.connections.usage
+    metric_name: db.client.connections.count
     stability: experimental
     brief: "The number of connections that are currently in state described by the `state` attribute"
     instrument: updowncounter

--- a/schema-next.yaml
+++ b/schema-next.yaml
@@ -4,6 +4,9 @@ versions:
   next:
     metrics:
       changes:
+        #
+        - rename_metrics:
+            db.client.connections.usage: db.client.connections.count
         # https://github.com/open-telemetry/semantic-conventions/pull/909
         - rename_attributes:
             attribute_map:


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/201 

## Changes

As described in #201: `db.client.connections.usage` ->  `db.client.connections.count` 


## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
