### PR TITLE
Label all new issues with `triage:needs-triage` label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Create a report to help us improve
-labels: ["bug", "triage:needs-triage"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/change_proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/change_proposal.yaml
@@ -1,6 +1,6 @@
 name: Propose changes to existing conventions
 description: Propose changes you'd like to be added to existing conventions
-labels: ["enhancement", "triage:needs-triage"]
+labels: ["enhancement"]
 body:
   - type: dropdown
     id: area

--- a/.github/ISSUE_TEMPLATE/new-conventions.yaml
+++ b/.github/ISSUE_TEMPLATE/new-conventions.yaml
@@ -1,6 +1,6 @@
 name: Propose new semantic conventions
 description: Propose new conventions you'd like to be part of the OpenTelemetry project
-labels: ["enhancement", "triage:needs-triage", "experts needed"]
+labels: ["enhancement", "experts needed"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/scripts/prepare-new-issue.sh
+++ b/.github/workflows/scripts/prepare-new-issue.sh
@@ -28,7 +28,7 @@ if [[ -z "${ISSUE:-}" || -z "${BODY:-}" || -z "${OPENER:-}" ]]; then
   exit 0
 fi
 
-LABELS=""
+LABELS="triage:needs-triage,"
 AREAS_SECTION_START=$( (echo "${BODY}" | grep -n '### Area(s)' | awk '{ print $1 }' | grep -oE '[0-9]+') || echo '-1' )
 BODY_AREAS=""
 
@@ -51,8 +51,8 @@ for AREA in ${BODY_AREAS}; do
     LABELS+="${AREA}"
 done
 
-if [[ -v PINGED_AREAS[@] ]]; then
-  echo "The issue was associated with areas:" "${!PINGED_AREAS[@]}"
+if [[ -v BODY_AREAS[@] ]]; then
+  echo "The issue was associated with areas:" "${!BODY_AREAS[@]}"
 else
   echo "No related areas were given"
 fi

--- a/.github/workflows/scripts/prepare-new-issue.sh
+++ b/.github/workflows/scripts/prepare-new-issue.sh
@@ -45,10 +45,7 @@ for AREA in ${BODY_AREAS}; do
     continue
   fi
 
-  if [[ -n "${LABELS}" ]]; then
-      LABELS+=","
-  fi
-    LABELS+="${AREA}"
+  LABELS+=",${AREA}"
 done
 
 if [[ -v BODY_AREAS[@] ]]; then

--- a/.github/workflows/scripts/prepare-new-issue.sh
+++ b/.github/workflows/scripts/prepare-new-issue.sh
@@ -54,14 +54,10 @@ else
   echo "No related areas were given"
 fi
 
-if [[ -n "${LABELS}" ]]; then
-  # Notes on this call:
-  # 1. Labels will be deduplicated by the GitHub CLI.
-  # 2. The call to edit the issue will fail if any of the
-  #    labels doesn't exist. We can be reasonably sure that
-  #    all labels will exist since they come from a known set.
-  echo "Adding the following labels: ${LABELS//,/ /}"
-  gh issue edit "${ISSUE}" --add-label "${LABELS}" || true
-else
-  echo "No labels were found to add"
-fi
+# Notes on this call:
+# 1. Labels will be deduplicated by the GitHub CLI.
+# 2. The call to edit the issue will fail if any of the
+#    labels doesn't exist. We can be reasonably sure that
+#    all labels will exist since they come from a known set.
+echo "Adding the following labels: ${LABELS//,/ /}"
+gh issue edit "${ISSUE}" --add-label "${LABELS}" || true

--- a/.github/workflows/scripts/prepare-new-issue.sh
+++ b/.github/workflows/scripts/prepare-new-issue.sh
@@ -28,7 +28,7 @@ if [[ -z "${ISSUE:-}" || -z "${BODY:-}" || -z "${OPENER:-}" ]]; then
   exit 0
 fi
 
-LABELS="triage:needs-triage,"
+LABELS="triage:needs-triage"
 AREAS_SECTION_START=$( (echo "${BODY}" | grep -n '### Area(s)' | awk '{ print $1 }' | grep -oE '[0-9]+') || echo '-1' )
 BODY_AREAS=""
 


### PR DESCRIPTION
we currently label issues that were created using template and don't label blank ones.