### PR TITLE
ci: sort with dictionary mode for compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -28,8 +28,8 @@ body:
         - area:browser
         - area:cicd
         - area:client
-        - area:cloud
         - area:cloudevents
+        - area:cloud
         - area:code
         - area:container
         - area:cpu

--- a/.github/ISSUE_TEMPLATE/change_proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/change_proposal.yaml
@@ -20,8 +20,8 @@ body:
         - area:browser
         - area:cicd
         - area:client
-        - area:cloud
         - area:cloudevents
+        - area:cloud
         - area:code
         - area:container
         - area:cpu

--- a/.github/ISSUE_TEMPLATE/new-conventions.yaml
+++ b/.github/ISSUE_TEMPLATE/new-conventions.yaml
@@ -29,8 +29,8 @@ body:
         - area:browser
         - area:cicd
         - area:client
-        - area:cloud
         - area:cloudevents
+        - area:cloud
         - area:code
         - area:container
         - area:cpu

--- a/.github/workflows/scripts/get-registry-areas.sh
+++ b/.github/workflows/scripts/get-registry-areas.sh
@@ -9,8 +9,8 @@ CUR_DIRECTORY=$(dirname "$0")
 REPO_DIR="$( cd "$CUR_DIRECTORY/../../../" && pwd )"
 REGISTRY_DIR="$( cd "$REPO_DIR/model/registry" && pwd )"
 
-
-for entry in $(ls $REGISTRY_DIR | egrep '\.yaml$' | sort)
+# Explicitly sort with `-d` (dictionary) so BSD and GNU work alike.
+for entry in $(ls $REGISTRY_DIR | egrep '\.yaml$' | sort -d)
 do
   echo "$entry"
 done


### PR DESCRIPTION
In #1337 I found the sort order to differ between CI and my workstation.

https://github.com/open-telemetry/semantic-conventions/actions/runs/10702984450/job/29674122154?pr=1337 details the difference.

Since BSD, GNU and busybox sort all have a `-d` (dictionary) flag, use that for consistent ordering.