### PR TITLE
Check attribute/metric/event name format

### DIFF
--- a/.chloggen/1302.yaml
+++ b/.chloggen/1302.yaml
@@ -1,4 +1,4 @@
 change_type: enhancement
 component: docs
-note: Add note on tooling limitations for attribute names and enforce attribute name format and uniqueness.
+note: Add note on tooling limitations for attribute names and enforce name format.
 issues: [1124]

--- a/.chloggen/1302.yaml
+++ b/.chloggen/1302.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: docs
+note: Add note on tooling limitations for attribute names and enforce attribute name format and uniqueness.
+issues: [1124]

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,7 @@ check-policies:
 test-policies:
 	docker run --rm -v $(PWD)/policies:/policies -v $(PWD)/policies_test:/policies_test \
 	${OPA_CONTAINER} test \
+    --var-values \
 	--explain fails \
 	/policies \
 	/policies_test

--- a/docs/general/attribute-naming.md
+++ b/docs/general/attribute-naming.md
@@ -116,6 +116,12 @@ denote old attribute names in rename operations).
   the following Unicode code points: Latin alphabet, Numeric, Underscore, Dot
   (as namespace delimiter).
 
+> Note:
+> Semantic Conventions tooling limits names to lowercase
+> Latin alphabet, Numeric, Underscore, Dot (as namespace delimiter).
+> Names must start with a letter, end with an alphanumeric character, and must not
+> contain two or more consecutive delimiters (Underscore or Dot).
+
 ## Recommendations for Application Developers
 
 As an application developer when you need to record an attribute first consult

--- a/policies/attribute_name_collisions.rego
+++ b/policies/attribute_name_collisions.rego
@@ -1,4 +1,4 @@
-package attribute_name_collisions
+package after_resolution
 
 import rego.v1
 

--- a/policies/attribute_name_collisions.rego
+++ b/policies/attribute_name_collisions.rego
@@ -39,7 +39,7 @@ deny contains attr_registry_collision(description, name) if {
     ]
     count(collisions) > 0
     # TODO (https://github.com/open-telemetry/weaver/issues/279): provide other violation properties once weaver supports it.
-    description := sprintf("Attribute '%s' is used as a namespace in '%s'.", [name, collisions])
+    description := sprintf("Attribute '%s' name is used as a namespace in the following attributes '%s'.", [name, collisions])
 }
 
 # check that attribute is not defined or referenced more than once within the same group

--- a/policies/attribute_name_collisions.rego
+++ b/policies/attribute_name_collisions.rego
@@ -1,4 +1,4 @@
-package after_resolution
+package attribute_name_collisions
 
 import rego.v1
 

--- a/policies/attribute_name_collisions.rego
+++ b/policies/attribute_name_collisions.rego
@@ -43,7 +43,7 @@ deny contains attr_registry_collision(description, name) if {
 }
 
 # check that attribute is not defined or referenced more than once within the same group
-deny contains attr_registry_collision(description, name) {
+deny contains attr_registry_collision(description, name) if {
     group := input.groups[_]
     attr := group.attributes[_]
     name := attr.name

--- a/policies/attribute_name_collisions_test.rego
+++ b/policies/attribute_name_collisions_test.rego
@@ -1,6 +1,4 @@
-package attribute_name_collisions_test
-
-import data.attribute_name_collisions
+package after_resolution
 import future.keywords
 
 test_fails_on_const_name_collision if {
@@ -9,7 +7,7 @@ test_fails_on_const_name_collision if {
         {"id": "test2", "attributes": [{"name": "foo.bar_baz"}]}
     ]}
     # each attribute counts as a collision, so there are 2 collisions
-    count(attribute_name_collisions.deny) == 2 with input as collision
+    count(deny) == 2 with input as collision
 }
 
 test_fails_on_namespace_collision if {
@@ -17,5 +15,5 @@ test_fails_on_namespace_collision if {
         {"id": "test1", "attributes": [{"name": "foo.bar.baz"}]},
         {"id": "test2", "attributes": [{"name": "foo.bar"}]}
     ]}
-    count(attribute_name_collisions.deny) == 1 with input as collision
+    count(deny) == 1 with input as collision
 }

--- a/policies/attribute_name_collisions_test.rego
+++ b/policies/attribute_name_collisions_test.rego
@@ -1,0 +1,21 @@
+package attribute_name_collisions_test
+
+import data.attribute_name_collisions
+import future.keywords
+
+test_fails_on_const_name_collision if {
+    collision := {"groups": [
+        {"id": "test1", "attributes": [{"name": "foo.bar.baz"}]},
+        {"id": "test2", "attributes": [{"name": "foo.bar_baz"}]}
+    ]}
+    # each attribute counts as a collision, so there are 2 collisions
+    count(attribute_name_collisions.deny) == 2 with input as collision
+}
+
+test_fails_on_namespace_collision if {
+    collision := {"groups": [
+        {"id": "test1", "attributes": [{"name": "foo.bar.baz"}]},
+        {"id": "test2", "attributes": [{"name": "foo.bar"}]}
+    ]}
+    count(attribute_name_collisions.deny) == 1 with input as collision
+}

