### PR TITLE
Clarification to db.namespace when a query explicitly targets a specific database

### DIFF
--- a/.chloggen/dbnamespace_clarification.yaml
+++ b/.chloggen/dbnamespace_clarification.yaml
@@ -10,7 +10,7 @@ change_type: enhancement
 component: db
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note:  Clarify `{db.namespace}` when a query explicitly targets a specific database.
+note: Clarify `{db.namespace}` when a query explicitly targets a specific database.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/.chloggen/dbnamespace_clarification.yaml
+++ b/.chloggen/dbnamespace_clarification.yaml
@@ -14,7 +14,7 @@ note:  Clarify `{db.namespace}` when a query explicitly targets a specific datab
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.
-issues: []
+issues: [1312]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/dbnamespace_clarification.yaml
+++ b/.chloggen/dbnamespace_clarification.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: db
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:  Clarify `{db.namespace}` when a query explicitly targets a specific database.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/database/sql.md
+++ b/docs/database/sql.md
@@ -78,6 +78,9 @@ in the connection string and keep track of the currently selected database name.
 
 For commands that switch the database, this SHOULD be set to the target database (even if the command fails).
 
+In case a specific query explicitly targets a database different from the one used by the connection,
+the db.namespace should still be the one from the connection.
+
 If instrumentation cannot reliably determine the current database name, it SHOULD NOT set `db.namespace`.
 
 **[4]:** This SHOULD be the SQL command such as `SELECT`, `INSERT`, `UPDATE`, `CREATE`, `DROP`.

--- a/model/trace/database.yaml
+++ b/model/trace/database.yaml
@@ -331,6 +331,9 @@ groups:
 
           For commands that switch the database, this SHOULD be set to the target database (even if the command fails).
 
+          In case a specific query explicitly targets a database different from the one used by the connection,
+          the db.namespace should still be the one from the connection.
+
           If instrumentation cannot reliably determine the current database name, it SHOULD NOT set `db.namespace`.
   - id: db.cosmosdb
     type: span


### PR DESCRIPTION
## Changes

From today's DB Stability WG meeting.

We also discussed that the spec should say that instrumentation should best effort keep track of the currently selected database. I feel this is already very well covered by the current text above my new line, so I did not add anything to this. This is what we have and I think this is captures what we meant in the meeting:
>   The database name can usually be obtained with database driver API such as  [JDBC `Connection.getCatalog()`](https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#getCatalog--) or [.NET `SqlConnection.Database`](https://learn.microsoft.com/dotnet/api/system.data.sqlclient.sqlconnection.database).

> Some database drivers don't detect when the current database is changed (for example, with SQL `USE database` statement). Instrumentations that parse SQL statements MAY use the database name provided in the connection string and keep track of the currently selected database name.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
