### PR TITLE
[chore] Add link to migration guide

### DIFF
--- a/docs/http/README.md
+++ b/docs/http/README.md
@@ -44,4 +44,6 @@ Semantic conventions for HTTP are defined for the following signals:
 * [HTTP Spans](http-spans.md): Semantic Conventions for HTTP client and server *spans*.
 * [HTTP Metrics](http-metrics.md): Semantic Conventions for HTTP client and server *metrics*.
 
+For help migrating from non-stable to stable conventions, see [the migration guide](../non-normative/http-migration.md).
+
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status


### PR DESCRIPTION
## Changes
I went looking for the http semantic convention migration guide today and couldn't find it since it had been moved out of the http folder.  I'd like the README to link to it, since the http README is the most likely place a user interested in http semconv will start their journey.

## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [X] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [X] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
