### PR TITLE
[chore] add user agent to the link check

### DIFF
--- a/.markdown_link_check_config.json
+++ b/.markdown_link_check_config.json
@@ -17,6 +17,14 @@
       "replacement": "LINK-CHECK-ERROR-USE-LOCAL-PATH-TO-DOC-PAGE-NOT-EXTERNAL-URL/"
     }
   ],
+  "httpHeaders": [
+    {
+      "urls": ["http", ".", "/"],
+      "headers": {
+        "User-Agent": "Mozilla/5.0 (compatible; OpenTelemetryDocsBot/1.0;"
+      }
+    }
+  ],
   "retryOn429": true,
   "timeout": "30s",
   "aliveStatusCodes": [200, 403]


### PR DESCRIPTION
https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html is not providing content without user-agent. I have tried some python snippet and it was returning 404 as well. 

With user-agent it is working now.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
