### PR TITLE
Fix typo in `tls.yaml`

### DIFF
--- a/docs/attributes-registry/tls.md
+++ b/docs/attributes-registry/tls.md
@@ -57,6 +57,6 @@ This document defines semantic convention attributes in the TLS namespace.
 
 Describes deprecated `tls` attributes.
 
-| Attribute                | Type   | Description                               | Examples           | Stability                                                                                   |
-| ------------------------ | ------ | ----------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------- |
-| `tls.client.server_name` | string | Deprecated, use `server.address` instead. | `opentelemetry.io` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `server.address`. |
+| Attribute                | Type   | Description                               | Examples           | Stability                                                                                    |
+| ------------------------ | ------ | ----------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------- |
+ | `tls.client.server_name` | string | Deprecated, use `server.address` instead. | `opentelemetry.io` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `server.address`. |

--- a/docs/attributes-registry/tls.md
+++ b/docs/attributes-registry/tls.md
@@ -59,4 +59,4 @@ Describes deprecated `tls` attributes.
 
 | Attribute                | Type   | Description                               | Examples           | Stability                                                                                    |
 | ------------------------ | ------ | ----------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------- |
- | `tls.client.server_name` | string | Deprecated, use `server.address` instead. | `opentelemetry.io` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `server.address`. |
+| `tls.client.server_name` | string | Deprecated, use `server.address` instead. | `opentelemetry.io` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `server.address`. |

--- a/docs/attributes-registry/tls.md
+++ b/docs/attributes-registry/tls.md
@@ -59,4 +59,4 @@ Describes deprecated `tls` attributes.
 
 | Attribute                | Type   | Description                               | Examples           | Stability                                                                                   |
 | ------------------------ | ------ | ----------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------- |
-| `tls.client.server_name` | string | Deprecated, use `server.address` instead. | `opentelemetry.io` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `server.address. |
+| `tls.client.server_name` | string | Deprecated, use `server.address` instead. | `opentelemetry.io` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `server.address`. |

--- a/model/registry/deprecated/tls.yaml
+++ b/model/registry/deprecated/tls.yaml
@@ -6,6 +6,6 @@ groups:
       - id: tls.client.server_name
         type: string
         stability: experimental
-        deprecated: "Replaced by `server.address."
+        deprecated: "Replaced by `server.address`."
         brief: "Deprecated, use `server.address` instead."
         examples: ["opentelemetry.io"]


### PR DESCRIPTION
Noticed reviewing https://github.com/open-telemetry/semantic-conventions-java/pull/70