### PR TITLE
Define Nginx Ingress Controller events

### DIFF
--- a/docs/nginx/events.md
+++ b/docs/nginx/events.md
@@ -1,4 +1,4 @@
- Semantic conventions for Nginx Ingress Controller events
+Semantic conventions for Nginx Ingress Controller events
 
 **Status**: [Experimental](../../../document-status.md)
 
@@ -7,6 +7,9 @@
 <!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
 
 <!-- toc -->
+
+- [Access](#access)
+- [Error](#error)
 
 <!-- tocstop -->
 
@@ -20,24 +23,23 @@ The event name MUST be `nginx_ingress_controller.access`.
 
 This event describes the details of an the Nginx access.
 
-
 | Body Field | Type | Description | Examples | Requirement Level |
 |---|---|---|---|---|
-`http.request.id` | string | The randomly generated ID of the request | `529a007902362a5f51385a5fa7049884` | Required |
-`http.request.length` | int | The request length (including request line, header, and request body) | `89` | Recommended |
-`http.request.time` | double | Time elapsed since the first bytes were read from the client | `0.001`| Recommended |
-`remote_ip_list` | array | An array of remote IP addresses. It is a list because it is common to include, besides the client IP address, IP addresses from headers like X-Forwarded-For. Real source IP is restored to source.ip. | `["192.168.64.1"]` | Recommended |
-`upstream.alternative_name` | string | The name of the alternative upstream. |  | Recommended |
-`upstream.ip` | string | The IP address of the upstream server. If several servers were contacted during request processing, their addresses are separated by commas. | `172.17.0.5` |Recommended |
-`upstream.name` | string | The name of the upstream. | `default-web-8080` | Recommended |
-`upstream.port` | string | The port of the upstream server. | `8080` | Recommended |
-`upstream.response.length` | int | The length of the response obtained from the upstream server | `59` | Recommended |
-`response.length_list` | array | An array of upstream response lengths. It is a list because it is common that several upstream servers were contacted during request processing. |  | Recommended |
-`response.status_code` | int | The status code of the response obtained from the upstream server | `200` | Recommended |
-`status_code_list` |  array | An array of upstream response status codes. It is a list because it is common that several upstream servers were contacted during request processing. | | Recommended |
-`response.time` | int | The time spent on receiving the response from the upstream server as seconds with millisecond resolution | `0` | Recommended |
-`response.time_list` | array | An array of upstream response durations. It is a list because it is common that several upstream servers were contacted during request processing. | | Recommended |
-`upstream_address_list` |  array | An array of the upstream addresses. It is a list because it is common that several upstream servers were contacted during request processing. |  | Recommended |
+| `http.request.id` | string | The randomly generated ID of the request | `529a007902362a5f51385a5fa7049884` | Required |
+| `http.request.length` | int | The request length (including request line, header, and request body) | `89` | Recommended |
+| `http.request.time` | double | Time elapsed since the first bytes were read from the client | `0.001`| Recommended |
+| `remote_ip_list` | array | An array of remote IP addresses. It is a list because it is common to include, besides the client IP address, IP addresses from headers like X-Forwarded-For. Real source IP is restored to source.ip. | `["192.168.64.1"]` | Recommended |
+| `upstream.alternative_name` | string | The name of the alternative upstream. |  | Recommended |
+| `upstream.ip` | string | The IP address of the upstream server. If several servers were contacted during request processing, their addresses are separated by commas. | `172.17.0.5` |Recommended |
+| `upstream.name` | string | The name of the upstream. | `default-web-8080` | Recommended |
+| `upstream.port` | string | The port of the upstream server. | `8080` | Recommended |
+| `upstream.response.length` | int | The length of the response obtained from the upstream server | `59` | Recommended |
+| `response.length_list` | array | An array of upstream response lengths. It is a list because it is common that several upstream servers were contacted during request processing. |  | Recommended |
+| `response.status_code` | int | The status code of the response obtained from the upstream server | `200` | Recommended |
+| `status_code_list` |  array | An array of upstream response status codes. It is a list because it is common that several upstream servers were contacted during request processing. | | Recommended |
+| `response.time` | int | The time spent on receiving the response from the upstream server as seconds with millisecond resolution | `0` | Recommended |
+| `response.time_list` | array | An array of upstream response durations. It is a list because it is common that several upstream servers were contacted during request processing. | | Recommended |
+| `upstream_address_list` |  array | An array of the upstream addresses. It is a list because it is common that several upstream servers were contacted during request processing. |  | Recommended |
 
 # Error
 
@@ -47,6 +49,6 @@ This event describes the details of an the error in Nginx Ingress Controller.
 
 | Body Field | Type | Description | Examples | Requirement Level |
 |---|---|---|---|---|
-`source.file` | string | Source file | `client_config.go` | Recommended |
-`source.line_number` | int | Source line number | 608 | Recommended |
-`thread_id` | int | Thread ID | 8 | Recommended |
+| `source.file` | string | Source file | `client_config.go` | Recommended |
+| `source.line_number` | int | Source line number | 608 | Recommended |
+| `thread_id` | int | Thread ID | 8 | Recommended |


### PR DESCRIPTION

## Changes

Following the events convention, adding definition for Nginx Ingress Controller events. All this information is from the [Elastic Nginx Ingress Controller Logs integration](https://docs.elastic.co/en/integrations/nginx_ingress_controller#access-logs).

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
