### PR TITLE
Add Daniel Dyla to SemConv approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Approvers ([@open-telemetry/specs-semconv-approvers](https://github.com/orgs/ope
 
 - [Alexandra Konrad](https://github.com/trisch-me), Elastic
 - [Christian Neumüller](https://github.com/Oberon00), Dynatrace
+- [Daniel Dyla](https://github.com/dyladan), Dynatrace
 - [James Moessis](https://github.com/jamesmoessis), Atlassian
 - [Sean Marciniak](https://github.com/MovieStoreGuy), Atlassian
 - [Ted Young](https://github.com/tedsuo), Lightstep


### PR DESCRIPTION
I'd like to nominate @dyladan to semconv approvers for his excellent leadership defining feature flags conventions, tooling improvements, code reviews, and push for backward compatibility checks and code generation improvements.

Thanks  @dyladan !