### PR TITLE
Add k8s.container.status.waiting metric

### DIFF
--- a/.chloggen/container-waiting.yaml
+++ b/.chloggen/container-waiting.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: k8s
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add k8s.container.status.waiting metric
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1672]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/model/k8s/metrics.yaml
+++ b/model/k8s/metrics.yaml
@@ -63,6 +63,15 @@ groups:
       - ref: network.interface.name
       - ref: network.io.direction
 
+  # k8s.container.* metrics
+  - id: metric.k8s.container.status.waiting
+    type: metric
+    metric_name: k8s.container.status.waiting
+    stability: experimental
+    brief: "Whether container is in waiting state. (0 for no, 1 for yes)"
+    instrument: gauge
+    unit: ""
+
   # k8s.node.* metrics
   - id: metric.k8s.node.uptime
     type: metric


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/1672

## Changes

Add k8s.container.status.waiting metric

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
