### PR TITLE
[db] rename `db.system` to `db.system.name` for metrics and update values

### DIFF
--- a/.chloggen/rename-db-metric-name.yaml
+++ b/.chloggen/rename-db-metric-name.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: db
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename `db.system` to `db.system.name` in database metrics.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1581]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/rename-db-metric-name.yaml
+++ b/.chloggen/rename-db-metric-name.yaml
@@ -10,7 +10,7 @@ change_type: breaking
 component: db
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Rename `db.system` to `db.system.name` in database metrics.
+note: Rename `db.system` to `db.system.name` in database metrics, and update the values to be consistent with database spans.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/docs/database/cassandra.md
+++ b/docs/database/cassandra.md
@@ -160,6 +160,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 Cassandra client instrumentations SHOULD collect metrics according to the general
 [Semantic Conventions for Database Client Metrics](database-metrics.md).
 
-`db.system` MUST be set to `"cassandra"`.
+`db.system.name` MUST be set to `"cassandra"`.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/database/couchdb.md
+++ b/docs/database/couchdb.md
@@ -84,6 +84,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 CouchDB client instrumentations SHOULD collect metrics according to the general
 [Semantic Conventions for Database Client Metrics](database-metrics.md).
 
-`db.system` MUST be set to `"couchdb"`.
+`db.system.name` MUST be set to `"couchdb"`.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/database/dynamodb.md
+++ b/docs/database/dynamodb.md
@@ -593,6 +593,6 @@ The following table outlines the span attributes applicable to DynamoDB.
 AWS DynamoDB client instrumentations SHOULD collect metrics according to the general
 [Semantic Conventions for Database Client Metrics](database-metrics.md).
 
-`db.system.name` MUST be set to `"dynamodb"`.
+`db.system.name` MUST be set to `"aws.dynamodb"`.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/database/dynamodb.md
+++ b/docs/database/dynamodb.md
@@ -593,6 +593,6 @@ The following table outlines the span attributes applicable to DynamoDB.
 AWS DynamoDB client instrumentations SHOULD collect metrics according to the general
 [Semantic Conventions for Database Client Metrics](database-metrics.md).
 
-`db.system` MUST be set to `"dynamodb"`.
+`db.system.name` MUST be set to `"dynamodb"`.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/database/elasticsearch.md
+++ b/docs/database/elasticsearch.md
@@ -182,6 +182,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 Elasticsearch client instrumentations SHOULD collect metrics according to the general
 [Semantic Conventions for Database Client Metrics](database-metrics.md).
 
-`db.system` MUST be set to `"elasticsearch"`.
+`db.system.name` MUST be set to `"elasticsearch"`.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/database/hbase.md
+++ b/docs/database/hbase.md
@@ -100,6 +100,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 HBase client instrumentations SHOULD collect metrics according to the general
 [Semantic Conventions for Database Client Metrics](database-metrics.md).
 
-`db.system` MUST be set to `"hbase"`.
+`db.system.name` MUST be set to `"hbase"`.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/database/mariadb.md
+++ b/docs/database/mariadb.md
@@ -111,6 +111,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 MariaDB client instrumentations SHOULD collect metrics according to the general
 [Semantic Conventions for Database Client Metrics](database-metrics.md).
 
-`db.system` MUST be set to `"mariadb"`.
+`db.system.name` MUST be set to `"mariadb"`.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/database/mongodb.md
+++ b/docs/database/mongodb.md
@@ -114,6 +114,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 MongoDB client instrumentations SHOULD collect metrics according to the general
 [Semantic Conventions for Database Client Metrics](database-metrics.md).
 
-`db.system` MUST be set to `"mongodb"`.
+`db.system.name` MUST be set to `"mongodb"`.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/database/mssql.md
+++ b/docs/database/mssql.md
@@ -114,6 +114,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 Microsoft SQL Server client instrumentations SHOULD collect metrics according to the general
 [Semantic Conventions for Database Client Metrics](database-metrics.md).
 
-`db.system.name` MUST be set to `"mssql"`.
+`db.system.name` MUST be set to `"microsoft.sql_server"`.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/database/mssql.md
+++ b/docs/database/mssql.md
@@ -114,6 +114,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 Microsoft SQL Server client instrumentations SHOULD collect metrics according to the general
 [Semantic Conventions for Database Client Metrics](database-metrics.md).
 
-`db.system` MUST be set to `"mssql"`.
+`db.system.name` MUST be set to `"mssql"`.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/database/mysql.md
+++ b/docs/database/mysql.md
@@ -109,6 +109,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 MySQL client instrumentations SHOULD collect metrics according to the general
 [Semantic Conventions for Database Client Metrics](database-metrics.md).
 
-`db.system` MUST be set to `"mysql"`.
+`db.system.name` MUST be set to `"mysql"`.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/database/postgresql.md
+++ b/docs/database/postgresql.md
@@ -116,6 +116,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 PostgreSQL client instrumentations SHOULD collect metrics according to the general
 [Semantic Conventions for Database Client Metrics](database-metrics.md).
 
-`db.system` MUST be set to `"postgresql"`.
+`db.system.name` MUST be set to `"postgresql"`.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status


### PR DESCRIPTION
Part of #1581 , relevant to #1734 

## Changes

Rename `db.system` to `db.system.name` for metrics, and update the values to be consistent with database spans.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
