### PR TITLE
ci: fix makefile docker ownership

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ WEAVER_CONTAINER=$(shell cat dependencies.Dockerfile | awk '$$4=="weaver" {print
 SEMCONVGEN_CONTAINER=$(shell cat dependencies.Dockerfile | awk '$$4=="semconvgen" {print $$2}')
 OPA_CONTAINER=$(shell cat dependencies.Dockerfile | awk '$$4=="opa" {print $$2}')
 
+DOCKER_USER=$(shell id -u):$(shell id -g)
+
 
 # TODO: add `yamllint` step to `all` after making sure it works on Mac.
 .PHONY: all
@@ -114,7 +116,7 @@ yamllint:
 .PHONY: table-generation
 table-generation:
 	docker run --rm \
-		-u $(id -u ${USER}):$(id -g ${USER}) \
+		-u $(DOCKER_USER) \
 		--mount 'type=bind,source=$(PWD)/templates,target=/home/weaver/templates,readonly' \
 		--mount 'type=bind,source=$(PWD)/model,target=/home/weaver/source,readonly' \
 		--mount 'type=bind,source=$(PWD)/docs,target=/home/weaver/target' \
@@ -129,7 +131,7 @@ table-generation:
 .PHONY: attribute-registry-generation
 attribute-registry-generation:
 	docker run --rm \
-		-u $(id -u ${USER}):$(id -g ${USER}) \
+		-u $(DOCKER_USER) \
 		--mount 'type=bind,source=$(PWD)/templates,target=/home/weaver/templates,readonly' \
 		--mount 'type=bind,source=$(PWD)/model,target=/home/weaver/source,readonly' \
 		--mount 'type=bind,source=$(PWD)/docs,target=/home/weaver/target' \
@@ -227,7 +229,7 @@ LATEST_RELEASED_SEMCONV_VERSION := $(shell git ls-remote --tags https://github.c
 .PHONY: check-policies
 check-policies:
 	docker run --rm \
-		-u $(id -u ${USER}):$(id -g ${USER}) \
+		-u $(DOCKER_USER) \
 		--mount 'type=bind,source=$(PWD)/policies,target=/home/weaver/policies,readonly' \
 		--mount 'type=bind,source=$(PWD)/model,target=/home/weaver/source,readonly' \
 		${WEAVER_CONTAINER} registry check \

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,6 @@ LATEST_RELEASED_SEMCONV_VERSION := $(shell git ls-remote --tags https://github.c
 .PHONY: check-policies
 check-policies:
 	docker run --rm \
-		-u $(DOCKER_USER) \
 		--mount 'type=bind,source=$(PWD)/policies,target=/home/weaver/policies,readonly' \
 		--mount 'type=bind,source=$(PWD)/model,target=/home/weaver/source,readonly' \
 		${WEAVER_CONTAINER} registry check \

--- a/dependencies.Dockerfile
+++ b/dependencies.Dockerfile
@@ -6,7 +6,7 @@
 FROM otel/weaver:v0.9.1 AS weaver
 
 # OPA is used to test policies enforced by weaver.
-FROM openpolicyagent/opa:0.67.1 AS opa
+FROM openpolicyagent/opa:0.68.0 AS opa
 
 # Semconv gen is used for backwards compatibility checks.
 # TODO(jsuereth): Remove this when no longer used.


### PR DESCRIPTION
Fix the docker user flag to properly fetch group and user IDs.

Without this, on linux with GNU Make 4, a new registry component will end up throwing an error:
```
[error] Unable to write file "docs/attributes-registry/csi.md":
```
because it writes out as root rather than the current user.