### PR TITLE
Policy checks with jq

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -93,6 +93,13 @@ jobs:
     - name: verify semantic convention compatibility with latest released version
       run: make compatibility-check
 
+  semantic-conventions-collisions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: verify attribute naming collisions within semantic conventions
+      run: make codegen-collision-checks
+
   schemas-check:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -220,4 +220,4 @@ codegen-collision-checks:
 		--registry=/source \
 		--output=/output/resolved.json \
 		-f json;
-	$(PWD)/node_modules/node-jq/bin/jq.exe -f $(TOOLS_DIR)/codegen_collisions_check.jq ./resolved.json
+	$(PWD)/node_modules/node-jq/bin/jq -f $(TOOLS_DIR)/codegen_collisions_check.jq ./resolved.json

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ generate-gh-issue-templates:
 
 #.PHONY: codegen-collision-checks
 codegen-collision-checks:
+	@if ! npm ls node-jq; then npm install; fi
 	docker run --rm -v $(PWD)/model:/source -v $(PWD)/:/output \
 		$(WEAVER_CONTAINER) registry resolve \
 		--registry=/source \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CHLOGGEN_CONFIG  := .chloggen/config.yaml
 # see https://github.com/open-telemetry/build-tools/releases for semconvgen updates
 # Keep links in model/README.md and .vscode/settings.json in sync!
 SEMCONVGEN_VERSION=0.24.0
-WEAVER_VERSION=0.2.0
+WEAVER_VERSION=0.4.0
 
 # From where to resolve the containers (e.g. "otel/weaver").
 CONTAINER_REPOSITORY=docker.io
@@ -211,3 +211,12 @@ chlog-update: $(CHLOGGEN)
 .PHONY: generate-gh-issue-templates
 generate-gh-issue-templates:
 	$(TOOLS_DIR)/scripts/update-issue-template-areas.sh
+
+#.PHONY: codegen-collision-checks
+codegen-collision-checks:
+	docker run --rm -v $(PWD)/model:/source -v $(PWD)/:/output \
+		$(WEAVER_CONTAINER) registry resolve \
+		--registry=/source \
+		--output=/output/resolved.json \
+		-f json;
+	$(PWD)/node_modules/node-jq/bin/jq.exe -f $(TOOLS_DIR)/codegen_collisions_check.jq ./resolved.json

--- a/internal/tools/codegen_collisions_check.jq
+++ b/internal/tools/codegen_collisions_check.jq
@@ -1,0 +1,23 @@
+def to_const_name: .| split(".")|join("_");
+def exclude(list):
+  map(select( .name as $name | list | all(. != $name) ) );
+def to_const_name: .| split(".")|join("_");
+def get_namespaces: . | split(".") as $parts  | reduce range(1; ($parts |length)) as $i ([]; . + [$parts[0:$i] | join(".")]  );
+def fail_on_const_name_collision: . as $original
+    | exclude(["messaging.client_id"])
+    | group_by(.const_name)
+    | map(select(length>1))
+    | map({error: ("Multiple attributes with the same constant name are defined: " + (. | map(.name) | join(", ")))});
+def fail_on_attr_name_collision: . as $original
+    | exclude(["messaging.operation", "db.operation"])
+    | {names: map(.|.name), namespaces: map(.|.name|get_namespaces[] ) | unique}
+    | .namespaces as $namespaces
+    | .names | map(select( . as $name | $namespaces | index($name)))
+    | map({error: ("Attribute and namespace name collision: " + .)});
+.groups
+    | map(select(.type == "attribute_group"))
+    | map(select(.id | startswith("registry")))
+    | map({attributes: .attributes | map(.const_name= (.name | to_const_name)) })
+    | [.[].attributes[]] as $original
+    | [($original | fail_on_const_name_collision)[][], ($original | fail_on_attr_name_collision)[][]]
+    | if length > 0 then error("\nErrors:\n\t" + (. | join("\n\t"))) else "success" end

--- a/internal/tools/codegen_collisions_check.jq
+++ b/internal/tools/codegen_collisions_check.jq
@@ -4,12 +4,12 @@ def exclude(list):
 def to_const_name: .| split(".")|join("_");
 def get_namespaces: . | split(".") as $parts  | reduce range(1; ($parts |length)) as $i ([]; . + [$parts[0:$i] | join(".")]  );
 def fail_on_const_name_collision: . as $original
-    | exclude(["messaging.client_id"])
+    | exclude(["messaging.client_id_1"])
     | group_by(.const_name)
     | map(select(length>1))
     | map({error: ("Multiple attributes with the same constant name are defined: " + (. | map(.name) | join(", ")))});
 def fail_on_attr_name_collision: . as $original
-    | exclude(["messaging.operation", "db.operation"])
+    | exclude(["messaging.operation1", "db.operation1"])
     | {names: map(.|.name), namespaces: map(.|.name|get_namespaces[] ) | unique}
     | .namespaces as $namespaces
     | .names | map(select( . as $name | $namespaces | index($name)))

--- a/package.json
+++ b/package.json
@@ -15,13 +15,11 @@
     "markdown-toc": "^1.2.0",
     "markdownlint": "0.34.0",
     "markdownlint-cli": "0.31.0",
+    "node-jq": "^4.4.0",
     "prettier": "^3.0.0",
     "through2": "^4.0.2"
   },
   "prettier": {
     "proseWrap": "preserve"
-  },
-  "dependencies": {
-    "node-jq": "^4.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   },
   "prettier": {
     "proseWrap": "preserve"
+  },
+  "dependencies": {
+    "node-jq": "^4.4.0"
   }
 }


### PR DESCRIPTION
Fixes #1068, detect constant name collisions

## Changes
```
Errors:
	Multiple attributes with the same constant name are defined: messaging.client_id, messaging.client.id
	Attribute and namespace name collision: messaging.operation
	Attribute and namespace name collision: db.operation
```

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
