### PR TITLE
[chore] Allow way for PRs to never become stale

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -12,7 +12,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days.'
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
-          exempt-pr-labels: 'bug,work in progress,experts needed, never stale'
+          exempt-pr-labels: 'bug,work in progress,experts needed,never stale'
           exempt-draft-pr: true
           # opt out of defaults to avoid marking issues as stale
           days-before-stale: -1

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -12,7 +12,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days.'
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
-          exempt-pr-labels: 'bug,work in progress,experts needed'
+          exempt-pr-labels: 'bug,work in progress,experts needed, never stale'
           exempt-draft-pr: true
           # opt out of defaults to avoid marking issues as stale
           days-before-stale: -1


### PR DESCRIPTION
## Changes

Add the `never stale` label, similar to the ones in the collector repos to allow having a PR open without being marked as stale by the GH stale bot.

This is useful, for example for PRs that are blocked by something else but still makes sense. E.g., https://github.com/open-telemetry/semantic-conventions/pull/985

PS: I already created the label in GH.

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
