### PR TITLE
Update database span name:  clarify `target` and remove fallback

### DIFF
--- a/.chloggen/1069.yaml
+++ b/.chloggen/1069.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+
+component: db
+
+note: 'Update database span name: clarify that target depends on the operation and should not be set when corresponding data is not available.'
+
+issues: [1045]

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -73,7 +73,7 @@ and SHOULD adhere to one of the following values, provided they are accessible:
 - `db.namespace` SHOULD be used only for operations on a specific database namespace.
 - `server.address:server.port` SHOULD be used for other operations not targeting any specific database(s) or collection(s)
 
-If a corresponding `{target}` value is not available for a specific operation, the instrumentation SHOULD NOT populate `{target}`.
+If a corresponding `{target}` value is not available for a specific operation, the instrumentation SHOULD omit the `{target}`.
 For example, for an operation describing SQL query on an anonymous table `SELECT * FROM (VALUES 'a', 'b', 'c') AS t (name)`, span name should be `SELECT`.
 
 ## Common attributes

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -73,6 +73,9 @@ and SHOULD adhere to one of the following values, provided they are accessible:
 - `db.namespace` SHOULD be used only for operations on a specific database namespace.
 - `server.address:server.port` SHOULD be used for other operations not targeting any specific database(s) or collection(s)
 
+If a corresponding `{target}` value is not available for a specific operation, the instrumentation SHOULD NOT populate `{target}`.
+For example, for an operation describing SQL query on an anonymous table `SELECT * FROM (VALUES 'a', 'b', 'c') AS t (name)`, span name should be `SELECT`.
+
 ## Common attributes
 
 These attributes will usually be the same for all operations performed over the same database connection.

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -56,13 +56,13 @@ Database spans MUST follow the overall [guidelines for span names](https://githu
 <!-- markdown-link-check-disable -->
 <!-- HTML anchors are not supported https://github.com/tcort/markdown-link-check/issues/225-->
 The **span name** SHOULD be `{db.operation.name} {target}` if there is a
-(low-cardinality) `db.operation.name` available (see below for the exact definition of the [`{target}`](#target-placeholder) placeholder).
+(low-cardinality) `{db.operation.name}` available (see below for the exact definition of the [`{target}`](#target-placeholder) placeholder).
 
 If there is no (low-cardinality) `db.operation.name` available, database span names
 SHOULD be [`{target}`](#target-placeholder).
 <!-- markdown-link-check-enable -->
 
-If neither `db.operation.name` nor `{target}` are available, span name SHOULD be `db.system`.
+If neither `{db.operation.name}` nor `{target}` are available, span name SHOULD be `{db.system}`.
 
 Semantic conventions for individual database systems MAY specify different span name format.
 
@@ -70,11 +70,11 @@ The <span id="target-placeholder">`{target}`</span> SHOULD describe the entity t
 and SHOULD adhere to one of the following values, provided they are accessible:
 
 - `db.collection.name` SHOULD be used for data manipulation operations or operations on database collections.
-- `db.namespace` SHOULD be used only for operations on a specific database namespace.
+- `db.namespace` SHOULD be used for operations on a specific database namespace.
 - `server.address:server.port` SHOULD be used for other operations not targeting any specific database(s) or collection(s)
 
 If a corresponding `{target}` value is not available for a specific operation, the instrumentation SHOULD omit the `{target}`.
-For example, for an operation describing SQL query on an anonymous table `SELECT * FROM (VALUES 'a', 'b', 'c') AS t (name)`, span name should be `SELECT`.
+For example, for an operation describing SQL query on an anonymous table like `SELECT * FROM (SELECT * FROM table) t`, span name should be `SELECT`.
 
 ## Common attributes
 

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -66,12 +66,12 @@ If neither `db.operation.name` nor `{target}` are available, span name SHOULD be
 
 Semantic conventions for individual database systems MAY specify different span name format.
 
-The <span id="target-placeholder">`{target}`</span> SHOULD describe the entity operation is performed against
+The <span id="target-placeholder">`{target}`</span> SHOULD describe the entity that the operation is performed against
 and SHOULD adhere to one of the following values, provided they are accessible:
 
 - `db.collection.name` SHOULD be used for data manipulation operations or operations on database collections.
 - `db.namespace` SHOULD be used only for operations on a specific database namespace.
-- `server.address:server.port` SHOULD be used for other operations not targeting a specific database or collection
+- `server.address:server.port` SHOULD be used for other operations not targeting any specific database(s) or collection(s)
 
 ## Common attributes
 

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -62,14 +62,16 @@ If there is no (low-cardinality) `db.operation.name` available, database span na
 SHOULD be [`{target}`](#target-placeholder).
 <!-- markdown-link-check-enable -->
 
+If neither `db.operation.name` nor `{target}` are available, span name SHOULD be `db.system`.
+
 Semantic conventions for individual database systems MAY specify different span name format.
 
-The <span id="target-placeholder">`{target}`</span> SHOULD adhere to one of the following values, arranged in prioritized order, provided they are accessible:
+The <span id="target-placeholder">`{target}`</span> SHOULD describe the entity operation is performed against
+and SHOULD adhere to one of the following values, provided they are accessible:
 
-- `db.collection.name`
-- `db.namespace`
-- `server.address:server.port`
-- `db.system`
+- `db.collection.name` SHOULD be used for data manipulation operations or operations on database collections.
+- `db.namespace` SHOULD be used only for operations on a specific database namespace.
+- `server.address:server.port` SHOULD be used for other operations not targeting a specific database or collection
 
 ## Common attributes
 


### PR DESCRIPTION
Fixes #1045

Alternative to #1061

## Changes

Clarifies that target depends on the operation and if target is not available, instrumentation should not fallback to other options.

E.g. for query like `SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t (id, name)`  that uses anonymous table, the span name should be `SELECT` and not `SELECT {db.namespace}`.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
