### PR TITLE
Check and close milestone if any as part of release steps

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,7 @@
 # Making a Release
 
+- Close the [release milestone](https://github.com/open-telemetry/semantic-conventions/milestones)
+  if there is one.
 - Ensure the referenced specification version is up to date. Use
   [tooling to update the spec](./CONTRIBUTING.md#updating-the-referenced-specification-version)
   if needed.


### PR DESCRIPTION
I find milestones useful for tracking "last minute" things that different people would like to get into a release before it's made, and this step ensures we don't make a release without at least checking the milestone (we can always intentionally defer something).