### PR TITLE
Editorial: mention that Redis `db.namespace` is a string

### DIFF
--- a/docs/database/redis.md
+++ b/docs/database/redis.md
@@ -23,7 +23,7 @@ described on this page.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`db.namespace`](/docs/attributes-registry/db.md) | string | The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select). [1] | `0`; `1`; `15` | `Conditionally Required` If and only if it can be captured reliably. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| [`db.namespace`](/docs/attributes-registry/db.md) | string | The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select) (captured as a string). [1] | `0`; `1`; `15` | `Conditionally Required` If and only if it can be captured reliably. | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | [`db.operation.name`](/docs/attributes-registry/db.md) | string | The name of the operation or command being executed. [2] | `findAndModify`; `HMSET`; `SELECT` | `Conditionally Required` [3] | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | [`error.type`](/docs/attributes-registry/error.md) | string | Describes a class of error the operation ended with. [4] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | `Conditionally Required` If and only if the operation failed. | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`server.port`](/docs/attributes-registry/server.md) | int | Server port number. [5] | `80`; `8080`; `443` | `Conditionally Required` [6] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |

--- a/model/trace/database.yaml
+++ b/model/trace/database.yaml
@@ -162,7 +162,8 @@ groups:
     attributes:
       - ref: db.namespace
         brief: >
-          The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select).
+          The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select)
+          (captured as a string).
         requirement_level:
           conditionally_required: If and only if it can be captured reliably.
         note: >


### PR DESCRIPTION
To avoid what could be a common question.

I don't think a change log is necessary, but happy to add one if anyone wishes.