### PR TITLE
[chore] update codeowners for security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,4 +76,13 @@
 /model/trace/gen-ai.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-llm-approvers
 /docs/gen-ai/ @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-llm-approvers
 
+# Security semantic conventions approvers
+/model/registry/file.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
+/model/registry/dns.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
+/model/registry/network.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
+/model/registry/process.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
+/model/registry/tls.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
+/model/registry/user.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
+
+
 # TODO - Add semconv area experts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,5 +84,9 @@
 /model/registry/tls.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
 /model/registry/user.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
 
+/model/metrics/dns.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
+/model/metrics/process-metrics.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
+/model/resource/process.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
+/model/network.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
 
 # TODO - Add semconv area experts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,7 @@
 /model/registry/http.yaml   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
 /model/registry/server.yaml   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
 /model/registry/client.yaml   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
-/model/registry/network.yaml   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
+/model/registry/network.yaml   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers @open-telemetry/semconv-security-approvers
 /model/registry/error.yaml   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
 /model/registry/url.yaml   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
 /model/registry/user-agent.yaml   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
@@ -79,7 +79,6 @@
 # Security semantic conventions approvers
 /model/registry/file.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
 /model/registry/dns.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
-/model/registry/network.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
 /model/registry/process.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
 /model/registry/tls.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers
 /model/registry/user.yaml @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers


### PR DESCRIPTION
According to the https://github.com/open-telemetry/community/issues/2100 the approvers group was created

I have update codeowners file to reflect changes

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
