### PR TITLE
Add tests for rego policies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,11 @@ check-policies:
 		--diagnostic-format=ansi \
 		--policy=/policies/registry.rego
 
+# Test rego policies
+.PHONY: test-policies
+test-policies:
+	docker run --rm -v $(PWD)/policies:/policies openpolicyagent/opa:0.67.1 test --explain fails /policies
+
 # Generate markdown tables from YAML definitions
 .PHONY: table-generation
 table-generation:

--- a/policies/registry_test.rego
+++ b/policies/registry_test.rego
@@ -1,0 +1,24 @@
+package before_resolution_test
+
+import data.before_resolution
+
+import future.keywords.if
+
+test_registry_attribute_groups if {
+	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.test", "type": "foo"}]}
+	count(before_resolution.deny) == 0 with input as {"groups": [{"id": "registry.test", "type": "attribute_group"}]}
+}
+
+test_attribute_ids if {
+	# This requires a prefix for use with opa, but weaver will fill in.
+	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "not_registry", "prefix": "", "attributes": [{"id": "foo"}]}]}
+	count(before_resolution.deny) == 0 with input as {"groups": [
+		{"id": "registry.test", "prefix": "", "attributes": [{"id": "foo"}]},
+		{"id": "not_registry", "prefix": "", "attributes": [{"ref": "foo"}]},
+	]}
+}
+
+test_attribute_refs if {
+	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.foo", "attributes": [{"ref": "foo"}]}]}
+	count(before_resolution.deny) == 0 with input as {"groups": [{"id": "not_registry", "attributes": [{"ref": "foo"}]}]}
+}


### PR DESCRIPTION
Fixes #

## Changes

Adds tests for rego policies.

You can test these via the opa tool, `opa test policies/*.rego` or `make test-policies.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
