### PR TITLE
Adapt messaging examples/tables 

### DIFF
--- a/docs/messaging/gcp-pubsub.md
+++ b/docs/messaging/gcp-pubsub.md
@@ -141,7 +141,7 @@ flowchart LR;
   linkStyle 0,1 color:green,stroke:green
 ```
 
-| Field or Attribute | Span Create A | Span Create B | Span Send A B |
+| Field or Attribute | Producer Span Create A | Producer Span Create B | Producer Span Send A B |
 |-|-|-|-|
 | Span name | `create T` | `create T` | `send T` |
 | Parent |  |  |  |
@@ -162,13 +162,13 @@ flowchart LR;
 flowchart TD;
   subgraph CONSUMER
   direction LR
-  R1[Receive m1]
-  SM1[Ack m1]
-  EM1[Modack m1]
+  R1[Receive A]
+  SM1[Ack A]
+  EM1[Modack A]
   end
   subgraph PRODUCER
   direction LR
-  CM1[Create m1]
+  CM1[Create A]
   PM1[Send]
   end
   %% Link 0
@@ -200,7 +200,7 @@ flowchart TD;
   linkStyle 3 color:#0560f2,stroke:#0560f2
 ```
 
-| Field or Attribute | Span Create A | Span Send A | Span Receive A | Span Modack A | Span Ack A |
+| Field or Attribute | Producer Span Create A | Producer Span Send | Consumer Span Receive A | Consumer Span Modack A | Consumer Span Ack A |
 |-|-|-|-|-|-|
 | Span name | `create T` | `send T` |  `receive S` | `modack S` | `ack S` |
 | Parent |  |  |  | |  |

--- a/docs/messaging/kafka.md
+++ b/docs/messaging/kafka.md
@@ -165,7 +165,7 @@ flowchart LR;
   linkStyle 1 color:green,stroke:green
 ```
 
-| Field or Attribute | Span Send | Span Poll | Span Process | Span Commit T |
+| Field or Attribute | Producer | Consumer Span Poll | Consumer Span Process | Consumer Span Commit T |
 |-|-|-|-|-|
 | Span name | `"send T"` | `"poll T"` | `"process T"` | `"commit T"` |
 | Parent |  |  |  (optional) Span Send  | Span Process |

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -505,7 +505,7 @@ Solid arrows denote parent/child relationships, dotted arrows denote link
 relationships.
 
 > [!IMPORTANT]
-> The text inside the "Span" boxes is only for reference and visualization purposes.
+> The text inside the "Span" box is only for reference and visualization purposes.
 > Check the accompaining table to see the actual span name to be reported
 > as well as other attributes.
 

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -506,7 +506,7 @@ relationships.
 
 > [!IMPORTANT]
 > The text inside the "Span" box is only for reference and visualization purposes.
-> Check the accompaining table to see the actual span name to be reported
+> Check the accompanying table to see the actual span name to be reported
 > as well as other attributes.
 
 ### Topic with multiple consumers

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -504,6 +504,11 @@ understanding how messaging spans can be integrated into an overall trace flow.
 Solid arrows denote parent/child relationships, dotted arrows denote link
 relationships.
 
+> [!IMPORTANT]
+> The text inside the "Span" boxes is only for reference and visualization purposes.
+> Check the accompaining table to see the actual span name to be reported
+> as well as other attributes.
+
 ### Topic with multiple consumers
 
 Given is a publisher that publishes a message to a topic exchange "T" on RabbitMQ, and two consumers which both get the message delivered.
@@ -532,7 +537,7 @@ flowchart LR;
   linkStyle 0,1,2,3 color:green,stroke:green
 ```
 
-| Field or Attribute | Span Send A | Span Process A 1| Span Process A 2 |
+| Field or Attribute | Producer | Consumer 1| Consumer 2 |
 |-|-|-|-|
 | Span name | `publish T` | `consume T` | `consume T` |
 | Parent (optional) | | `publish T` | `publish T` |
@@ -557,7 +562,7 @@ flowchart LR;
   PA[Span Send A]
   PB[Span Send B]
   end
-  subgraph CONSUMER1
+  subgraph CONSUMER
   direction TB
   D1[Span Receive A B]
   end
@@ -569,7 +574,7 @@ flowchart LR;
   linkStyle 0,1 color:green,stroke:green
 ```
 
-| Field or Attribute | Span Send A | Span Send B | Span Receive A B |
+| Field or Attribute | Producer Span A | Producer Span B | Consumer |
 |-|-|-|-|
 | Span name | `send Q` | `send Q` | `poll Q` |
 | Parent |  |  |  |
@@ -620,7 +625,7 @@ flowchart LR;
   linkStyle 0,1,2,3 color:green,stroke:green
 ```
 
-| Field or Attribute | Span Create A | Span Create B | Span Send | Span Receive A | Span Receive B |
+| Field or Attribute | Producer Span Create A | Producer Span Create B | Producer Span Send | Consumer 1 | Consumer 2 |
 |-|-|-|-|-|-|
 | Span name | `create Q` | `create Q` | `send Q` | `poll Q` | `poll Q` |
 | Parent |  | | | | |
@@ -637,7 +642,7 @@ flowchart LR;
 
 ### Batch publishing without "Create" spans
 
-Given is a publisher that publishes a batch with two messages to a topic "Q" on
+Given is a producer that publishes a batch with two messages to a topic "Q" on
 Kafka, and two different consumers receiving one of the messages.
 
 Based on the configuration provided by user, instrumentation in this case reports
@@ -665,7 +670,7 @@ flowchart LR;
   linkStyle 0,1 color:green,stroke:green
 ```
 
-| Field or Attribute | Span Publish | Span Receive A | Span Receive B |
+| Field or Attribute | Producer | Consumer 1 | Consumer 2 |
 |-|-|-|-|
 | Span name | `send Q` | `poll Q` | `poll Q` |
 | Parent | | | |


### PR DESCRIPTION
Fixes #1465

## Changes

The mermaid diagrams and the tables use different terms/names for things, which may cause confusion for end-users. This PR attempts to make them a bit more clear.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
