### PR TITLE
[chore] move process metrics to the registry

### DIFF
--- a/docs/attributes-registry/process.md
+++ b/docs/attributes-registry/process.md
@@ -11,6 +11,7 @@
 | `process.command` | string | The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`. | `cmd/otelcol` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `process.command_args` | string[] | All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`. | `[cmd/otecol, --config=config.yaml]` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `process.command_line` | string | The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead. | `C:\cmd\otecol --config="my directory\config.yaml"` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `process.context_switch_type` | string | Specifies whether the context switches for this data point were voluntary or involuntary. | `voluntary` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `process.creation.time` | string | The date and time the process was created, in ISO 8601 format. | `2023-11-21T09:25:34.853Z` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `process.executable.name` | string | The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`. | `otelcol` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `process.executable.path` | string | The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`. | `/usr/bin/cmd/otelcol` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -19,6 +20,7 @@
 | `process.group_leader.pid` | int | The PID of the process's group leader. This is also the process group ID (PGID) of the process. | `23` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `process.interactive` | boolean | Whether the process is connected to an interactive shell. |  | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `process.owner` | string | The username of the user that owns the process. | `root` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `process.paging.fault_type` | string | The type of page fault for this data point. Type `major` is for major/hard page faults, and `minor` is for minor/soft page faults. | `major` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `process.parent_pid` | int | Parent Process identifier (PPID). | `111` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `process.pid` | int | Process identifier (PID). | `1234` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `process.real_user.id` | int | The real user ID (RUID) of the process. | `1000` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -34,4 +36,32 @@
 | `process.vpid` | int | Virtual process identifier. [1] | `12` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 **[1]:** The process ID within a PID namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.
+
+`process.context_switch_type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `voluntary` | voluntary | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `involuntary` | involuntary | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+`process.paging.fault_type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `major` | major | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `minor` | minor | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->
+
+<!-- semconv registry.process.cpu(omit_requirement_level) -->
+| Attribute  | Type | Description  | Examples  | Stability |
+|---|---|---|---|---|
+| `process.cpu.state` | string | The CPU state for this data point. A process SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `system` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+`process.cpu.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `system` | system | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `user` | user | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `wait` | wait | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->

--- a/docs/system/process-metrics.md
+++ b/docs/system/process-metrics.md
@@ -58,7 +58,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.process.cpu.time(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `process.cpu.state` | string | The CPU state for this data point. A process SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `system` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`process.cpu.state`](../attributes-registry/process.md) | string | The CPU state for this data point. A process SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `system` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `process.cpu.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
@@ -82,7 +82,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.process.cpu.utilization(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `process.cpu.state` | string | The CPU state for this data point. A process SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `system` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`process.cpu.state`](../attributes-registry/process.md) | string | The CPU state for this data point. A process SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. | `system` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `process.cpu.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
@@ -204,7 +204,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.process.context_switches(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `process.context_switch_type` | string | Specifies whether the context switches for this data point were voluntary or involuntary. | `voluntary` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`process.context_switch_type`](../attributes-registry/process.md) | string | Specifies whether the context switches for this data point were voluntary or involuntary. | `voluntary` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `process.context_switch_type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
@@ -227,7 +227,7 @@ This metric is [recommended][MetricRecommended].
 <!-- semconv metric.process.paging.faults(full) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| `process.paging.fault_type` | string | The type of page fault for this data point. Type `major` is for major/hard page faults, and `minor` is for minor/soft page faults. | `major` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`process.paging.fault_type`](../attributes-registry/process.md) | string | The type of page fault for this data point. Type `major` is for major/hard page faults, and `minor` is for minor/soft page faults. | `major` | `Recommended` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 `process.paging.fault_type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 

--- a/model/metrics/process-metrics.yaml
+++ b/model/metrics/process-metrics.yaml
@@ -1,24 +1,4 @@
 groups:
-  - id: attributes.process.cpu
-    prefix: process.cpu
-    type: attribute_group
-    brief: "Attributes for process CPU metrics."
-    attributes:
-      - id: state
-        brief: "The CPU state for this data point. A process SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels."
-        type:
-          allow_custom_values: true
-          members:
-            - id: system
-              value: 'system'
-              stability: experimental
-            - id: user
-              value: 'user'
-              stability: experimental
-            - id: wait
-              value: 'wait'
-              stability: experimental
-        stability: experimental
   - id: metric.process.cpu.time
     type: metric
     metric_name: process.cpu.time
@@ -102,18 +82,7 @@ groups:
     instrument: counter
     unit: "{count}"
     attributes:
-      - id: process.context_switch_type
-        brief: "Specifies whether the context switches for this data point were voluntary or involuntary."
-        type:
-          allow_custom_values: true
-          members:
-            - id: voluntary
-              value: 'voluntary'
-              stability: experimental
-            - id: involuntary
-              value: 'involuntary'
-              stability: experimental
-        stability: experimental
+      - ref: process.context_switch_type
   - id: metric.process.paging.faults
     type: metric
     metric_name: process.paging.faults
@@ -122,15 +91,4 @@ groups:
     instrument: counter
     unit: "{fault}"
     attributes:
-      - id: process.paging.fault_type
-        brief: "The type of page fault for this data point. Type `major` is for major/hard page faults, and `minor` is for minor/soft page faults."
-        type:
-          allow_custom_values: true
-          members:
-            - id: major
-              value: 'major'
-              stability: experimental
-            - id: minor
-              value: 'minor'
-              stability: experimental
-        stability: experimental
+      - ref: process.paging.fault_type

--- a/model/registry/process.yaml
+++ b/model/registry/process.yaml
@@ -170,3 +170,53 @@ groups:
         stability: experimental
         brief: >
           Whether the process is connected to an interactive shell.
+      - id: context_switch_type
+        brief: "Specifies whether the context switches for this data point were voluntary or involuntary."
+        type:
+          allow_custom_values: true
+          members:
+            - id: voluntary
+              value: 'voluntary'
+              stability: experimental
+            - id: involuntary
+              value: 'involuntary'
+              stability: experimental
+        stability: experimental
+      - id: paging.fault_type
+        brief: > 
+          The type of page fault for this data point. Type `major` is for major/hard page faults, and `minor`
+          is for minor/soft page faults.
+        type:
+          allow_custom_values: true
+          members:
+            - id: major
+              value: 'major'
+              stability: experimental
+            - id: minor
+              value: 'minor'
+              stability: experimental
+        stability: experimental
+
+  - id: registry.process.cpu
+    prefix: process.cpu
+    type: attribute_group
+    brief: >
+        Attributes for process CPU
+    attributes:
+      - id: state
+        brief: >
+          The CPU state for this data point. A process SHOULD be characterized _either_ by data points with no `state`
+          labels, _or only_ data points with `state` labels.
+        type:
+          allow_custom_values: true
+          members:
+            - id: system
+              value: 'system'
+              stability: experimental
+            - id: user
+              value: 'user'
+              stability: experimental
+            - id: wait
+              value: 'wait'
+              stability: experimental
+        stability: experimental


### PR DESCRIPTION
Replacement for #681 which is stale and outdated

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
