### PR TITLE
[chore] Add blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/blank_issue.yaml
@@ -1,0 +1,10 @@
+name: Blank issue
+description: Create an issue that doesn't fit the other categories
+labels: ["triage:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this issue!
+        Please make sure to provide all the relevant context in order to help us triage and track down your bug as quickly as possible.
+


### PR DESCRIPTION
Many issues/work items don't fit into existing issue categories:
- there is no clear area or area is not important (e.g. #1031)
- tooling suggestions and housekeeping stuff (e.g. #1096)
- design discussions (e.g. #1073)
- small obvious things (e.g. https://github.com/open-telemetry/semantic-conventions/issues/1079) where the boilerplate takes up more space than the issue description

I'd like to have a blank issue template for such cases. 
