### PR TITLE
Clean up database systems

### DIFF
--- a/.chloggen/1120.yaml
+++ b/.chloggen/1120.yaml
@@ -1,0 +1,12 @@
+change_type: breaking
+
+component: db
+
+note: |
+  Clean up `db.system` enum members:
+
+  - remove `firstsql`, `mssqlcompact`, and `cloudscape` as the corresponding databases are discontinued.
+  - rename `cache` to `intersystems_cache`
+  - remove `coldfusion` as it is not a database.
+
+issues: [1110]

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -65,7 +65,7 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 | `cache`              | Deprecated, use `intersystems_cache` instead.             | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `intersystems_cache`. |
 | `cassandra`          | Apache Cassandra                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
 | `clickhouse`         | ClickHouse                                                | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `cloudscape`         | Deprecated, use `derby` instead.                          | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `derby`.              |
+| `cloudscape`         | Deprecated, use `other_sql` instead.                      | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `other_sql`.          |
 | `cockroachdb`        | CockroachDB                                               | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
 | `coldfusion`         | Deprecated, no replacement at this time.                  | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed.                          |
 | `cosmosdb`           | Microsoft Azure Cosmos DB                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
@@ -78,7 +78,7 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 | `elasticsearch`      | Elasticsearch                                             | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
 | `filemaker`          | FileMaker                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
 | `firebird`           | Firebird                                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `firstsql`           | Deprecated, no replacement at this time.                  | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed.                          |
+| `firstsql`           | Deprecated, use `other_sql` instead.                      | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `other_sql`.          |
 | `geode`              | Apache Geode                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
 | `h2`                 | H2                                                        | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
 | `hanadb`             | SAP HANA                                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -59,61 +59,62 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 
 `db.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-| Value           | Description                                        | Stability                                                        |
-| --------------- | -------------------------------------------------- | ---------------------------------------------------------------- |
-| `adabas`        | Adabas (Adaptable Database System)                 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `cache`         | InterSystems Caché                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `cassandra`     | Apache Cassandra                                   | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `clickhouse`    | ClickHouse                                         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `cloudscape`    | Cloudscape                                         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `cockroachdb`   | CockroachDB                                        | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `coldfusion`    | ColdFusion IMQ                                     | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `cosmosdb`      | Microsoft Azure Cosmos DB                          | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `couchbase`     | Couchbase                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `couchdb`       | CouchDB                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `db2`           | IBM Db2                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `derby`         | Apache Derby                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `dynamodb`      | Amazon DynamoDB                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `edb`           | EnterpriseDB                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `elasticsearch` | Elasticsearch                                      | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `filemaker`     | FileMaker                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `firebird`      | Firebird                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `firstsql`      | FirstSQL                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `geode`         | Apache Geode                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `h2`            | H2                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `hanadb`        | SAP HANA                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `hbase`         | Apache HBase                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `hive`          | Apache Hive                                        | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `hsqldb`        | HyperSQL DataBase                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `influxdb`      | InfluxDB                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `informix`      | Informix                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `ingres`        | Ingres                                             | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `instantdb`     | InstantDB                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `interbase`     | InterBase                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `mariadb`       | MariaDB                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `maxdb`         | SAP MaxDB                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `memcached`     | Memcached                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `mongodb`       | MongoDB                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `mssql`         | Microsoft SQL Server                               | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `mssqlcompact`  | Microsoft SQL Server Compact                       | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `mysql`         | MySQL                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `neo4j`         | Neo4j                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `netezza`       | Netezza                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `opensearch`    | OpenSearch                                         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `oracle`        | Oracle Database                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `other_sql`     | Some other SQL database. Fallback only. See notes. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `pervasive`     | Pervasive PSQL                                     | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `pointbase`     | PointBase                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `postgresql`    | PostgreSQL                                         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `progress`      | Progress Database                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `redis`         | Redis                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `redshift`      | Amazon Redshift                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `spanner`       | Cloud Spanner                                      | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `sqlite`        | SQLite                                             | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `sybase`        | Sybase                                             | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `teradata`      | Teradata                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `trino`         | Trino                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `vertica`       | Vertica                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| Value                | Description                                        | Stability                                                                                        |
+| -------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `adabas`             | Adabas (Adaptable Database System)                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `cache`              | Deprecated, use `intersystems_cache` instead.      | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `intersystems_cache`. |
+| `cassandra`          | Apache Cassandra                                   | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `clickhouse`         | ClickHouse                                         | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `cloudscape`         | Deprecated, use `derby` instead.                   | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `derby``.             |
+| `cockroachdb`        | CockroachDB                                        | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `coldfusion`         | Deprecated, no replacement at this time.           | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed.                          |
+| `cosmosdb`           | Microsoft Azure Cosmos DB                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `couchbase`          | Couchbase                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `couchdb`            | CouchDB                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `db2`                | IBM Db2                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `derby`              | Apache Derby                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `dynamodb`           | Amazon DynamoDB                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `edb`                | EnterpriseDB                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `elasticsearch`      | Elasticsearch                                      | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `filemaker`          | FileMaker                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `firebird`           | Firebird                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `firstsql`           | Deprecated, no replacement at this time.           | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed.                          |
+| `geode`              | Apache Geode                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `h2`                 | H2                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `hanadb`             | SAP HANA                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `hbase`              | Apache HBase                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `hive`               | Apache Hive                                        | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `hsqldb`             | HyperSQL DataBase                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `influxdb`           | InfluxDB                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `informix`           | Informix                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `ingres`             | Ingres                                             | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `instantdb`          | InstantDB                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `interbase`          | InterBase                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `intersystems_cache` | InterSystems Caché                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `mariadb`            | MariaDB                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `maxdb`              | SAP MaxDB                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `memcached`          | Memcached                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `mongodb`            | MongoDB                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `mssql`              | Microsoft SQL Server                               | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `mssqlcompact`       | Deprecated, no replacement at this time.           | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed.                          |
+| `mysql`              | MySQL                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `neo4j`              | Neo4j                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `netezza`            | Netezza                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `opensearch`         | OpenSearch                                         | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `oracle`             | Oracle Database                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `other_sql`          | Some other SQL database. Fallback only. See notes. | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `pervasive`          | Pervasive PSQL                                     | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `pointbase`          | PointBase                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `postgresql`         | PostgreSQL                                         | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `progress`           | Progress Database                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `redis`              | Redis                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `redshift`           | Amazon Redshift                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `spanner`            | Cloud Spanner                                      | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `sqlite`             | SQLite                                             | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `sybase`             | Sybase                                             | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `teradata`           | Teradata                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `trino`              | Trino                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `vertica`            | Vertica                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
 
 ## Db Cassandra Attributes
 

