### PR TITLE
Fix failing resource back compat checks

### DIFF
--- a/policies/compatibility.rego
+++ b/policies/compatibility.rego
@@ -386,7 +386,7 @@ deny contains back_comp_violation(description, group_id, "") if {
     resource.stability == "stable"
     some nresource in registry_resources
     resource.name == nresource.name
-    nresource.stability == "stable"
+    nresource.stability == "stable" # remove after https://github.com/open-telemetry/semantic-conventions/pull/1423 is merged
 
     baseline_attributes := { attr.name |
         some attr in resource.attributes

--- a/policies/compatibility.rego
+++ b/policies/compatibility.rego
@@ -160,7 +160,7 @@ deny contains back_comp_violation(description, group_id, attr.name) if {
      some nmember in nattr.type.members
      member.id == nmember.id
 
-     # Enforce the policy    
+     # Enforce the policy
      member.stability == "stable"
      nmember.stability != "stable"
 
@@ -184,7 +184,7 @@ deny contains back_comp_violation(description, group_id, attr.name) if {
      some nmember in nattr.type.members
      member.id == nmember.id
 
-     # Enforce the policy    
+     # Enforce the policy
      member.value != nmember.value
 
      # Generate human readable error.
@@ -294,7 +294,7 @@ deny contains back_comp_violation(description, group_id, "") if {
     metric.stability == "stable"
     some nmetric in registry_metrics
     metric.metric_name = nmetric.metric_name
-    
+
     baseline_attributes := { attr.name |
         some attr in metric.attributes
         not is_opt_in(attr)
@@ -321,7 +321,7 @@ deny contains back_comp_violation(description, group_id, "") if {
     metric.stability == "stable"
     some nmetric in registry_metrics
     metric.metric_name = nmetric.metric_name
-    
+
     baseline_attributes := { attr.name |
         some attr in metric.attributes
         not is_opt_in(attr)
@@ -385,8 +385,9 @@ deny contains back_comp_violation(description, group_id, "") if {
     some resource in baseline_resources
     resource.stability == "stable"
     some nresource in registry_resources
-    resource.name = nresource.name
-    
+    resource.name == nresource.name
+    nresource.stability == "stable"
+
     baseline_attributes := { attr.name |
         some attr in resource.attributes
         not is_opt_in(attr)


### PR DESCRIPTION
Back-compat checks are failing since 1.28.0 was released with 
```
Violation: Resource 'service' cannot remove required/recommended attributes (missing '{"service.name", "service.version"}')
  - Category         : backward_compatibility
  - Type             : semconv_attribute
  - SemConv group    : service
  - SemConv attribute: 
  - Provenance: /home/weaver/source

Violation: Resource 'telemetry.sdk' cannot remove required/recommended attributes (missing '{"telemetry.sdk.language", "telemetry.sdk.name", "telemetry.sdk.version"}')
  - Category         : backward_compatibility
  - Type             : semconv_attribute
  - SemConv group    : telemetry.sdk
  - SemConv attribute: 
  - Provenance: /home/weaver/source
```

E.g. here https://github.com/open-telemetry/semantic-conventions/pull/1454

It happens because we marked `service` and `telemetry.sdk`  groups as stable, but there are two groups with the same name and they are being compared against each other. 

This is being fixed in  https://github.com/open-telemetry/semantic-conventions/pull/1423, in the meantime we need to compare stable groups.