### PR TITLE
[chore] Fixed a dead link for machine id man page

### DIFF
--- a/docs/attributes-registry/service.md
+++ b/docs/attributes-registry/service.md
@@ -29,7 +29,7 @@ SHOULD use the following UUID as the namespace: `4d63009a-8d0f-11ee-aad7-4c796ed
 
 UUIDs are typically recommended, as only an opaque value for the purposes of identifying a service instance is
 needed. Similar to what can be seen in the man page for the
-[`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file, the underlying
+[`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/latest/machine-id.html) file, the underlying
 data, such as pod name and namespace should be treated as confidential, being the user's choice to expose it
 or not via another resource attribute.
 

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -107,7 +107,7 @@ SHOULD use the following UUID as the namespace: `4d63009a-8d0f-11ee-aad7-4c796ed
 
 UUIDs are typically recommended, as only an opaque value for the purposes of identifying a service instance is
 needed. Similar to what can be seen in the man page for the
-[`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file, the underlying
+[`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/latest/machine-id.html) file, the underlying
 data, such as pod name and namespace should be treated as confidential, being the user's choice to expose it
 or not via another resource attribute.
 

--- a/model/service/registry.yaml
+++ b/model/service/registry.yaml
@@ -54,7 +54,7 @@ groups:
 
           UUIDs are typically recommended, as only an opaque value for the purposes of identifying a service instance is
           needed. Similar to what can be seen in the man page for the
-          [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/machine-id.html) file, the underlying
+          [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/latest/machine-id.html) file, the underlying
           data, such as pod name and namespace should be treated as confidential, being the user's choice to expose it
           or not via another resource attribute.
 


### PR DESCRIPTION
Fixes #

## Changes

This is fixing a CI error here https://github.com/open-telemetry/semantic-conventions/actions/runs/11861560247/job/33059139725?pr=1574

@lmolkova ^^

Please provide a brief description of the changes here.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
