### PR TITLE
process: change process.uptime instrument to gauge

### DIFF
--- a/.chloggen/process_uptime.yaml
+++ b/.chloggen/process_uptime.yaml
@@ -4,13 +4,13 @@
 # your pull request title with [chore] or use the "Skip Changelog" label.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
 component: process
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add process.uptime metric.
+note: Change process.uptime instrument to a gauge.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/.chloggen/process_uptime.yaml
+++ b/.chloggen/process_uptime.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: process
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add process.uptime metric.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1518]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/system/process-metrics.md
+++ b/docs/system/process-metrics.md
@@ -341,9 +341,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
 | -------- | --------------- | ----------- | -------------- | --------- |
-| `process.uptime` | Counter | `s` | The time the process has been running. [1] | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `process.uptime` | Gauge | `s` | The time the process has been running. [1] | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
-**[1]:** Instrumentations SHOULD use counter with type `double` and measure uptime with at least millisecond precision
+**[1]:** Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
+The actual accuracy would depend on the instrumentation and operating system.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/model/process/metrics.yaml
+++ b/model/process/metrics.yaml
@@ -108,15 +108,6 @@ groups:
     metric_name: process.uptime
     stability: experimental
     brief: "The time the process has been running."
-    instrument: counter
-    unit: "s"
-    note: "Instrumentations SHOULD use counter with type `double` and measure uptime with at least millisecond precision"
-
-  - id: metric.process.uptime
-    type: metric
-    metric_name: process.uptime
-    stability: experimental
-    brief: "The time the process has been running."
     note: |
       Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
       The actual accuracy would depend on the instrumentation and operating system.

--- a/model/process/metrics.yaml
+++ b/model/process/metrics.yaml
@@ -111,3 +111,14 @@ groups:
     instrument: counter
     unit: "s"
     note: "Instrumentations SHOULD use counter with type `double` and measure uptime with at least millisecond precision"
+
+  - id: metric.process.uptime
+    type: metric
+    metric_name: process.uptime
+    stability: experimental
+    brief: "The time the process has been running."
+    note: |
+      Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
+      The actual accuracy would depend on the instrumentation and operating system.
+    instrument: gauge
+    unit: "s"


### PR DESCRIPTION
Fixes #1518 

## Changes

This PR changes the `process.uptime` metric instrument to a gauge, adding the additional subtext guidance that was part of `system.uptime`.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
