### PR TITLE
Add k8s.volume.{name,type} attributes

### DIFF
--- a/.chloggen/add_k8s_volume_type.yaml
+++ b/.chloggen/add_k8s_volume_type.yaml
@@ -10,7 +10,7 @@ change_type: enhancement
 component: k8s
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Adds k8s.volume.name and k8s.volume.type
+note: Adds k8s.volume.name and k8s.volume.type in the registry
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/.chloggen/add_k8s_volume_type.yaml
+++ b/.chloggen/add_k8s_volume_type.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: k8s
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds k8s.volume.name and k8s.volume.type
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1164]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/add_k8s_volume_type.yaml
+++ b/.chloggen/add_k8s_volume_type.yaml
@@ -10,7 +10,7 @@ change_type: enhancement
 component: k8s
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Adds k8s.volume.name and k8s.volume.type in the registry
+note: Adds `k8s.volume.name` and `k8s.volume.type` attributes to the registry
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/docs/attributes-registry/k8s.md
+++ b/docs/attributes-registry/k8s.md
@@ -69,7 +69,6 @@ conflict.
 
 | Value                   | Description                                                                                                             | Stability                                                        |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `awsElasticBlockStore`  | An [awsElasticBlockStore](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#awselasticblockstore) volume  | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `configMap`             | A [configMap](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#configmap) volume                         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `downwardAPI`           | A [downwardAPI](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#downwardapi) volume                     | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `emptyDir`              | An [emptyDir](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume                          | ![Experimental](https://img.shields.io/badge/-experimental-blue) |

--- a/docs/attributes-registry/k8s.md
+++ b/docs/attributes-registry/k8s.md
@@ -72,8 +72,6 @@ conflict.
 | `configMap`             | A [configMap](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#configmap) volume                         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `downwardAPI`           | A [downwardAPI](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#downwardapi) volume                     | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `emptyDir`              | An [emptyDir](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume                          | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `gcePersistentDisk`     | A [gcePersistentDisk](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#gcepersistentdisk) volume         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
-| `glusterfs`             | A [glusterfs](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#glusterfs) volume                         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `local`                 | A [local](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#local) volume                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `persistentVolumeClaim` | A [persistentVolumeClaim](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim) volume | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `secret`                | A [secret](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#secret) volume                               | ![Experimental](https://img.shields.io/badge/-experimental-blue) |

--- a/docs/attributes-registry/k8s.md
+++ b/docs/attributes-registry/k8s.md
@@ -39,6 +39,8 @@ Kubernetes resource attributes.
 | `k8s.replicaset.uid`                          | string | The UID of the ReplicaSet.                                                                                                                                       | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`                                                                                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `k8s.statefulset.name`                        | string | The name of the StatefulSet.                                                                                                                                     | `opentelemetry`                                                                                                                           | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `k8s.statefulset.uid`                         | string | The UID of the StatefulSet.                                                                                                                                      | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`                                                                                                    | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `k8s.volume.name`                             | string | The name of the K8s volume.                                                                                                                                      | `volume0`                                                                                                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `k8s.volume.type`                             | string | The type of the K8s volume.                                                                                                                                      | `emptyDir`; `persistentVolumeClaim`                                                                                                       | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 **[1]:** K8s doesn't have support for obtaining a cluster ID. If this is ever
 added, we will recommend collecting the `k8s.cluster.uid` through the
@@ -62,6 +64,20 @@ Which states:
 
 Therefore, UIDs between clusters should be extremely unlikely to
 conflict.
+
+`k8s.volume.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value                   | Description                                                                                                             | Stability                                                        |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `awsElasticBlockStore`  | An [awsElasticBlockStore](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#awselasticblockstore) volume  | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `configMap`             | A [configMap](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#configmap) volume                         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `downwardAPI`           | A [downwardAPI](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#downwardapi) volume                     | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `emptyDir`              | An [emptyDir](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume                          | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `gcePersistentDisk`     | A [gcePersistentDisk](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#gcepersistentdisk) volume         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `glusterfs`             | A [glusterfs](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#glusterfs) volume                         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `local`                 | A [local](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#local) volume                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `persistentVolumeClaim` | A [persistentVolumeClaim](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim) volume | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `secret`                | A [secret](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#secret) volume                               | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 ## Deprecated Kubernetes Attributes
 

--- a/model/registry/k8s.yaml
+++ b/model/registry/k8s.yaml
@@ -177,13 +177,13 @@ groups:
         brief: >
           The name of the CronJob.
         examples: ['opentelemetry']
-      - id: volume.name
+      - id: k8s.volume.name
         type: string
         stability: experimental
         brief: >
           The name of the K8s volume.
         examples: [ 'volume0' ]
-      - id: volume.type
+      - id: k8s.volume.type
         stability: experimental
         brief: >
           The type of the K8s volume.

--- a/model/registry/k8s.yaml
+++ b/model/registry/k8s.yaml
@@ -177,3 +177,53 @@ groups:
         brief: >
           The name of the CronJob.
         examples: ['opentelemetry']
+      - id: volume.name
+        type: string
+        stability: experimental
+        brief: >
+          The name of the K8s volume.
+        examples: [ 'volume0' ]
+      - id: volume.type
+        stability: experimental
+        brief: >
+          The type of the K8s volume.
+        examples: [ "emptyDir", "persistentVolumeClaim" ]
+        type:
+          allow_custom_values: true
+          members:
+            - id: persistentvolumeclaim
+              value: 'persistentVolumeClaim'
+              brief: "A [persistentVolumeClaim](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim) volume"
+              stability: experimental
+            - id: configmap
+              value: 'configMap'
+              brief: "A [configMap](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#configmap) volume"
+              stability: experimental
+            - id: downwardapi
+              value: 'downwardAPI'
+              brief: "A [downwardAPI](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#downwardapi) volume"
+              stability: experimental
+            - id: emptydir
+              value: 'emptyDir'
+              brief: "An [emptyDir](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume"
+              stability: experimental
+            - id: secret
+              value: 'secret'
+              brief: "A [secret](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#secret) volume"
+              stability: experimental
+            - id: local
+              value: 'local'
+              brief: "A [local](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#local) volume"
+              stability: experimental
+            - id: awselasticblockstore
+              value: 'awsElasticBlockStore'
+              brief: "An [awsElasticBlockStore](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#awselasticblockstore) volume"
+              stability: experimental
+            - id: gcepersistentdisk
+              value: 'gcePersistentDisk'
+              brief: "A [gcePersistentDisk](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#gcepersistentdisk) volume"
+              stability: experimental
+            - id: glusterfs
+              value: 'glusterfs'
+              brief: "A [glusterfs](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#glusterfs) volume"
+              stability: experimental

--- a/model/registry/k8s.yaml
+++ b/model/registry/k8s.yaml
@@ -189,21 +189,20 @@ groups:
           The type of the K8s volume.
         examples: [ "emptyDir", "persistentVolumeClaim" ]
         type:
-          allow_custom_values: true
           members:
-            - id: persistentvolumeclaim
+            - id: persistent_volume_claim
               value: 'persistentVolumeClaim'
               brief: "A [persistentVolumeClaim](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim) volume"
               stability: experimental
-            - id: configmap
+            - id: config_map
               value: 'configMap'
               brief: "A [configMap](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#configmap) volume"
               stability: experimental
-            - id: downwardapi
+            - id: downward_api
               value: 'downwardAPI'
               brief: "A [downwardAPI](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#downwardapi) volume"
               stability: experimental
-            - id: emptydir
+            - id: empty_dir
               value: 'emptyDir'
               brief: "An [emptyDir](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume"
               stability: experimental
@@ -215,11 +214,7 @@ groups:
               value: 'local'
               brief: "A [local](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#local) volume"
               stability: experimental
-            - id: awselasticblockstore
-              value: 'awsElasticBlockStore'
-              brief: "An [awsElasticBlockStore](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#awselasticblockstore) volume"
-              stability: experimental
-            - id: gcepersistentdisk
+            - id: gce_persistent_disk
               value: 'gcePersistentDisk'
               brief: "A [gcePersistentDisk](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#gcepersistentdisk) volume"
               stability: experimental

--- a/model/registry/k8s.yaml
+++ b/model/registry/k8s.yaml
@@ -214,11 +214,3 @@ groups:
               value: 'local'
               brief: "A [local](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#local) volume"
               stability: experimental
-            - id: gce_persistent_disk
-              value: 'gcePersistentDisk'
-              brief: "A [gcePersistentDisk](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#gcepersistentdisk) volume"
-              stability: experimental
-            - id: glusterfs
-              value: 'glusterfs'
-              brief: "A [glusterfs](https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#glusterfs) volume"
-              stability: experimental

--- a/model/resource/k8s.yaml
+++ b/model/resource/k8s.yaml
@@ -89,3 +89,12 @@ groups:
     attributes:
       - ref: k8s.cronjob.uid
       - ref: k8s.cronjob.name
+
+  - id: k8s.volume
+    prefix: k8s.volume
+    type: resource
+    brief: >
+      A Kubernetes Volume.
+    attributes:
+      - ref: k8s.volume.name
+      - ref: k8s.volume.type

--- a/model/resource/k8s.yaml
+++ b/model/resource/k8s.yaml
@@ -89,12 +89,3 @@ groups:
     attributes:
       - ref: k8s.cronjob.uid
       - ref: k8s.cronjob.name
-
-  - id: k8s.volume
-    prefix: k8s.volume
-    type: resource
-    brief: >
-      A Kubernetes Volume.
-    attributes:
-      - ref: k8s.volume.name
-      - ref: k8s.volume.type


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/1164

## Changes

Please provide a brief description of the changes here.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

Add k8s.volume.{name,type} attributes.

From https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.102.0/receiver/kubeletstatsreceiver/internal/kubelet/conventions.go#L7

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
