### PR TITLE
Add semconv-event-approvers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,7 @@
 /model/logs/                        @open-telemetry/specs-semconv-approvers @tigrannajaryan
 /docs/exceptions/exceptions-logs.md       @open-telemetry/specs-semconv-approvers @tigrannajaryan
 /docs/feature-flags/feature-flags-logs.md @open-telemetry/specs-semconv-approvers @tigrannajaryan
-/docs/general/events-general.md           @open-telemetry/specs-semconv-approvers @tigrannajaryan
+/docs/general/events-general.md           @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-event-approvers @tigrannajaryan
 /docs/general/logs-general.md             @open-telemetry/specs-semconv-approvers @tigrannajaryan
 /docs/logs/                               @open-telemetry/specs-semconv-approvers @tigrannajaryan
 


### PR DESCRIPTION
Part of #1177

cc @open-telemetry/semconv-event-approvers

@open-telemetry/specs-semconv-maintainers can you grant @open-telemetry/semconv-event-approvers write permission to this repository before merging this? thanks