### PR TITLE
db: OTEL_SEMCONV_STABILITY_OPT_IN is important instrumentation libraries supporting v1.25.0 and prior

### DIFF
--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -15,7 +15,7 @@ database metrics and logs.
 > **Warning**
 >
 > Existing database instrumentations that are using
-> [v1.24.0 of this document](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/database-spans.md)
+> [v1.25.0 of this document](https://github.com/open-telemetry/semantic-conventions/blob/v1.25.0/docs/database/database-spans.md)
 > (or prior):
 >
 > * SHOULD NOT change the version of the database conventions that they emit by default

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -29,7 +29,7 @@ linkTitle: Metrics
 > **Warning**
 >
 > Existing database instrumentations that are using
-> [v1.24.0 of this document](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/database-spans.md)
+> [v1.25.0 of this document](https://github.com/open-telemetry/semantic-conventions/blob/v1.25.0/docs/database/database-spans.md)
 > (or prior):
 >
 > * SHOULD NOT change the version of the database conventions that they emit by default

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -21,7 +21,7 @@ linkTitle: Client Calls
 > **Warning**
 >
 > Existing database instrumentations that are using
-> [v1.24.0 of this document](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/database-spans.md)
+> [v1.25.0 of this document](https://github.com/open-telemetry/semantic-conventions/blob/v1.25.0/docs/database/database-spans.md)
 > (or prior):
 >
 > * SHOULD NOT change the version of the database conventions that they emit by default


### PR DESCRIPTION
Addresses https://github.com/open-telemetry/opentelemetry-go-contrib/pull/6172#issuecomment-2397429335

Most likely it was a "copy-paste" error from messaging spans and metrics or someone has forgotten to bump the version.

Do you want a changelog entry for this?

CC @trask 
