### PR TITLE
Add section on span status for databases

### DIFF
--- a/.chloggen/1560.yaml
+++ b/.chloggen/1560.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: db
+note: Specify how to set span kind for database operations.
+issues: [1536, 1560]

--- a/.chloggen/1560.yaml
+++ b/.chloggen/1560.yaml
@@ -1,4 +1,4 @@
 change_type: enhancement
 component: db
-note: Specify how to set span kind for database operations.
+note: Specify how to set span status for database operations.
 issues: [1536, 1560]

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -96,6 +96,7 @@ Instrumentation SHOULD consider the operation as failed if any of the following 
 - the `db.response.status_code` value indicates an error
 
   > [!NOTE]
+  >
   > The classification of status code as an error depends on the context.
   > For example, a SQL STATE `02000` (`no_data`) indicates an error when the application
   > expected the data to be available. However, it is not an error when the
@@ -127,15 +128,19 @@ When the operation ends with an error, instrumentation:
 **Status**: [Experimental][DocumentStatus]
 
 When the operation fails with an exception, instrumentation SHOULD record
-an [exception event](../exceptions/exceptions-spans.md) by default if and only if the
-span being recorded is a local root span (does not have a local parent).
+an [exception event](../exceptions/exceptions-spans.md) by default if, and only if,
+the span being recorded is a local root span (does not have a local parent).
 
 > [!NOTE]
+>
 > Exception stack traces could be very long and are expensive to capture and store.
 > Exceptions which are not handled by instrumented libraries are likely to be handled
 > and logged by the caller.
 > Exceptions that are not handled will be recorded by the outermost (local root)
 > instrumentation such as HTTP or gRPC server.
+
+Instrumentation MAY provide a configuration option to record exceptions that
+escape the surface of the instrumented API.
 
 ## Common attributes
 
@@ -369,6 +374,7 @@ The `db.query.summary` attribute captures a shortened representation of a query 
 which SHOULD have low-cardinality and SHOULD NOT contain any dynamic or sensitive data.
 
 > [!NOTE]
