### PR TITLE
Escape square brackets that don’t represent a link

### DIFF
--- a/model/go/metrics.yaml
+++ b/model/go/metrics.yaml
@@ -89,7 +89,7 @@ groups:
     metric_name: go.config.gogc
     brief: "Heap size target percentage configured by the user, otherwise 100."
     note: >
-      The value range is [0.0,100.0].
+      The value range is \[0.0,100.0\].
       Computed from `/gc/gogc:percent`.
     instrument: updowncounter
     unit: "%"

--- a/model/jvm/metrics-experimental.yaml
+++ b/model/jvm/metrics-experimental.yaml
@@ -14,7 +14,7 @@ groups:
     stability: experimental
     brief: "Recent CPU utilization for the whole system as reported by the JVM."
     note: >
-      The value range is [0.0,1.0].
+      The value range is \[0.0,1.0\].
       This utilization is not defined as being for the specific interval since last measurement
       (unlike `system.cpu.utilization`).
       [Reference](https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getCpuLoad()).
@@ -27,7 +27,7 @@ groups:
     stability: experimental
     brief: "Average CPU load of the whole system for the last minute as reported by the JVM."
     note: >
-      The value range is [0,n], where n is the number of CPU cores - or a negative number if the value is not available.
+      The value range is \[0,n\], where n is the number of CPU cores - or a negative number if the value is not available.
       This utilization is not defined as being for the specific interval since last measurement
       (unlike `system.cpu.utilization`).
       [Reference](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/OperatingSystemMXBean.html#getSystemLoadAverage()).

--- a/model/jvm/metrics.yaml
+++ b/model/jvm/metrics.yaml
@@ -116,7 +116,7 @@ groups:
     metric_name: jvm.cpu.recent_utilization
     brief: "Recent CPU utilization for the process as reported by the JVM."
     note: >
-      The value range is [0.0,1.0].
+      The value range is \[0.0,1.0\].
       This utilization is not defined as being for the specific interval since last measurement
       (unlike `system.cpu.utilization`).
       [Reference](https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getProcessCpuLoad()).

--- a/model/nodejs/metrics.yaml
+++ b/model/nodejs/metrics.yaml
@@ -77,7 +77,7 @@ groups:
     unit: "1"
     stability: experimental
     note: >
-      The value range is [0.0, 1.0] and can be retrieved from
+      The value range is \[0.0, 1.0\] and can be retrieved from
       [`performance.eventLoopUtilization([utilization1[, utilization2]])`](https://nodejs.org/api/perf_hooks.html#performanceeventlooputilizationutilization1-utilization2)
 
   - id: metric.nodejs.eventloop.time


### PR DESCRIPTION
Square brackets are often used to specify a range in metrics. However, without escaping them, Markdown-based documentation interprets these as links. This PR addresses the issue by escaping such square brackets, ensuring they are displayed correctly as plain text. 

This change is similar to [PR #1416](https://github.com/open-telemetry/semantic-conventions/pull/1416).