### PR TITLE
Rename `semconv-llm-approvers` to `semconv-genai-approvers` in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,8 +69,8 @@
 /model/signalr/                   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-dotnet-approver @open-telemetry/semconv-http-approvers
 
 # Gen-AI semantic conventions
-/docs/gen-ai/                     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-llm-approvers
-/model/gen-ai/                    @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-llm-approvers
+/docs/gen-ai/                     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-genai-approvers
+/model/gen-ai/                    @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-genai-approvers
 
 # Security semantic conventions
 /model/dns/                       @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-security-approvers


### PR DESCRIPTION
I renamed a group as the outcome of https://github.com/open-telemetry/community/pull/2326, but forgot to update the CODEOWNERS file.

Fixing it.