### PR TITLE
Clarify `target` in DB Span name

### DIFF
--- a/.chloggen/db_span_name_target.yaml
+++ b/.chloggen/db_span_name_target.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: db
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Clarify `{target}` in db span name for edge cases.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1045]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -71,6 +71,8 @@ The <span id="target-placeholder">`{target}`</span> SHOULD adhere to one of the 
 - `server.address:server.port`
 - `db.system`
 
+A given instrumentation SHOULD strive for consistency in span names. This means that if a specific attribute from the [`{target}`](#target-placeholder) list is selected, it should always be used for the span name. If certain queries lack this specific attribute, the instrumentation SHOULD use `{db.operation.name}` as the span name and omit `{target}`, rather than falling back to the next attribute in the [`{target}`](#target-placeholder) list.
+
 ## Common attributes
 
 These attributes will usually be the same for all operations performed over the same database connection.

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -71,7 +71,10 @@ The <span id="target-placeholder">`{target}`</span> SHOULD adhere to one of the 
 - `server.address:server.port`
 - `db.system`
 
-A given instrumentation SHOULD strive for consistency in span names. This means that if a specific attribute from the [`{target}`](#target-placeholder) list is selected, it should always be used for the span name. If certain queries lack this specific attribute, the instrumentation SHOULD use `{db.operation.name}` as the span name and omit `{target}`, rather than falling back to the next attribute in the [`{target}`](#target-placeholder) list.
+A given instrumentation SHOULD strive for consistency in span names.
+This means that if a specific attribute from the [`{target}`](#target-placeholder) list is selected, it should always be used for the span name.
+If certain queries lack this specific attribute, the instrumentation SHOULD use `{db.operation.name}` as the span name and omit `{target}`, 
+rather than falling back to the next attribute in the [`{target}`](#target-placeholder) list.
 
 ## Common attributes
 


### PR DESCRIPTION
Clarify span name to avoid alternating span name formats and allow dropping `{target}` in edge cases.

Fixes https://github.com/open-telemetry/semantic-conventions/issues/1045

## Changes

Implementing https://github.com/open-telemetry/semantic-conventions/issues/1045#issuecomment-2117930389 from DB Stabilization WG meeting. 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
