### PR TITLE
Render attribute value notes

### DIFF
--- a/templates/registry/markdown/attribute_namespace.md.j2
+++ b/templates/registry/markdown/attribute_namespace.md.j2
@@ -38,7 +38,9 @@
 
 | Value  | Description | Stability |
 |---|---|---|
-{% for espec in enum.type.members %}| `{{espec.value}}` | {{espec.brief | trim}} | {{ stability.badge(espec.stability, espec.deprecated) }} |
+{% for espec in enum.type.members %}| `{{espec.value}}` | {{espec.brief | trim}}{{ notes.add(espec.note) }} | {{ stability.badge(espec.stability, espec.deprecated) }} |
+
+{{ notes.render() }}
 {% endfor %}
 {% endif %}
 {%- endfor -%}


### PR DESCRIPTION
Found while working on https://github.com/open-telemetry/semantic-conventions/pull/981, since my note was removed after the rebase: https://github.com/open-telemetry/semantic-conventions/pull/981/commits/ae353e0e8b1c9beba74d13d182a073ed81f89a87

This appears to have been missed in https://github.com/open-telemetry/semantic-conventions/pull/917.

## Changes

Render notes added to enum values the way they were before https://github.com/open-telemetry/semantic-conventions/pull/917.

@jsuereth 