### PR TITLE
feat: add k8s.container.status.last_terminated_reason resource attribute

### DIFF
--- a/.chloggen/k8s-status.yaml
+++ b/.chloggen/k8s-status.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: "k8s"
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add container.status.last_terminated_reason resource attribute
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [922]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/attributes-registry/k8s.md
+++ b/docs/attributes-registry/k8s.md
@@ -15,7 +15,8 @@
 | `k8s.cluster.name` | string | The name of the cluster. | `opentelemetry-cluster` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `k8s.cluster.uid` | string | A pseudo-ID for the cluster, set to the UID of the `kube-system` namespace. [1] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `k8s.container.name` | string | The name of the Container from Pod specification, must be unique within a Pod. Container runtime usually uses different globally unique name (`container.name`). | `redis` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `k8s.container.restart_count` | int | Number of times the container was restarted. This attribute can be used to identify a particular container (running or stopped) within a container spec. | `0`; `2` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `k8s.container.restart_count` | int | Number of times the container was restarted. This attribute can be used to identify a particular container (running or stopped) within a container spec. |  | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `k8s.container.status.last_terminated_reason` | string | Last terminated reason of the Container. | `Evicted`; `Error` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `k8s.cronjob.name` | string | The name of the CronJob. | `opentelemetry` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `k8s.cronjob.uid` | string | The UID of the CronJob. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `k8s.daemonset.name` | string | The name of the DaemonSet. | `opentelemetry` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |

--- a/docs/resource/k8s.md
+++ b/docs/resource/k8s.md
@@ -114,7 +114,8 @@ to a running container.
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`k8s.container.name`](../attributes-registry/k8s.md) | string | The name of the Container from Pod specification, must be unique within a Pod. Container runtime usually uses different globally unique name (`container.name`). | `redis` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| [`k8s.container.restart_count`](../attributes-registry/k8s.md) | int | Number of times the container was restarted. This attribute can be used to identify a particular container (running or stopped) within a container spec. | `0`; `2` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`k8s.container.restart_count`](../attributes-registry/k8s.md) | int | Number of times the container was restarted. This attribute can be used to identify a particular container (running or stopped) within a container spec. |  | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`k8s.container.status.last_terminated_reason`](../attributes-registry/k8s.md) | string | Last terminated reason of the Container. | `Evicted`; `Error` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ## ReplicaSet

--- a/model/registry/k8s.yaml
+++ b/model/registry/k8s.yaml
@@ -98,7 +98,12 @@ groups:
           Number of times the container was restarted. This attribute can be
           used to identify a particular container (running or stopped) within a
           container spec.
-        examples: [0, 2]
+      - id: container.status.last_terminated_reason
+        type: string
+        stability: experimental
+        brief: >
+          Last terminated reason of the Container.
+        examples: ["Evicted", "Error"]
       - id: replicaset.uid
         type: string
         stability: experimental

--- a/model/resource/k8s.yaml
+++ b/model/resource/k8s.yaml
@@ -45,6 +45,7 @@ groups:
     attributes:
       - ref: k8s.container.name
       - ref: k8s.container.restart_count
+      - ref: k8s.container.status.last_terminated_reason
 
   - id: k8s.replicaset
     prefix: k8s.replicaset


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/922

## Changes



## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [X] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
