### PR TITLE
Messaging: Align span kind in example tables with the spec

### DIFF
--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -608,7 +608,7 @@ flowchart LR;
 | Links |  |  | Span Send A, Span Send B |
 | Link attributes |  |  | Span Send A: `messaging.message.id`: `"a1"`  |
 |                 |  |  | Span Send B: `messaging.message.id`: `"a2"`  |
-| SpanKind | `PRODUCER` | `PRODUCER` | `CONSUMER` |
+| SpanKind | `PRODUCER` | `PRODUCER` | `CLIENT` |
 | `server.address` | `"ms"` | `"ms"` | `"ms"` |
 | `server.port` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` |
@@ -657,7 +657,7 @@ flowchart LR;
 | Span name | `create Q` | `create Q` | `send Q` | `poll Q` | `poll Q` |
 | Parent |  | | | | |
 | Links |  |  |  | Span Create A | Span Create B |
-| SpanKind | `PRODUCER` | `PRODUCER` | `CLIENT` | `CONSUMER` | `CONSUMER` |
+| SpanKind | `PRODUCER` | `PRODUCER` | `CLIENT` | `CLIENT` | `CLIENT` |
 | `server.address` | `"ms"` | `"ms"` | `"ms"` | `"ms"` | `"ms"` |
 | `server.port` | `1234` | `1234` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` |
@@ -702,7 +702,7 @@ flowchart LR;
 | Span name | `send Q` | `poll Q` | `poll Q` |
 | Parent | | | |
 | Links |  | Span Publish | Span Publish |
-| SpanKind | `PRODUCER` | `CONSUMER` | `CONSUMER` |
+| SpanKind | `PRODUCER` | `CLIENT` | `CLIENT` |
 | `server.address` | `"ms"` | `"ms"` | `"ms"` |
 | `server.port` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` |


### PR DESCRIPTION
## Changes

As found by Cees and discussed in slack https://cloud-native.slack.com/archives/C02Q4AAHDSA/p1736407996891579 the span kind shown in the example tables are not aligned with the recommendation in the conventions for messaging spans. 

This PR makes sure they are correct.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
