### PR TITLE
Prototype:  Use Weaver to enforce semantic convention policies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,13 @@ check-file-and-folder-names-in-docs:
 $(MISSPELL):
 	cd $(TOOLS_DIR) && go build -o $(MISSPELL_BINARY) github.com/client9/misspell/cmd/misspell
 
+.PHONY: check-policies
+check-policies:
+	docker run --rm -v $(PWD)/model:/source -v $(PWD)/docs:/spec -v $(PWD)/policies:/policies \
+		otel/weaver:${WEAVER_VERSION} registry check \
+		--registry=/source \
+		--before-resolution-policies=/policies/before_resolution/registry.rego
+
 .PHONY: misspell
 misspell:	$(MISSPELL)
 	$(MISSPELL) -error $(ALL_DOCS)

--- a/policies/before_resolution/registry.rego
+++ b/policies/before_resolution/registry.rego
@@ -30,7 +30,7 @@ attr_registry_violation(violation_id, group_id, attr_id) = violation {
 	violation := {
 		"id": violation_id,
 		"type": "semconv_attribute",
-		"category": "attrigute_registry",
+		"category": "attribute_registry",
 		"group": group_id,
 		"attr": attr_id,
 	}

--- a/policies/before_resolution/registry.rego
+++ b/policies/before_resolution/registry.rego
@@ -1,0 +1,37 @@
+package otel
+
+# A registry `attribute_group` containing at least one `ref` attribute is
+# considered invalid if it's not in the registry group.
+deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
+	group := input.groups[_]
+	startswith(group.id, "registry.")
+	attr := group.attributes[_]
+	attr.ref != null
+}
+
+# We only allow attribute groups in the attribute registry.
+deny[attr_registry_violation("registry_must_be_attribute_group", group.id, "")] {
+	group := input.groups[_]
+	startswith(group.id, "registry.")
+	group.type != "attribute_group"
+}
+
+# Any group that is NOT in the attribute registry that has an attribute id is
+# in violation of not using the attribute registry.
+deny[attr_registry_violation("nonregistry_with_id_attr", group.id, attr.id)] {
+	group := input.groups[_]
+	not startswith(group.id, "registry.")
+	attr := group.attributes[_]
+	attr.id != null
+}
+
+# Build an attribute registry violation
+attr_registry_violation(violation_id, group_id, attr_id) = violation {
+	violation := {
+		"id": violation_id,
+		"type": "semconv_attribute",
+		"category": "attrigute_registry",
+		"group": group_id,
+		"attr": attr_id,
+	}
+}


### PR DESCRIPTION
This is a prototype of using Weaver to enforce semantic convention policies via the experimental Open-Policy-Agent support.

This defines three policies:

- `nonregistry_with_id_attr`: We only allow new attribute definitions inside the attribute registry, all other attributes must be `ref`.
- `registry_must_be_attribute_group`: All groups in attribute registry MUST be type `attribute_group`.
- `registry_with_ref_attr`: Attribute registry is not allowed to contain `ref` - An attribute can only belong to one group. 

Example output on today's repository:

```
$ make check-policies 
docker run --rm -v /home/joshuasuereth/src/open-telemetry/semantic-conventions/model:/source -v /home/joshuasuereth/src/open-telemetry/semantic-conventions/docs:/spec -v /home/joshuasuereth/src/open-telemetry/semantic-conventions/policies:/policies \
	otel/weaver:latest registry check \
	--registry=/source \
	--before-resolution-policies=/policies/before_resolution/registry.rego
✔ SemConv registry loaded (129 files)
✖ Policy violation: id=nonregistry_with_id_attr, category=attribute_registry, group=attributes.jvm.buffer, attr=pool.name, provenance: /source/metrics/jvm-metrics-experimental.yaml
✖ Policy violation: id=nonregistry_with_id_attr, category=attribute_registry, group=metric.process.context_switches, attr=process.context_switch_type, provenance: /source/metrics/process-metrics.yaml
✖ Policy violation: id=nonregistry_with_id_attr, category=attribute_registry, group=metric.process.paging.faults, attr=process.paging.fault_type, provenance: /source/metrics/process-metrics.yaml
✖ Policy violation: id=nonregistry_with_id_attr, category=attribute_registry, group=attributes.process.cpu, attr=state, provenance: /source/metrics/process-metrics.yaml
make: *** [Makefile:38: check-policies] Error 1
```
Each of these current violations are something we should fix.


## Changes

- Add new `check-policies` command to the makefile which can check weaver policies
- Add `policies/before_resolution/` folder for policies we can enforce on raw YAML model.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
