### PR TITLE
[chore] Mention JavaAgent v2.0.0 default behaviour

### DIFF
--- a/docs/non-normative/http-migration.md
+++ b/docs/non-normative/http-migration.md
@@ -29,7 +29,7 @@ updated to the stable HTTP semantic conventions, they:
 - May drop the environment variable in their next major version and emit only
   the stable HTTP and networking conventions.
 
-The OpenTelemetry Java Agent v2.0.0 and later already defaults to the stable
+The OpenTelemetry Java Agent [v2.0.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.0.0) and later already defaults to the stable
 conventions -- you do not have to opt into them.
 
 ## Summary of changes

--- a/docs/non-normative/http-migration.md
+++ b/docs/non-normative/http-migration.md
@@ -29,6 +29,9 @@ updated to the stable HTTP semantic conventions, they:
 - May drop the environment variable in their next major version and emit only
   the stable HTTP and networking conventions.
 
+The OpenTelemetry Java Agent v2.0.0 and later already defaults to the stable
+conventions -- you do not have to opt into them.
+
 ## Summary of changes
 
 This section summarizes the changes made to the HTTP semantic conventions


### PR DESCRIPTION
## Changes

HTTP semantic convention stability migration docs [^1] do not mention that the JavaAgent v2.0.0 already defaults to the new, stable behaviour  [^2], which could lead to people believing they have to set `OTEL_SEMCONV_STABILITY_OPT_IN=http` when they don't.

[^1]: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/
[^2]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.0.0

This does not change an actual convention, thus I believe it does not need a changelog entry.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
