### PR TITLE
Extend GenAI system well-known values

### DIFF
--- a/docs/attributes-registry/gen-ai.md
+++ b/docs/attributes-registry/gen-ai.md
@@ -21,7 +21,7 @@ This document defines the attributes used to describe telemetry in the context o
 | `gen_ai.response.finish_reasons` | string[] | Array of reasons the model stopped generating tokens, corresponding to each generation received. | `stop`                                                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `gen_ai.response.id`             | string   | The unique identifier for the completion.                                                        | `chatcmpl-123`                                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `gen_ai.response.model`          | string   | The name of the LLM a response was generated from.                                               | `gpt-4-0613`                                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `gen_ai.system`                  | string   | The name of the LLM foundation model vendor.                                                     | `openai`                                                                | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `gen_ai.system`                  | string   | The name of the LLM foundation model vendor.                                                     | `openai`; `microsoft`; `huggingface`                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `gen_ai.usage.completion_tokens` | int      | The number of tokens used in the LLM response (completion).                                      | `180`                                                                   | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `gen_ai.usage.prompt_tokens`     | int      | The number of tokens used in the LLM prompt.                                                     | `100`                                                                   | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
@@ -30,6 +30,13 @@ This document defines the attributes used to describe telemetry in the context o
 
 `gen_ai.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-| Value    | Description | Stability                                                        |
-| -------- | ----------- | ---------------------------------------------------------------- |
-| `openai` | OpenAI      | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| Value         | Description  | Stability                                                        |
+| ------------- | ------------ | ---------------------------------------------------------------- |
+| `openai`      | OpenAI       | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `microsoft`   | Microsoft    | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `huggingface` | Hugging Face | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `google`      | Google       | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `meta`        | Meta         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `anthropic`   | Anthropic    | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `mistral`     | Mistral      | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `cohere`      | Cohere       | ![Experimental](https://img.shields.io/badge/-experimental-blue) |

--- a/docs/gen-ai/llm-spans.md
+++ b/docs/gen-ai/llm-spans.md
@@ -61,6 +61,13 @@ These attributes track input data and metadata for a request to an LLM. Each att
 | Value  | Description | Stability |
 |---|---|---|
 | `openai` | OpenAI | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `microsoft` | Microsoft | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `huggingface` | Hugging Face | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `google` | Google | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `meta` | Meta | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `anthropic` | Anthropic | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `mistral` | Mistral | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `cohere` | Cohere | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 <!-- endsemconv -->
 
 ## Events

--- a/model/registry/gen-ai.yaml
+++ b/model/registry/gen-ai.yaml
@@ -26,6 +26,14 @@ groups:
               stability: experimental
               value: "google"
               brief: 'Google'
+            - id: meta
+              stability: experimental
+              value: "meta"
+              brief: 'Meta'
+            - id: anthropic
+              stability: experimental
+              value: "anthropic"
+              brief: "Anthropic"
             - id: mistral
               stability: experimental
               value: "mistral"

--- a/model/registry/gen-ai.yaml
+++ b/model/registry/gen-ai.yaml
@@ -14,6 +14,26 @@ groups:
               stability: experimental
               value: "openai"
               brief: 'OpenAI'
+            - id: microsoft
+              stability: experimental
+              value: "microsoft"
+              brief: 'Microsoft'
+            - id: huggingface
+              stability: experimental
+              value: "huggingface"
+              brief: 'Hugging Face'
+            - id: google
+              stability: experimental
+              value: "google"
+              brief: 'Google'
+            - id: mistral
+              stability: experimental
+              value: "mistral"
+              brief: 'Mistral'
+            - id: cohere
+              stability: experimental
+              value: "cohere"
+              brief: 'Cohere'
         brief: The name of the LLM foundation model vendor.
         examples: 'openai'
         tag: llm-generic-request


### PR DESCRIPTION
Add more well-known GenAI model providers to the list of possible values that the `gen_ai.system` attribute can take. 

## Changes
The following are added:
- `microsoft` 
- `huggingface`
- `google`
- `meta`
- `anthropic`
- `mistral`
- `cohere` 

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
