### PR TITLE
Add cloud.account.name

### DIFF
--- a/.chloggen/add_cloud_account_name.yaml
+++ b/.chloggen/add_cloud_account_name.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: cloud
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `cloud.account.name` attribute."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1946]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/attributes-registry/cloud.md
+++ b/docs/attributes-registry/cloud.md
@@ -10,6 +10,7 @@ A cloud environment (e.g. GCP, Azure, AWS).
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
 | <a id="cloud-account-id" href="#cloud-account-id">`cloud.account.id`</a> | string | The cloud account ID the resource is assigned to. | `111111111111`; `opentelemetry` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="cloud-account-name" href="#cloud-account-name">`cloud.account.name`</a> | string | The human-readable name or alias used to identify cloud accounts. | `development`; `aws-prod` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="cloud-availability-zone" href="#cloud-availability-zone">`cloud.availability_zone`</a> | string | Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running. [1] | `us-east-1c` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="cloud-platform" href="#cloud-platform">`cloud.platform`</a> | string | The cloud platform in use. [2] | `alibaba_cloud_ecs`; `alibaba_cloud_fc`; `alibaba_cloud_openshift` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="cloud-provider" href="#cloud-provider">`cloud.provider`</a> | string | Name of the cloud provider. | `alibaba_cloud`; `aws`; `azure` | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/resource/cloud.md
+++ b/docs/resource/cloud.md
@@ -17,6 +17,7 @@
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`cloud.account.id`](/docs/attributes-registry/cloud.md) | string | The cloud account ID the resource is assigned to. | `111111111111`; `opentelemetry` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`cloud.account.name`](/docs/attributes-registry/cloud.md) | string | The human-readable name or alias used to identify cloud accounts. | `development`; `aws-prod` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`cloud.availability_zone`](/docs/attributes-registry/cloud.md) | string | Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running. [1] | `us-east-1c` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`cloud.platform`](/docs/attributes-registry/cloud.md) | string | The cloud platform in use. [2] | `alibaba_cloud_ecs`; `alibaba_cloud_fc`; `alibaba_cloud_openshift` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`cloud.provider`](/docs/attributes-registry/cloud.md) | string | Name of the cloud provider. | `alibaba_cloud`; `aws`; `azure` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/model/cloud/registry.yaml
+++ b/model/cloud/registry.yaml
@@ -49,6 +49,12 @@ groups:
         brief: >
           The cloud account ID the resource is assigned to.
         examples: ['111111111111', 'opentelemetry']
+      - id: cloud.account.name
+        type: string
+        brief: >
+          The human-readable name or alias used to identify cloud accounts.
+        examples: [ 'development', 'aws-prod' ]
+        stability: development
       - id: cloud.region
         type: string
         stability: development

--- a/model/cloud/resources.yaml
+++ b/model/cloud/resources.yaml
@@ -8,6 +8,7 @@ groups:
     attributes:
       - ref: cloud.provider
       - ref: cloud.account.id
+      - ref: cloud.account.name
       - ref: cloud.region
       - ref: cloud.resource_id
       - ref: cloud.availability_zone


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/1946

## Changes

This PR adds a new `cloud.account.name` attributes which can be used to provide a human-readable alias or name for cloud accounts.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [X] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
