### PR TITLE
[chore] Fix outdated registry markdown

### DIFF
--- a/docs/attributes-registry/tls.md
+++ b/docs/attributes-registry/tls.md
@@ -6,8 +6,8 @@
 
 # TLS
 
-- [Tls](#tls-attributes)
-- [Tls Deprecated](#tls-deprecated-attributes)
+- [TLS Attributes](#tls-attributes)
+- [TLS Deprecated Attributes](#tls-deprecated-attributes)
 
 ## TLS Attributes
 


### PR DESCRIPTION
Somehow https://github.com/open-telemetry/semantic-conventions/pull/1216 was merged even with the registry check failing 🤔 

This fixes it.