### PR TITLE
[chore] Move last 'loose' attribute to registry.

### DIFF
--- a/docs/attributes-registry/jvm.md
+++ b/docs/attributes-registry/jvm.md
@@ -10,20 +10,23 @@
 
 This document defines Java Virtual machine related attributes.
 
-| Attribute              | Type    | Description                               | Examples                                           | Stability                                                  |
-| ---------------------- | ------- | ----------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------- |
-| `jvm.gc.action`        | string  | Name of the garbage collector action. [1] | `end of minor GC`; `end of major GC`               | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `jvm.gc.name`          | string  | Name of the garbage collector. [2]        | `G1 Young Generation`; `G1 Old Generation`         | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `jvm.memory.pool.name` | string  | Name of the memory pool. [3]              | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `jvm.memory.type`      | string  | The type of memory.                       | `heap`; `non_heap`                                 | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `jvm.thread.daemon`    | boolean | Whether the thread is daemon or not.      |                                                    | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `jvm.thread.state`     | string  | State of the thread.                      | `runnable`; `blocked`                              | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| Attribute              | Type    | Description                               | Examples                                           | Stability                                                        |
+| ---------------------- | ------- | ----------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------- |
+| `jvm.buffer.pool.name` | string  | Name of the buffer pool. [1]              | `mapped`; `direct`                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `jvm.gc.action`        | string  | Name of the garbage collector action. [2] | `end of minor GC`; `end of major GC`               | ![Stable](https://img.shields.io/badge/-stable-lightgreen)       |
+| `jvm.gc.name`          | string  | Name of the garbage collector. [3]        | `G1 Young Generation`; `G1 Old Generation`         | ![Stable](https://img.shields.io/badge/-stable-lightgreen)       |
+| `jvm.memory.pool.name` | string  | Name of the memory pool. [4]              | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | ![Stable](https://img.shields.io/badge/-stable-lightgreen)       |
+| `jvm.memory.type`      | string  | The type of memory.                       | `heap`; `non_heap`                                 | ![Stable](https://img.shields.io/badge/-stable-lightgreen)       |
+| `jvm.thread.daemon`    | boolean | Whether the thread is daemon or not.      |                                                    | ![Stable](https://img.shields.io/badge/-stable-lightgreen)       |
+| `jvm.thread.state`     | string  | State of the thread.                      | `runnable`; `blocked`                              | ![Stable](https://img.shields.io/badge/-stable-lightgreen)       |
 
-**[1]:** Garbage collector action is generally obtained via [GarbageCollectionNotificationInfo#getGcAction()](<https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()>).
+**[1]:** Pool names are generally obtained via [BufferPoolMXBean#getName()](<https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName()>).
 
-**[2]:** Garbage collector name is generally obtained via [GarbageCollectionNotificationInfo#getGcName()](<https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcName()>).
+**[2]:** Garbage collector action is generally obtained via [GarbageCollectionNotificationInfo#getGcAction()](<https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()>).
 
-**[3]:** Pool names are generally obtained via [MemoryPoolMXBean#getName()](<https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()>).
+**[3]:** Garbage collector name is generally obtained via [GarbageCollectionNotificationInfo#getGcName()](<https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcName()>).
+
+**[4]:** Pool names are generally obtained via [MemoryPoolMXBean#getName()](<https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()>).
 
 `jvm.memory.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 

--- a/model/metrics/jvm-metrics-experimental.yaml
+++ b/model/metrics/jvm-metrics-experimental.yaml
@@ -39,15 +39,8 @@ groups:
     brief: "Describes JVM buffer metric attributes."
     prefix: jvm.buffer
     attributes:
-      - id: pool.name
-        type: string
-        stability: experimental
+      - ref: jvm.buffer.pool.name
         requirement_level: recommended
-        brief: Name of the buffer pool.
-        examples: [ "mapped", "direct" ]
-        note: >
-          Pool names are generally obtained via
-          [BufferPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName()).
 
   - id: metric.jvm.buffer.memory.usage
     type: metric

--- a/model/registry/jvm.yaml
+++ b/model/registry/jvm.yaml
@@ -79,3 +79,11 @@ groups:
               value: 'terminated'
               brief: 'A thread that has exited is in this state.'
               stability: stable
+      - id: buffer.pool.name
+        type: string
+        stability: experimental
+        brief: Name of the buffer pool.
+        examples: [ "mapped", "direct" ]
+        note: >
+          Pool names are generally obtained via
+          [BufferPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName()).


### PR DESCRIPTION
As of this PR - every single attribute is now located in the registry and all attribute_group, event or metric types reference their attributes from the registry.