### PR TITLE
[editorial] Set alias of semantic-convention-groups.md to group-stabi…

### DIFF
--- a/docs/general/semantic-convention-groups.md
+++ b/docs/general/semantic-convention-groups.md
@@ -1,6 +1,6 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Semantic Convention Groups
-aliases: [semantic-convention-groups]
+aliases: [group-stability]
 --->
 
 # Semantic Convention Groups


### PR DESCRIPTION
- Fixes #1815
- In #1704, the file was renamed to its alias, so we need to flip the alias to be the previous name of the file.

/cc @trask @lmolkova 