### PR TITLE
[editorial] Profiles: drop unnecessary alias

### DIFF
--- a/docs/general/profiles.md
+++ b/docs/general/profiles.md
@@ -1,6 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Profiles
-aliases: [docs/specs/semconv/general/profiles-general]
 --->
 
 # General Profiles Attributes


### PR DESCRIPTION
- Followup to:
  - #1188
  - #1471
- Drops alias: it is not needed because the referenced page never existed. Aliases are used when pages are moved. #1188 introduced a new page.

/cc @svrnm @theletterf 