### PR TITLE
[chore] update scripts to detect macos or linux for GNU sed usage

### DIFF
--- a/.github/workflows/scripts/prepare-new-issue.sh
+++ b/.github/workflows/scripts/prepare-new-issue.sh
@@ -15,6 +15,14 @@
 
 set -euo pipefail
 
+OS=$(uname | tr '[:upper:]' '[:lower:]')
+
+if [[ "${OS}" == "darwin" ]]; then
+  SED="gsed"
+else
+  SED="sed"
+fi
+
 if [[ -z "${ISSUE:-}" || -z "${BODY:-}" || -z "${OPENER:-}" ]]; then
   echo "Missing one of ISSUE, BODY, or OPENER, please ensure all are set."
   exit 0
@@ -25,7 +33,7 @@ AREAS_SECTION_START=$( (echo "${BODY}" | grep -n '### Area(s)' | awk '{ print $1
 BODY_AREAS=""
 
 if [[ "${AREAS_SECTION_START}" != '-1' ]]; then
-  BODY_AREAS=$(echo "${BODY}" | sed -n $((AREAS_SECTION_START+2))p)
+    BODY_AREAS=$(echo "${BODY}" | "${SED}" -n $((AREAS_SECTION_START+2))p)
 fi
 
 for AREA in ${BODY_AREAS}; do

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ package-lock.json
 
 # Python
 venv
+
+# Brew package lock
+Brewfile.lock.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew "gsed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,6 @@ environment configured:
 
   ```bash
   brew bundle
-
   ```
 
 ### 1. Modify the YAML model

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,14 @@ environment configured:
   npm install
   ```
 
+- If on MacOs, ensure you have `gsed` (GNU Sed) installed. If you have [HomeBrew](https://brew.sh)
+  installed, then you can run the following command to install GSED.
+
+  ```bash
+  brew bundle
+
+  ```
+
 ### 1. Modify the YAML model
 
 Refer to the

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@
 ALL_DOCS := $(shell find . -type f -name '*.md' -not -path './.github/*' -not -path './node_modules/*' | sort)
 PWD := $(shell pwd)
 
+# Determine OS & Arch for specific OS only tools on Unix based systems
+OS := $(shell uname | tr '[:upper:]' '[:lower:]')
+ifeq ($(OS),darwin)
+	SED := gsed
+else
+	SED := sed
+endif
+
 TOOLS_DIR := ./internal/tools
 
 MISSPELL_BINARY=bin/misspell
@@ -151,7 +159,7 @@ table-check:
 #
 # .. which is why some additional processing is required to extract the
 # latest version number and strip off the "v" prefix.
-LATEST_RELEASED_SEMCONV_VERSION := $(shell git ls-remote --tags https://github.com/open-telemetry/semantic-conventions.git | cut -f 2 | sort --reverse | head -n 1 | tr '/' ' ' | cut -d ' ' -f 3 | sed 's/v//g')
+LATEST_RELEASED_SEMCONV_VERSION := $(shell git ls-remote --tags https://github.com/open-telemetry/semantic-conventions.git | cut -f 2 | sort --reverse | head -n 1 | tr '/' ' ' | cut -d ' ' -f 3 | $(SED) 's/v//g')
 .PHONY: compatibility-check
 compatibility-check:
 	docker run --rm -v $(PWD)/model:/source -v $(PWD)/docs:/spec --pull=always \

--- a/internal/tools/scripts/update-issue-template-areas.sh
+++ b/internal/tools/scripts/update-issue-template-areas.sh
@@ -11,6 +11,14 @@
 
 set -euo pipefail
 
+OS=$(uname | tr '[:upper:]' '[:lower:]')
+
+if [[ "${OS}" == "darwin" ]]; then
+  SED="gsed"
+else
+  SED="sed"
+fi
+
 CUR_DIRECTORY=$(dirname "$0")
 REPO_DIR="$( cd "$CUR_DIRECTORY/../../../" && pwd )"
 GITHUB_DIR="$( cd "$REPO_DIR/.github/" && pwd )"
@@ -37,7 +45,7 @@ echo -e "The replacement text will be:"
 echo -e "---------------------------------------------\n"
 echo -e $replacement
 
-find ${TEMPLATES_DIR} -type f -name '*.yaml'  -print0 | xargs -0 sed -i "/$START_AREA_LIST/,/$END_AREA_LIST/c\\$replacement"
+find ${TEMPLATES_DIR} -type f -name '*.yaml'  -print0 | xargs -0 ${SED} -i "/$START_AREA_LIST/,/$END_AREA_LIST/c\\$replacement"
 
 echo -e "\nISSUE_TEMPLATES updated successfully"
 echo -e "---------------------------------------------"


### PR DESCRIPTION
## Changes

Adding some basic OS detection in scripts and `make` due to the difference between `sed` on MacOs and Linux. Namely, `gsed` (GNU Sed) will be used on MacOs. The contributing guide documents the install under pre-reqs and gives the `brew bundle` command as an optional way to install `gsed` on Mac. This is simply a quality of life improvement for those on Mac.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
