### PR TITLE
Proposal for GenAI Security fields

### DIFF
--- a/docs/attributes-registry/gen-ai.md
+++ b/docs/attributes-registry/gen-ai.md
@@ -6,8 +6,10 @@
 
 # Gen AI
 
-- [GenAI Attributes](#genai-attributes)
-- [Deprecated GenAI Attributes](#deprecated-genai-attributes)
+- [Gen AI](#gen-ai)
+  - [GenAI Attributes](#genai-attributes)
+  - [GenAI Security Attributes](#genai-security-attributes)
+  - [Deprecated GenAI Attributes](#deprecated-genai-attributes)
 
 ## GenAI Attributes
 
@@ -72,6 +74,17 @@ If none of these options apply, the `gen_ai.system` SHOULD be set to `_OTHER`.
 | -------- | ------------------------------------------ | ---------------------------------------------------------------- |
 | `input`  | Input tokens (prompt, input, etc.)         | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 | `output` | Output tokens (completion, response, etc.) | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+
+## GenAI Security Attributes
+
+| Attribute                          | Type     | Description                                                                                      | Examples                                                                | Stability                                                        |
+| ---------------------------------- | -------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `gen_ai.policy.name`                | string   | Name of the specific policy that was triggered.                                          | `contentPolicy` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `gen_ai.policy.action`            | string   | Action taken due to a policy violation, such as blocking, alerting, or modifying the content.                                                   | `INTERVENED`                                               | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `gen_ai.policy.confidence`                    | double   | Confidence level in the policy match that triggered the action, quantifying how closely the identified content matched the policy criteria.    | `0.8`       | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `gen_ai.compliance.violation_detected` | boolean   | Indicates if any compliance violation was detected during the interaction.    | `True`;`False`    | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `gen_ai.compliance.violation_code`        | string      | Code identifying the specific compliance rule that was violated.    | `FedRAMP`                                                                   | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `gen_ai.performance.request_size`             | int   | Size of the request payload in bytes.    | `456000`                                                                 | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
 ## Deprecated GenAI Attributes
 

--- a/model/registry/gen-ai.yaml
+++ b/model/registry/gen-ai.yaml
@@ -1,3 +1,4 @@
+// edit this file
 groups:
   - id: registry.gen_ai
     type: attribute_group
@@ -148,3 +149,39 @@ groups:
           If one of the predefined values applies, but specific system uses a different name it's RECOMMENDED to document it in the semantic
           conventions for specific GenAI system and use system-specific name in the instrumentation.
           If a different name is not documented, instrumentation libraries SHOULD use applicable predefined value.
+      - id: gen_ai.policy.name
+        stability: experimental
+        type: string
+        brief: Name of the specific policy that was triggered.
+        note: 
+        examples: contentPolicy
+      - id: gen_ai.policy.action
+        stability: experimental
+        type: string
+        brief: Action taken due to a policy violation, such as blocking, alerting, or modifying the content.
+        note: 
+        examples: INTERVENED
+      - id: gen_ai.policy.confidence
+        stability: experimental
+        type: double
+        brief: Confidence level in the policy match that triggered the action, quantifying how closely the identified content matched the policy criteria.
+        note: 
+        examples: 0.8
+      - id: gen_ai.compliance.violation_detected
+        stability: experimental
+        type: boolean
+        brief: Indicates if any compliance violation was detected during the interaction.
+        note: 
+        examples: True
+      - id: gen_ai.compliance.violation_code
+        stability: experimental
+        type: string
+        brief: Code identifying the specific compliance rule that was violated.
+        note: 
+        examples: FedRAMP
+      - id: gen_ai.performance.request_size
+        stability: experimental
+        type: int
+        brief: Size of the request payload in bytes.
+        note: 
+        examples: 456000


### PR DESCRIPTION
Related to: https://github.com/open-telemetry/semantic-conventions/issues/1034

## Changes

Proposing the following fields that enable security detections to protect LLMs from attacks, misuse (violations, compliance etc.). For example [these detection rules](https://github.com/elastic/detection-rules/tree/main/rules/integrations/aws_bedrock).

```
gen_ai.policy.name	
gen_ai.policy.action
gen_ai.policy.confidence
gen_ai.compliance.violation_detected
gen_ai.compliance.violation_code
gen_ai.performance.request_size
```

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