+>
 > The `db.query.text` attribute is intended to identify individual queries. Even though
 > it is sanitized if captured by default, it could still have high cardinality and
 > might reach hundreds of lines.

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -89,16 +89,16 @@ For example, for an operation describing SQL query on an anonymous table like `S
 
 ## Status
 
-[Span Status Code][SpanStatus] MUST be left unset if operation has ended without any errors.
+[Span Status Code][SpanStatus] MUST be left unset if the operation has ended without any errors.
 
-Instrumentation SHOULD consider operation as failed if:
+Instrumentation SHOULD consider the operation as failed if any of the following is true:
 
 - the `db.response.status_code` value indicates an error
 
   > [!NOTE]
   >
   > The classification of status code as an error depends on the context.
-  > For example, a SQL STATE `no_data` status code indicates an error if the application
+  > For example, a SQL STATE `no_data` status code indicates an error when the application
   > expected the data to be available. However, it is not an error when the
   > application is simply checking whether the data exists.
   >
@@ -107,33 +107,33 @@ Instrumentation SHOULD consider operation as failed if:
   > Instrumentations that don't have any additional context MUST follow the
   > guidelines in this section.
 
-- exception is thrown by the instrumented method call
-- instrumented method returns error in another way
+- an exception is thrown by the instrumented method call
+- the instrumented method returns error in another way
 
-When operation ends with an error, instrumentation:
+When the operation ends with an error, instrumentation:
 
-- SHOULD set span status code to `Error`
-- SHOULD set `error.type` attribute
-- SHOULD set span status description when it has additional information
+- SHOULD set the span status code to `Error`
+- SHOULD set the `error.type` attribute
+- SHOULD set the span status description when it has additional information
   about the error that aligns with [Span Status Description][SpanStatus] and
   can't be inferred from `db.response.status_code` or `error.type` attributes.
 
-  When operation fails with exception, the span status description SHOULD be set to
-  exception message.
+  When the operation fails with an exception, the span status description SHOULD be set to
+  the exception message.
 
 ### Recording exception events
 
 **Status**: [Experimental][DocumentStatus]
 
-When operation fails with exception, instrumentation MAY record
-[exception event](../exceptions/exceptions-spans.md) by default if and only if the
+When the operation fails with an exception, instrumentation MAY record
+an [exception event](../exceptions/exceptions-spans.md) by default if and only if the
 span being recorded is a local root span (does not have a local parent).
 
 > [!NOTE]
 > Exception stack traces could be very long and are expensive to capture and store.
 > Exceptions which are not handled by instrumented libraries are likely to be caught,
 > logged, and handled by the caller.
-> Exceptions that are not handled are recorded by they outermost instrumentation
+> Exceptions that are not handled will be recorded by the outermost (local root) instrumentation
 > such as HTTP or gRPC server.
 
 Instrumentations SHOULD NOT record exception events (by default) on spans that

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -98,7 +98,7 @@ Instrumentation SHOULD consider the operation as failed if any of the following 
   > [!NOTE]
   >
   > The classification of status code as an error depends on the context.
-  > For example, a SQL STATE `no_data` status code indicates an error when the application
+  > For example, a SQL STATE `02000` (`no_data`) indicates an error when the application
   > expected the data to be available. However, it is not an error when the
   > application is simply checking whether the data exists.
   >
@@ -108,15 +108,17 @@ Instrumentation SHOULD consider the operation as failed if any of the following 
   > guidelines in this section.
 
 - an exception is thrown by the instrumented method call
-- the instrumented method returns error in another way
+- the instrumented method returns an error in another way
 
 When the operation ends with an error, instrumentation:
 
 - SHOULD set the span status code to `Error`
 - SHOULD set the `error.type` attribute
 - SHOULD set the span status description when it has additional information
-  about the error that aligns with [Span Status Description][SpanStatus] and
-  can't be inferred from `db.response.status_code` or `error.type` attributes.
+  about the error that aligns with [Span Status Description][SpanStatus].
+
+  It's NOT RECOMMENDED to duplicate `db.response.status_code` or `error.type`
+  in span status description.
 
   When the operation fails with an exception, the span status description SHOULD be set to
   the exception message.
@@ -125,7 +127,7 @@ When the operation ends with an error, instrumentation:
 
 **Status**: [Experimental][DocumentStatus]
 
-When the operation fails with an exception, instrumentation MAY record
+When the operation fails with an exception, instrumentation SHOULD record
 an [exception event](../exceptions/exceptions-spans.md) by default if and only if the
 span being recorded is a local root span (does not have a local parent).
 
@@ -135,9 +137,6 @@ span being recorded is a local root span (does not have a local parent).
 > logged, and handled by the caller.
 > Exceptions that are not handled will be recorded by the outermost (local root) instrumentation
 > such as HTTP or gRPC server.
-
-Instrumentations SHOULD NOT record exception events (by default) on spans that
-have local parents.
 
 ## Common attributes
 

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -96,7 +96,6 @@ Instrumentation SHOULD consider the operation as failed if any of the following 
 - the `db.response.status_code` value indicates an error
 
   > [!NOTE]
-  >
   > The classification of status code as an error depends on the context.
   > For example, a SQL STATE `02000` (`no_data`) indicates an error when the application
   > expected the data to be available. However, it is not an error when the
@@ -133,10 +132,10 @@ span being recorded is a local root span (does not have a local parent).
 
 > [!NOTE]
 > Exception stack traces could be very long and are expensive to capture and store.
-> Exceptions which are not handled by instrumented libraries are likely to be caught,
-> logged, and handled by the caller.
-> Exceptions that are not handled will be recorded by the outermost (local root) instrumentation
-> such as HTTP or gRPC server.
+> Exceptions which are not handled by instrumented libraries are likely to be handled
+> and logged by the caller.
+> Exceptions that are not handled will be recorded by the outermost (local root)
+> instrumentation such as HTTP or gRPC server.
 
 ## Common attributes
 

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -115,7 +115,8 @@ When the operation ends with an error, instrumentation:
 - SHOULD set the span status code to `Error`
 - SHOULD set the `error.type` attribute
 - SHOULD set the span status description when it has additional information
-  about the error that aligns with [Span Status Description][SpanStatus].
+  about the error which is not expected to contain sensitive details and aligns
+  with [Span Status Description][SpanStatus] definition.
 
   It's NOT RECOMMENDED to duplicate `db.response.status_code` or `error.type`
   in span status description.


### PR DESCRIPTION
Addresses the DB part of https://github.com/open-telemetry/semantic-conventions/issues/1536.

Let's polish it for databases and then expand to other conventions (and potentially have a generic guidance).

The intention is to keep exception event part experimental since 
- there doesn't seem to be a consensus or a common approach for it
- span events is going away

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
