### PR TITLE
[chore] update codeowners with additional system semconv sections

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@
 /model/http/                      @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
 /model/error/                     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
 /model/client/                    @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
-/model/network/                   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers @open-telemetry/semconv-security-approvers
+/model/network/                   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers @open-telemetry/semconv-system-approvers @open-telemetry/semconv-security-approvers
 /model/server/                    @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
 /model/url/                       @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
 /model/user-agent/                @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
@@ -48,7 +48,7 @@
 /docs/system/                     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
 /model/disk/                      @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
 /model/host/                      @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
-/model/network/                   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
+# /model/network/                 is defined in HTTP section
 /model/os/                        @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
 /model/process/                   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers @open-telemetry/semconv-security-approvers
 /model/system/                    @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,10 +43,14 @@
 
 # System semantic conventions
 /docs/process/                    @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers @open-telemetry/semconv-security-approvers
-/docs/system/                     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
 /docs/resource/host.md            @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
+/docs/resource/process.md         @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
+/docs/system/                     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
+/model/disk/                      @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
 /model/host/                      @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
-/model/process/                    @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers @open-telemetry/semconv-security-approvers
+/model/network/                   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
+/model/os/                        @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
+/model/process/                   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers @open-telemetry/semconv-security-approvers
 /model/system/                    @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-system-approvers
 
 # Mobile semantic conventions


### PR DESCRIPTION
## Changes

This PR amends the CODEOWNERS file with the additional sections owned by @open-telemetry/semconv-system-approvers 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [N/A] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [N/A] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