--- a/docs/attributes-registry/db.md
+++ b/docs/attributes-registry/db.md
@@ -59,62 +59,62 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 
 `db.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-| Value                | Description                                        | Stability                                                                                        |
-| -------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `adabas`             | Adabas (Adaptable Database System)                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `cache`              | Deprecated, use `intersystems_cache` instead.      | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `intersystems_cache`. |
-| `cassandra`          | Apache Cassandra                                   | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `clickhouse`         | ClickHouse                                         | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `cloudscape`         | Deprecated, use `derby` instead.                   | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `derby``.             |
-| `cockroachdb`        | CockroachDB                                        | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `coldfusion`         | Deprecated, no replacement at this time.           | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed.                          |
-| `cosmosdb`           | Microsoft Azure Cosmos DB                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `couchbase`          | Couchbase                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `couchdb`            | CouchDB                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `db2`                | IBM Db2                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `derby`              | Apache Derby                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `dynamodb`           | Amazon DynamoDB                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `edb`                | EnterpriseDB                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `elasticsearch`      | Elasticsearch                                      | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `filemaker`          | FileMaker                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `firebird`           | Firebird                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `firstsql`           | Deprecated, no replacement at this time.           | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed.                          |
-| `geode`              | Apache Geode                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `h2`                 | H2                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `hanadb`             | SAP HANA                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `hbase`              | Apache HBase                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `hive`               | Apache Hive                                        | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `hsqldb`             | HyperSQL DataBase                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `influxdb`           | InfluxDB                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `informix`           | Informix                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `ingres`             | Ingres                                             | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `instantdb`          | InstantDB                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `interbase`          | InterBase                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `intersystems_cache` | InterSystems Caché                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `mariadb`            | MariaDB                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `maxdb`              | SAP MaxDB                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `memcached`          | Memcached                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `mongodb`            | MongoDB                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `mssql`              | Microsoft SQL Server                               | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `mssqlcompact`       | Deprecated, no replacement at this time.           | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed.                          |
-| `mysql`              | MySQL                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `neo4j`              | Neo4j                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `netezza`            | Netezza                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `opensearch`         | OpenSearch                                         | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `oracle`             | Oracle Database                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `other_sql`          | Some other SQL database. Fallback only. See notes. | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `pervasive`          | Pervasive PSQL                                     | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `pointbase`          | PointBase                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `postgresql`         | PostgreSQL                                         | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `progress`           | Progress Database                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `redis`              | Redis                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `redshift`           | Amazon Redshift                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `spanner`            | Cloud Spanner                                      | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `sqlite`             | SQLite                                             | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `sybase`             | Sybase                                             | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `teradata`           | Teradata                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `trino`              | Trino                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
-| `vertica`            | Vertica                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| Value                | Description                                               | Stability                                                                                        |
+| -------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `adabas`             | Adabas (Adaptable Database System)                        | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `cache`              | Deprecated, use `intersystems_cache` instead.             | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `intersystems_cache`. |
+| `cassandra`          | Apache Cassandra                                          | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `clickhouse`         | ClickHouse                                                | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `cloudscape`         | Deprecated, use `derby` instead.                          | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `derby`.              |
+| `cockroachdb`        | CockroachDB                                               | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `coldfusion`         | Deprecated, no replacement at this time.                  | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed.                          |
+| `cosmosdb`           | Microsoft Azure Cosmos DB                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `couchbase`          | Couchbase                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `couchdb`            | CouchDB                                                   | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `db2`                | IBM Db2                                                   | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `derby`              | Apache Derby                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `dynamodb`           | Amazon DynamoDB                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `edb`                | EnterpriseDB                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `elasticsearch`      | Elasticsearch                                             | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `filemaker`          | FileMaker                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `firebird`           | Firebird                                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `firstsql`           | Deprecated, no replacement at this time.                  | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed.                          |
+| `geode`              | Apache Geode                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `h2`                 | H2                                                        | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `hanadb`             | SAP HANA                                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `hbase`              | Apache HBase                                              | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `hive`               | Apache Hive                                               | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `hsqldb`             | HyperSQL DataBase                                         | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `influxdb`           | InfluxDB                                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `informix`           | Informix                                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `ingres`             | Ingres                                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `instantdb`          | InstantDB                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `interbase`          | InterBase                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `intersystems_cache` | InterSystems Caché                                        | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `mariadb`            | MariaDB                                                   | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `maxdb`              | SAP MaxDB                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `memcached`          | Memcached                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `mongodb`            | MongoDB                                                   | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `mssql`              | Microsoft SQL Server                                      | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `mssqlcompact`       | Deprecated, Microsoft SQL Server Compact is discontinued. | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, use `other_sql` instead. |
+| `mysql`              | MySQL                                                     | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `neo4j`              | Neo4j                                                     | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `netezza`            | Netezza                                                   | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `opensearch`         | OpenSearch                                                | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `oracle`             | Oracle Database                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `other_sql`          | Some other SQL database. Fallback only. See notes.        | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `pervasive`          | Pervasive PSQL                                            | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `pointbase`          | PointBase                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `postgresql`         | PostgreSQL                                                | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `progress`           | Progress Database                                         | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `redis`              | Redis                                                     | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `redshift`           | Amazon Redshift                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `spanner`            | Cloud Spanner                                             | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `sqlite`             | SQLite                                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `sybase`             | Sybase                                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `teradata`           | Teradata                                                  | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `trino`              | Trino                                                     | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
+| `vertica`            | Vertica                                                   | ![Experimental](https://img.shields.io/badge/-experimental-blue)                                 |
 
 ## Db Cassandra Attributes
 

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -146,12 +146,9 @@ If a database operation involved multiple network calls (for example retries), t
 | Value  | Description | Stability |
 |---|---|---|
 | `adabas` | Adabas (Adaptable Database System) | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `cache` | InterSystems Caché | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cassandra` | Apache Cassandra | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `clickhouse` | ClickHouse | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `cloudscape` | Cloudscape | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cockroachdb` | CockroachDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `coldfusion` | ColdFusion IMQ | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cosmosdb` | Microsoft Azure Cosmos DB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `couchbase` | Couchbase | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `couchdb` | CouchDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -162,7 +159,6 @@ If a database operation involved multiple network calls (for example retries), t
 | `elasticsearch` | Elasticsearch | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `filemaker` | FileMaker | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `firebird` | Firebird | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `firstsql` | FirstSQL | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `geode` | Apache Geode | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `h2` | H2 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `hanadb` | SAP HANA | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -174,12 +170,12 @@ If a database operation involved multiple network calls (for example retries), t
 | `ingres` | Ingres | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `instantdb` | InstantDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `interbase` | InterBase | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `intersystems_cache` | InterSystems Caché | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `mariadb` | MariaDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `maxdb` | SAP MaxDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `memcached` | Memcached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `mongodb` | MongoDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `mssql` | Microsoft SQL Server | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `mssqlcompact` | Microsoft SQL Server Compact | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `mysql` | MySQL | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `neo4j` | Neo4j | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `netezza` | Netezza | ![Experimental](https://img.shields.io/badge/-experimental-blue) |

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -144,12 +144,9 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 | Value  | Description | Stability |
 |---|---|---|
 | `adabas` | Adabas (Adaptable Database System) | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `cache` | InterSystems Caché | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cassandra` | Apache Cassandra | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `clickhouse` | ClickHouse | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `cloudscape` | Cloudscape | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cockroachdb` | CockroachDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `coldfusion` | ColdFusion IMQ | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cosmosdb` | Microsoft Azure Cosmos DB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `couchbase` | Couchbase | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `couchdb` | CouchDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -160,7 +157,6 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 | `elasticsearch` | Elasticsearch | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `filemaker` | FileMaker | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `firebird` | Firebird | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `firstsql` | FirstSQL | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `geode` | Apache Geode | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `h2` | H2 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `hanadb` | SAP HANA | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -172,12 +168,12 @@ If a parameter has no name and instead is referenced only by index, then `<key>`
 | `ingres` | Ingres | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `instantdb` | InstantDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `interbase` | InterBase | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `intersystems_cache` | InterSystems Caché | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `mariadb` | MariaDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `maxdb` | SAP MaxDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `memcached` | Memcached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `mongodb` | MongoDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `mssql` | Microsoft SQL Server | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `mssqlcompact` | Microsoft SQL Server Compact | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `mysql` | MySQL | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `neo4j` | Neo4j | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `netezza` | Netezza | ![Experimental](https://img.shields.io/badge/-experimental-blue) |

--- a/docs/database/dynamodb.md
+++ b/docs/database/dynamodb.md
@@ -36,12 +36,9 @@ These attributes are filled in for all DynamoDB request types.
 | Value  | Description | Stability |
 |---|---|---|
 | `adabas` | Adabas (Adaptable Database System) | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `cache` | InterSystems Caché | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cassandra` | Apache Cassandra | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `clickhouse` | ClickHouse | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `cloudscape` | Cloudscape | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cockroachdb` | CockroachDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `coldfusion` | ColdFusion IMQ | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `cosmosdb` | Microsoft Azure Cosmos DB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `couchbase` | Couchbase | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `couchdb` | CouchDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -52,7 +49,6 @@ These attributes are filled in for all DynamoDB request types.
 | `elasticsearch` | Elasticsearch | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `filemaker` | FileMaker | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `firebird` | Firebird | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `firstsql` | FirstSQL | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `geode` | Apache Geode | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `h2` | H2 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `hanadb` | SAP HANA | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
@@ -64,12 +60,12 @@ These attributes are filled in for all DynamoDB request types.
 | `ingres` | Ingres | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `instantdb` | InstantDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `interbase` | InterBase | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `intersystems_cache` | InterSystems Caché | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `mariadb` | MariaDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `maxdb` | SAP MaxDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `memcached` | Memcached | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `mongodb` | MongoDB | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `mssql` | Microsoft SQL Server | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `mssqlcompact` | Microsoft SQL Server Compact | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `mysql` | MySQL | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `neo4j` | Neo4j | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `netezza` | Netezza | ![Experimental](https://img.shields.io/badge/-experimental-blue) |

--- a/model/registry/db.yaml
+++ b/model/registry/db.yaml
@@ -114,8 +114,8 @@ groups:
               stability: experimental
             - id: cloudscape
               value: 'cloudscape'
-              deprecated: "Replaced by `derby`."
-              brief: "Deprecated, use `derby` instead."
+              deprecated: "Replaced by `other_sql`."
+              brief: "Deprecated, use `other_sql` instead."
               stability: experimental
             - id: cockroachdb
               value: 'cockroachdb'
@@ -168,8 +168,8 @@ groups:
               stability: experimental
             - id: firstsql
               value: 'firstsql'
-              deprecated: "Removed."
-              brief: "Deprecated, no replacement at this time."
+              deprecated: "Replaced by `other_sql`."
+              brief: "Deprecated, use `other_sql` instead."
               stability: experimental
             - id: geode
               value: 'geode'

--- a/model/registry/db.yaml
+++ b/model/registry/db.yaml
@@ -114,7 +114,7 @@ groups:
               stability: experimental
             - id: cloudscape
               value: 'cloudscape'
-              deprecated: "Replaced by `derby``."
+              deprecated: "Replaced by `derby`."
               brief: "Deprecated, use `derby` instead."
               stability: experimental
             - id: cockroachdb
@@ -237,8 +237,8 @@ groups:
               stability: experimental
             - id: mssqlcompact
               value: 'mssqlcompact'
-              deprecated: "Removed."
-              brief: "Deprecated, no replacement at this time."
+              deprecated: "Removed, use `other_sql` instead."
+              brief: "Deprecated, Microsoft SQL Server Compact is discontinued."
               stability: experimental
             - id: mysql
               value: 'mysql'

--- a/model/registry/db.yaml
+++ b/model/registry/db.yaml
@@ -97,7 +97,12 @@ groups:
               stability: experimental
             - id: cache
               value: 'cache'
-              brief: 'InterSystems Caché'
+              deprecated: "Replaced by `intersystems_cache`."
+              brief: "Deprecated, use `intersystems_cache` instead."
+              stability: experimental
+            - id: intersystems_cache
+              value: 'intersystems_cache'
+              brief: "InterSystems Caché"
               stability: experimental
             - id: cassandra
               value: 'cassandra'
@@ -109,7 +114,8 @@ groups:
               stability: experimental
             - id: cloudscape
               value: 'cloudscape'
-              brief: 'Cloudscape'
+              deprecated: "Replaced by `derby``."
+              brief: "Deprecated, use `derby` instead."
               stability: experimental
             - id: cockroachdb
               value: 'cockroachdb'
@@ -117,7 +123,8 @@ groups:
               stability: experimental
             - id: coldfusion
               value: 'coldfusion'
-              brief: 'ColdFusion IMQ'
+              deprecated: "Removed."
+              brief: "Deprecated, no replacement at this time."
               stability: experimental
             - id: cosmosdb
               value: 'cosmosdb'
@@ -161,7 +168,8 @@ groups:
               stability: experimental
             - id: firstsql
               value: 'firstsql'
-              brief: 'FirstSQL'
+              deprecated: "Removed."
+              brief: "Deprecated, no replacement at this time."
               stability: experimental
             - id: geode
               value: 'geode'
@@ -229,7 +237,8 @@ groups:
               stability: experimental
             - id: mssqlcompact
               value: 'mssqlcompact'
-              brief: 'Microsoft SQL Server Compact'
+              deprecated: "Removed."
+              brief: "Deprecated, no replacement at this time."
               stability: experimental
             - id: mysql
               value: 'mysql'


### PR DESCRIPTION
Fixes #1023

## Changes

- renames `cache` to `intersystems_cache` (cache is too broad)
- removes `cloudscape` in favor of `derby` "The [Apache Derby](http://db.apache.org/derby/) project is based upon Cloudscape version 10, which IBM contributed to Apache in 2004."  (see https://en.wikipedia.org/wiki/Apache_Derby, https://db.apache.org/ddlutils/databases/derby.html)
- removed `coldfusion` - it's a [web-development](https://www.adobe.com/products/coldfusion-family.html) platform, not a database. It can work with [different databases](https://helpx.adobe.com/coldfusion/configuring-administering/data-source-management-for-coldfusion.html). 
- `firstsql` - [no longer exists](https://dbdb.io/db/firstsqlj)
- `mssqlcompact` - [discontinued](https://en.wikipedia.org/wiki/SQL_Server_Compact), last released in 2011, end-of-support in 2021

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
