### PR TITLE
Website TOC updates

### DIFF
--- a/docs/cloudevents/cloudevents-spans.md
+++ b/docs/cloudevents/cloudevents-spans.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: CloudEvents spans
+linkTitle: Spans
 --->
 
 # Semantic conventions for CloudEvents spans

--- a/docs/database/dynamodb.md
+++ b/docs/database/dynamodb.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: AWS DynamoDB
+linkTitle: DynamoDB
 --->
 
 # Semantic conventions for AWS DynamoDB

--- a/docs/database/mssql.md
+++ b/docs/database/mssql.md
@@ -1,8 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: MSSQL
+linkTitle: SQL Server
 --->
 
-# Semantic conventions for MSSQL
+# Semantic conventions for Microsoft SQL Server
 
 **Status**: [Release Candidate][DocumentStatus]
 

--- a/docs/hardware/common.md
+++ b/docs/hardware/common.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: Common hardware
+linkTitle: Common
 --->
 
 # Semantic conventions for common hardware metrics

--- a/docs/object-stores/s3.md
+++ b/docs/object-stores/s3.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: AWS S3
+linkTitle: S3
 --->
 
 # Semantic conventions for AWS S3

--- a/docs/resource/cloud-provider/aws/ecs.md
+++ b/docs/resource/cloud-provider/aws/ecs.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: ECS
+--->
+
 # AWS ECS
 
 <!-- semconv resource.aws.ecs -->

--- a/docs/resource/cloud-provider/aws/eks.md
+++ b/docs/resource/cloud-provider/aws/eks.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: EKS
+--->
+
 # AWS EKS
 
 <!-- semconv resource.aws.eks -->

--- a/docs/resource/cloud-provider/aws/logs.md
+++ b/docs/resource/cloud-provider/aws/logs.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Logs
+--->
+
 # AWS logs
 
 <!-- semconv resource.aws.log -->


### PR DESCRIPTION
You can see the TOC based on `main` at https://deploy-preview-6122--opentelemetry.netlify.app/docs/specs/semconv/ (courtesy of https://github.com/open-telemetry/opentelemetry.io/pull/6122)

cc @chalin 