### PR TITLE
Remove requirement_level usages from registry and add a policy to check

### DIFF
--- a/model/aspnetcore/metrics.yaml
+++ b/model/aspnetcore/metrics.yaml
@@ -43,6 +43,8 @@ groups:
         examples: ['System.OperationCanceledException', 'Contoso.MyException']
         requirement_level: required
       - ref: aspnetcore.diagnostics.handler.type
+        requirement_level:
+          conditionally_required: if and only if the exception was handled by this handler.
       - ref: aspnetcore.diagnostics.exception.result
         requirement_level: required
 

--- a/model/aspnetcore/registry.yaml
+++ b/model/aspnetcore/registry.yaml
@@ -31,7 +31,6 @@ groups:
         stability: stable
         brief: Rate-limiting result, shows whether the lease was acquired or contains a rejection reason
         examples: ["acquired", "request_canceled"]
-        requirement_level: required
       - id: aspnetcore.routing.is_fallback
         type: boolean
         stability: stable
@@ -43,8 +42,6 @@ groups:
         brief: Full type name of the [`IExceptionHandler`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.diagnostics.iexceptionhandler)
           implementation that handled the exception.
         examples: ["Contoso.MyHandler"]
-        requirement_level:
-          conditionally_required: if and only if the exception was handled by this handler.
       - id: aspnetcore.request.is_unhandled
         type: boolean
         stability: stable

--- a/model/aws/registry.yaml
+++ b/model/aws/registry.yaml
@@ -303,8 +303,6 @@ groups:
         stability: experimental
         brief: >
           The ID of a running ECS task. The ID MUST be extracted from `task.arn`.
-        requirement_level:
-          conditionally_required: If and only if `task.arn` is populated.
         examples:
           [
             "10838bed-421f-43ef-870a-f43feacbbb5b",

--- a/model/go/registry.yaml
+++ b/model/go/registry.yaml
@@ -19,6 +19,5 @@ groups:
               value: 'other'
               brief: 'Memory used by the Go runtime, excluding other categories of memory usage described in this enumeration.'
               stability: experimental
-        requirement_level: recommended
         brief: The type of memory.
         examples: ["other", "stack"]

--- a/model/process/registry.yaml
+++ b/model/process/registry.yaml
@@ -113,8 +113,6 @@ groups:
           This field can be useful for querying or performing bucket analysis on how many
           arguments were provided to start a process. More arguments may be an indication
           of suspicious activity.
-        requirement_level:
-          recommended: if `process.command_args` is populated.
         examples: [4]
       - id: process.owner
         type: string

--- a/model/telemetry/registry.yaml
+++ b/model/telemetry/registry.yaml
@@ -8,7 +8,6 @@ groups:
       - id: telemetry.sdk.name
         type: string
         stability: stable
-        requirement_level: required
         brief: >
           The name of the telemetry SDK as defined above.
         note: |
@@ -59,13 +58,11 @@ groups:
               value: "webjs"
               stability: stable
         stability: stable
-        requirement_level: required
         brief: >
           The language of the telemetry SDK.
       - id: telemetry.sdk.version
         type: string
         stability: stable
-        requirement_level: required
         brief: >
           The version string of the telemetry SDK.
         examples: ["1.2.3"]

--- a/policies/registry.rego
+++ b/policies/registry.rego
@@ -55,6 +55,20 @@ deny[attr_registry_violation(description, group.id, attr.ref)] {
     description := sprintf("Registry group '%s' references attribute '%s'. Registry groups can only define new attributes.", [group.id, attr.ref])
 }
 
+# We don't allow attribute definitions to have requirement_level
+deny[attr_registry_violation(description, group.id, attr.id)] {
+    group := input.groups[_]
+    startswith(group.id, "registry.")
+
+    attr := group.attributes[_]
+
+    # TODO: requirement_level defaults to recommended - no way to check if it's not set.
+    attr.requirement_level != "recommended"
+
+    # TODO (https://github.com/open-telemetry/weaver/issues/279): provide other violation properties once weaver supports it.
+    description := sprintf("Attribute definition '%s' has requirement_level set to %s. Only attribute references can set requirement_level.", [attr.id, attr.requirement_level])
+}
+
 get_attribute_name(attr, group) = name {
     full_name = concat(".", [group.prefix, attr.id])
 

--- a/policies_test/registry_test.rego
+++ b/policies_test/registry_test.rego
@@ -22,3 +22,9 @@ test_attribute_refs if {
 	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.foo", "attributes": [{"ref": "foo"}]}]}
 	count(before_resolution.deny) == 0 with input as {"groups": [{"id": "not_registry", "attributes": [{"ref": "foo"}]}]}
 }
+
+test_attribute_requirement_levels if {
+	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.foo", "attributes": [{"id": "foo", "requirement_level": "required"}]}]}
+	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.foo", "attributes": [{"id": "foo", "requirement_level": {"recommended": "if available"}}]}]}
+	count(before_resolution.deny) == 0 with input as {"groups": [{"id": "not_registry", "attributes": [{"ref": "foo", "requirement_level": "required"}]}]}
+}


### PR DESCRIPTION
Requirement levels should only appear on spans/metrics/events/profiles definitions. They are  not rendered on the registry attributes and make no sense there. 

Related: https://github.com/open-telemetry/semantic-conventions/pull/1603#discussion_r1853060494