### PR TITLE
Change `<PID>` to `[PID]`

### DIFF
--- a/docs/attributes-registry/process.md
+++ b/docs/attributes-registry/process.md
@@ -81,7 +81,7 @@ Describes Linux Process attributes
 |---|---|---|---|---|
 | <a id="process-linux-cgroup" href="#process-linux-cgroup">`process.linux.cgroup`</a> | string | The control group associated with the process. [4] | `1:name=systemd:/user.slice/user-1000.slice/session-3.scope`; `0::/user.slice/user-1000.slice/user@1000.service/tmux-spawn-0267755b-4639-4a27-90ed-f19f88e53748.scope` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
 
-**[4] `process.linux.cgroup`:** Control groups (cgroups) are a kernel feature used to organize and manage process resources. This attribute provides the path(s) to the cgroup(s) associated with the process, which should match the contents of the [/proc/<PID>/cgroup](https://man7.org/linux/man-pages/man7/cgroups.7.html) file.
+**[4] `process.linux.cgroup`:** Control groups (cgroups) are a kernel feature used to organize and manage process resources. This attribute provides the path(s) to the cgroup(s) associated with the process, which should match the contents of the [/proc/\[PID\]/cgroup](https://man7.org/linux/man-pages/man7/cgroups.7.html) file.
 
 ## Deprecated Process Attributes
 

--- a/docs/resource/process.md
+++ b/docs/resource/process.md
@@ -57,7 +57,7 @@
 
 **[5] `process.executable.path`:** See [Selecting process attributes](#selecting-process-attributes) for details.
 
-**[6] `process.linux.cgroup`:** Control groups (cgroups) are a kernel feature used to organize and manage process resources. This attribute provides the path(s) to the cgroup(s) associated with the process, which should match the contents of the [/proc/<PID>/cgroup](https://man7.org/linux/man-pages/man7/cgroups.7.html) file.
+**[6] `process.linux.cgroup`:** Control groups (cgroups) are a kernel feature used to organize and manage process resources. This attribute provides the path(s) to the cgroup(s) associated with the process, which should match the contents of the [/proc/\[PID\]/cgroup](https://man7.org/linux/man-pages/man7/cgroups.7.html) file.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/model/process/registry.yaml
+++ b/model/process/registry.yaml
@@ -254,5 +254,5 @@ groups:
           manage process resources. This attribute provides the path(s) to the
           cgroup(s) associated with the process, which should match the contents
           of the
-          [/proc/<PID>/cgroup](https://man7.org/linux/man-pages/man7/cgroups.7.html)
+          [/proc/\[PID\]/cgroup](https://man7.org/linux/man-pages/man7/cgroups.7.html)
           file.


### PR DESCRIPTION
This is causing a javadoc issue when updating to the latest semconv because it looks like HTML.

Also noticed it isn't rendering in this repo's markdown: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/process.md#process:

![image](https://github.com/user-attachments/assets/5498e924-cfc9-4f9e-862f-a8c8d5f00d78)

I'll open a weaver issue about this. UPDATE: https://github.com/open-telemetry/weaver/issues/519