### PR TITLE
chore: Remove support for the event `fields` referencing/inheriting definitions from global attributes.

### DIFF
--- a/.chloggen/remove_body_field_ref.yaml
+++ b/.chloggen/remove_body_field_ref.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: event
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove support for the event `fields` supporting referencing / inheriting fields from global attributes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1341]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/general/events.md
+++ b/docs/general/events.md
@@ -101,9 +101,6 @@ Recommendations on using attributes vs. body fields:
   * The _fields_ are unique to the named event (`event.name`) and different events
     may use the same _field_ name to represent different data, due to the unique
     nature of the event.
-* The _fields_ MAY reference / inherit details from the attribute registry
-  attributes and provide additional details specific to the event, including
-  providing an _alias_ (shorter) name for the attribute.
 
 ## External event compatibility
 


### PR DESCRIPTION
Fixes #1341 

## Changes

Removes the option of an event body field to reference / inherit definitions from existing global attribute and providing an optional alias within the event body.

This was discussed during the Event WG Sig meeting on August 9th.
