### PR TITLE
add metric.messaging.queue.latency

### DIFF
--- a/model/messaging/metrics.yaml
+++ b/model/messaging/metrics.yaml
@@ -92,3 +92,14 @@ groups:
     attributes:
       - ref: messaging.operation.name
         examples: ["receive", "peek", "poll", "consume"]
+  - id: metric.messaging.queue.latency
+    type: metric
+    metric_name: messaging.queue.latency
+    brief: "Time between enqueueing a message and the start of its processing."
+    note: >
+      Records the time between a message being produced into a queue and that same message being delivered
+      to a processor. This metric SHOULD NOT include the time taken to process the message.
+    stability: experimental
+    instrument: histogram
+    unit: "s"
+    extends: metric.messaging.attributes


### PR DESCRIPTION
Fixes #

## Changes

Please provide a brief description of the changes here.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
