### PR TITLE
[chore] Remove docfx as unnecessary

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -70,20 +70,6 @@ jobs:
     - name: run misspell
       run: make misspell
 
-  docfx:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-
-    - name: install docfx
-      run: dotnet tool update -g docfx --version "3.0.0-*" --add-source https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-public-packages/nuget/v3/index.json
-
-    - name: run docfx
-      run: docfx build --dry-run
-
   semantic-conventions:
     runs-on: ubuntu-latest
     steps:

--- a/docfx.json
+++ b/docfx.json
@@ -1,7 +1,0 @@
-{
-  "files": "**/*.{md,png}",
-  "warningsAsErrors": true,
-  "rules": {
-    "link-out-of-scope": "off"
-  }
-}


### PR DESCRIPTION
Fixes #987

## Changes

Docfx was introduced in the spec repo a while ago - https://github.com/open-telemetry/opentelemetry-specification/pull/742
with the intention to detect broken links.

Docfx v3 we used since https://github.com/open-telemetry/opentelemetry-specification/pull/2285 was in preview and is no longer accessible and not recommended to be used even if built from sources.

Docfx is a site-generator, not a linting tool, there is no (?) documentation on checks against docs it does.

We already have individual markdown lint and link checks.

With all of this I suggest removing docfx since it seems to be unnecessary.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`

PS: I'll send a similar PR to the spec.