--- a/policies/yaml_schema.rego
+++ b/policies/yaml_schema.rego
@@ -1,4 +1,4 @@
-package yaml_schema
+package before_resolution
 
 # checks attribute name format
 deny[yaml_schema_violation(description, group.id, name)] {

--- a/policies/yaml_schema.rego
+++ b/policies/yaml_schema.rego
@@ -1,10 +1,10 @@
-package before_resolution
+package yaml_schema
 
 # checks attribute name format
 deny[yaml_schema_violation(description, group.id, name)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    name := get_attribute_name(attr, group)
+    name := attr.id
 
     not regex.match(name_regex, name)
 
@@ -38,7 +38,7 @@ deny[yaml_schema_violation(description, group.id, name)] {
 deny[yaml_schema_violation(description, group.id, attr_name)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    attr_name := get_attribute_name(attr, group)
+    attr_name := attr.id
     name := attr.type.members[_].id
 
     not regex.match(name_regex, name)
@@ -61,10 +61,3 @@ yaml_schema_violation(description, group, attr) = violation {
 name_regex := "^[a-z][a-z0-9]*([._][a-z0-9]+)*$"
 
 invalid_name_helper := "must consist of lowercase alphanumeric characters separated by '_' and '.'"
-
-get_attribute_name(attr, group) = name {
-    full_name = concat(".", [group.prefix, attr.id])
-
-    # if there was no prefix, we have a leading dot
-    name := trim(full_name, ".")
-}

--- a/policies/yaml_schema.rego
+++ b/policies/yaml_schema.rego
@@ -46,6 +46,17 @@ deny[yaml_schema_violation(description, group.id, attr_name)] {
     description := sprintf("Member id '%s' on attribute '%s' is invalid. Member id %s'", [name, attr_name, invalid_name_helper])
 }
 
+# check that attribute is fully qualified with their id, prefix is no longer supported
+deny[yaml_schema_violation(description, group.id, "")] {
+    group := input.groups[_]
+
+    group.prefix != null
+    group.prefix != ""
+
+    # TODO (https://github.com/open-telemetry/weaver/issues/279): provide other violation properties once weaver supports it.
+    description := sprintf("Group '%s' uses prefix '%s'. All attribute should be fully qualified with their id, prefix is no longer supported.", [group.id, group.prefix])
+}
+
 yaml_schema_violation(description, group, attr) = violation {
     violation := {
         "id": description,

--- a/policies/yaml_schema.rego
+++ b/policies/yaml_schema.rego
@@ -1,5 +1,51 @@
 package before_resolution
 
+# checks attribute name format
+deny[yaml_schema_violation(description, group.id, name)] {
+    group := input.groups[_]
+    attr := group.attributes[_]
+    name := get_attribute_name(attr, group)
+
+    not regex.match(name_regex, name)
+
+    description := sprintf("Attribute name '%s' is invalid. Attribute name %s", [name, invalid_name_helper])
+}
+
+# checks metric name format
+deny[yaml_schema_violation(description, group.id, name)] {
+    group := input.groups[_]
+    name := group.metric_name
+
+    name != null
+    not regex.match(name_regex, name)
+
+    description := sprintf("Metric name '%s' is invalid. Metric name %s'", [name, invalid_name_helper])
+}
+
+# checks event name format
+deny[yaml_schema_violation(description, group.id, name)] {
+    group := input.groups[_]
+    group.type == "event"
+    name := group.name
+
+    name != null
+    not regex.match(name_regex, name)
+
+    description := sprintf("Event name '%s' is invalid. Event name %s'", [name, invalid_name_helper])
+}
+
+# checks attribute member id format
+deny[yaml_schema_violation(description, group.id, attr_name)] {
+    group := input.groups[_]
+    attr := group.attributes[_]
+    attr_name := get_attribute_name(attr, group)
+    name := attr.type.members[_].id
+
+    not regex.match(name_regex, name)
+
+    description := sprintf("Member id '%s' on attribute '%s' is invalid. Member id %s'", [name, attr_name, invalid_name_helper])
+}
+
 yaml_schema_violation(description, group, attr) = violation {
     violation := {
         "id": description,
@@ -10,12 +56,15 @@ yaml_schema_violation(description, group, attr) = violation {
     }
 }
 
-deny[yaml_schema_violation(description, group.id, "")] {
-    group := input.groups[_]
+# not valid: '1foo.bar', 'foo.bar.', 'foo.bar_', 'foo..bar', 'foo._bar' ...
+# valid: 'foo.bar', 'foo.1bar', 'foo.1_bar'
+name_regex := "^[a-z][a-z0-9]*([._][a-z0-9]+)*$"
 
-    group.prefix != null
-    group.prefix != ""
+invalid_name_helper := "must consist of lowercase alphanumeric characters separated by '_' and '.'"
 
-    # TODO (https://github.com/open-telemetry/weaver/issues/279): provide other violation properties once weaver supports it.
-    description := sprintf("Group '%s' uses prefix '%s'. All attribute should be fully qualified with their id, prefix is no longer supported.", [group.id, group.prefix])
+get_attribute_name(attr, group) = name {
+    full_name = concat(".", [group.prefix, attr.id])
+
+    # if there was no prefix, we have a leading dot
+    name := trim(full_name, ".")
 }

--- a/policies/yaml_schema_test.rego
+++ b/policies/yaml_schema_test.rego
@@ -1,0 +1,64 @@
+package yaml_schema_test
+
+import data.yaml_schema
+import future.keywords
+
+test_fails_on_invalid_attribute_name if {
+    every name in invalid_names {
+        count(yaml_schema.deny) == 1 with input as {"groups": create_attribute_group(name)}
+    }
+}
+
+test_fails_on_invalid_metric_name if {
+    every name in invalid_names {
+        count(yaml_schema.deny) == 1 with input as {"groups": create_metric(name)}
+    }
+}
+
+test_fails_on_invalid_event_name if {
+    every name in invalid_names {
+        count(yaml_schema.deny) == 1 with input as {"groups": create_event(name)}
+    }
+}
+
+test_passes_on_valid_names if {
+    every name in valid_names {
+        count(yaml_schema.deny) == 0 with input as {"groups": create_attribute_group(name)}
+        count(yaml_schema.deny) == 0 with input as {"groups": create_metric(name)}
+        count(yaml_schema.deny) == 0 with input as {"groups": create_event(name)}
+    }
+}
+
+create_attribute_group(attr) = json {
+    json := [{"id": "yaml_schema.test", "attributes": [{"id": attr}]}]
+}
+
+create_metric(name) = json {
+    json := [{"id": "yaml_schema.test", "type": "metric", "metric_name": name}]
+}
+
+create_event(name) = json {
+    json := [{"id": "yaml_schema.test", "type": "event", "name": name}]
+}
+
+invalid_names := [
+    "1foo.bar",
+    "_foo.bar",
+    ".foo.bar",
+    "foo.bar_",
+    "foo.bar.",
+    "foo..bar",
+    "foo._bar",
+    "foo__bar",
+    "foo_.bar",
+    "foo,bar",
+    "fü.bär",
+]
+
+valid_names := [
+    "foo.bar",
+    "foo.1bar",
+    "foo_1.bar",
+    "foo.bar.baz",
+    "foo.bar_baz",
+]

--- a/policies/yaml_schema_test.rego
+++ b/policies/yaml_schema_test.rego
@@ -29,6 +29,10 @@ test_passes_on_valid_names if {
     }
 }
 
+test_fails_if_prefix_is_present if {
+    count(yaml_schema.deny) == 1 with input as {"groups": [{"id": "test", "prefix": "foo"}]}
+}
+
 create_attribute_group(attr) = json {
     json := [{"id": "yaml_schema.test", "attributes": [{"id": attr}]}]
 }

--- a/policies/yaml_schema_test.rego
+++ b/policies/yaml_schema_test.rego
@@ -1,36 +1,35 @@
-package yaml_schema_test
+package before_resolution
 
-import data.yaml_schema
 import future.keywords
 
 test_fails_on_invalid_attribute_name if {
     every name in invalid_names {
-        count(yaml_schema.deny) == 1 with input as {"groups": create_attribute_group(name)}
+        count(deny) == 1 with input as {"groups": create_attribute_group(name)}
     }
 }
 
 test_fails_on_invalid_metric_name if {
     every name in invalid_names {
-        count(yaml_schema.deny) == 1 with input as {"groups": create_metric(name)}
+        count(deny) == 1 with input as {"groups": create_metric(name)}
     }
 }
 
 test_fails_on_invalid_event_name if {
     every name in invalid_names {
-        count(yaml_schema.deny) == 1 with input as {"groups": create_event(name)}
+        count(deny) == 1 with input as {"groups": create_event(name)}
     }
 }
 
 test_passes_on_valid_names if {
     every name in valid_names {
-        count(yaml_schema.deny) == 0 with input as {"groups": create_attribute_group(name)}
-        count(yaml_schema.deny) == 0 with input as {"groups": create_metric(name)}
-        count(yaml_schema.deny) == 0 with input as {"groups": create_event(name)}
+        count(deny) == 0 with input as {"groups": create_attribute_group(name)}
+        count(deny) == 0 with input as {"groups": create_metric(name)}
+        count(deny) == 0 with input as {"groups": create_event(name)}
     }
 }
 
 test_fails_if_prefix_is_present if {
-    count(yaml_schema.deny) == 1 with input as {"groups": [{"id": "test", "prefix": "foo"}]}
+    count(deny) == 1 with input as {"groups": [{"id": "test", "prefix": "foo"}]}
 }
 
 create_attribute_group(attr) = json {


### PR DESCRIPTION
Fixes open-telemetry/semantic-conventions#1124

## Changes

- adds checks for attribute, metrics, and event name format 
- adds a note to the attribute naming about current tooling limitations

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
