### PR TITLE
Relax collision detection policy to allow collisions between deprecated namespaces and attributes (and vice-versa)

### DIFF
--- a/policies_test/attribute_name_collisions_test.rego
+++ b/policies_test/attribute_name_collisions_test.rego
@@ -17,3 +17,15 @@ test_fails_on_namespace_collision if {
     ]}
     count(deny) == 1 with input as collision
 }
+
+test_does_not_fail_on_deprecated_namespace_collision if {
+    collision := {"groups": [
+        {"id": "test1", "attributes": [{"name": "test.namespace.id"}]},
+        {"id": "test2", "attributes": [{"name": "test.namespace", "deprecated": "replaced by foo.bar.baz"}]},
+
+        {"id": "test3", "attributes": [{"name": "another_test.namespace.id", "deprecated": "replaced by another_test.namespace"}]},
+        {"id": "test4", "attributes": [{"name": "another_test.namespace"}]},
+    ]}
+    count(deny) == 0 with input as collision
+}
+


### PR DESCRIPTION
Related to https://github.com/open-telemetry/semantic-conventions/pull/1624, https://github.com/open-telemetry/semantic-conventions/pull/1638

Preventing collisions between namespace and attribute name is a protection in case we want to support nested properties in the attributes or add any semantic meaning to namespaces. E.g. having non-deprecated attribute `foo` along with non-deprecated attribute `foo.bar` would be problematic. 

It seems fine however to have deprecated `foo` along with non-deprecated `foo.bar`. 

This PR relaxes the policy and unblocks PRs like #1624 and #1638 (if they are approved).

