### PR TITLE
[editorial] Fix invalid link syntax in `system/hardware-metrics`

### DIFF
--- a/docs/system/hardware-metrics.md
+++ b/docs/system/hardware-metrics.md
@@ -11,7 +11,7 @@ metrics in OpenTelemetry. Consider the [general metric semantic conventions](/do
 when creating instruments not explicitly defined in the specification.
 
 This document is being converted to specific hardware metrics, parts of this document that have already been
-converted are now located in the [Hardware] (/docs/hardware/README.md) folder and are no longer present in this file.
+converted are now located in the [Hardware](/docs/hardware/README.md) folder and are no longer present in this file.
 
 Please note that this is an [ongoing process](https://github.com/open-telemetry/semantic-conventions/issues/1309) and may take some time to complete.
 


### PR DESCRIPTION
Visit https://github.com/open-telemetry/semantic-conventions/blob/main/docs/system/hardware-metrics.md and you'll see:

> This document is being converted to specific hardware metrics, parts of this document that have already been converted are now located in the [Hardware] (/docs/hardware/README.md) folder and are no longer present in this file.

Note the invalid space in the link `[Hardware] (/docs/hardware/README.md)` between the `[]` and the `()`.

This PR drops that space character.