### PR TITLE
Change the definition of `device.id`

### DIFF
--- a/docs/attributes-registry/device.md
+++ b/docs/attributes-registry/device.md
@@ -9,12 +9,24 @@ Describes device attributes.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
-| <a id="device-id" href="#device-id">`device.id`</a> | string | A unique identifier representing the device [1] | `2ab2916d-a51f-4ac8-80ee-45ac31a28092` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="device-id" href="#device-id">`device.id`</a> | string | A unique identifier representing the device [1] | `123456789012345`; `01:23:45:67:89:AB` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="device-manufacturer" href="#device-manufacturer">`device.manufacturer`</a> | string | The name of the device manufacturer [2] | `Apple`; `Samsung` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="device-model-identifier" href="#device-model-identifier">`device.model.identifier`</a> | string | The model identifier for the device [3] | `iPhone3,4`; `SM-G920F` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="device-model-name" href="#device-model-name">`device.model.name`</a> | string | The marketing name for the device model [4] | `iPhone 6s Plus`; `Samsung Galaxy S6` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[1] `device.id`:** The device identifier MUST only be defined using the values outlined below. This value is not an advertising identifier and MUST NOT be used as such. On iOS (Swift or Objective-C), this value MUST be equal to the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor). On Android (Java or Kotlin), this value MUST be equal to the Firebase Installation ID or a globally unique UUID which is persisted across sessions in your application. More information can be found [here](https://developer.android.com/training/articles/user-data-ids) on best practices and exact implementation details. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
+**[1] `device.id`:** **The `device.id` SHOULD NOT be used in most user-facing applications due to privacy regulations.
+Consequently, instrumentations that provide it MUST provide it as an opt-in feature.**
+
+Its value SHOULD be identical for all apps on a device and it SHOULD NOT change if an app is uninstalled and re-installed.
+However, it might be resettable by the user for all apps on a device.
+Hardware IDs (e.g. vendor-specific serial number, IMEI or MAC address) MIGHT be used as values.
+
+More information about Android identifier best practices can be found [here](https://developer.android.com/training/articles/user-data-ids).
+
+> [!WARNING]
+>
+> This attribute contains sensitive (PII) information. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
+> See [`installation.id`](/docs/attributes-registry/installation.md#installation-id) as a more privacy-preserving alternative.
 
 **[2] `device.manufacturer`:** The Android OS provides this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER). iOS apps SHOULD hardcode the value `Apple`.
 

--- a/docs/resource/device.md
+++ b/docs/resource/device.md
@@ -16,18 +16,30 @@
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`device.id`](/docs/attributes-registry/device.md) | string | A unique identifier representing the device [1] | `2ab2916d-a51f-4ac8-80ee-45ac31a28092` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`device.manufacturer`](/docs/attributes-registry/device.md) | string | The name of the device manufacturer [2] | `Apple`; `Samsung` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`device.model.identifier`](/docs/attributes-registry/device.md) | string | The model identifier for the device [3] | `iPhone3,4`; `SM-G920F` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`device.model.name`](/docs/attributes-registry/device.md) | string | The marketing name for the device model [4] | `iPhone 6s Plus`; `Samsung Galaxy S6` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`device.manufacturer`](/docs/attributes-registry/device.md) | string | The name of the device manufacturer [1] | `Apple`; `Samsung` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`device.model.identifier`](/docs/attributes-registry/device.md) | string | The model identifier for the device [2] | `iPhone3,4`; `SM-G920F` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`device.model.name`](/docs/attributes-registry/device.md) | string | The marketing name for the device model [3] | `iPhone 6s Plus`; `Samsung Galaxy S6` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`device.id`](/docs/attributes-registry/device.md) | string | A unique identifier representing the device [4] | `123456789012345`; `01:23:45:67:89:AB` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[1] `device.id`:** The device identifier MUST only be defined using the values outlined below. This value is not an advertising identifier and MUST NOT be used as such. On iOS (Swift or Objective-C), this value MUST be equal to the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor). On Android (Java or Kotlin), this value MUST be equal to the Firebase Installation ID or a globally unique UUID which is persisted across sessions in your application. More information can be found [here](https://developer.android.com/training/articles/user-data-ids) on best practices and exact implementation details. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
+**[1] `device.manufacturer`:** The Android OS provides this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER). iOS apps SHOULD hardcode the value `Apple`.
 
-**[2] `device.manufacturer`:** The Android OS provides this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER). iOS apps SHOULD hardcode the value `Apple`.
+**[2] `device.model.identifier`:** It's recommended this value represents a machine-readable version of the model identifier rather than the market or consumer-friendly name of the device.
 
-**[3] `device.model.identifier`:** It's recommended this value represents a machine-readable version of the model identifier rather than the market or consumer-friendly name of the device.
+**[3] `device.model.name`:** It's recommended this value represents a human-readable version of the device model rather than a machine-readable alternative.
 
-**[4] `device.model.name`:** It's recommended this value represents a human-readable version of the device model rather than a machine-readable alternative.
+**[4] `device.id`:** **The `device.id` SHOULD NOT be used in most user-facing applications due to privacy regulations.
+Consequently, instrumentations that provide it MUST provide it as an opt-in feature.**
+
+Its value SHOULD be identical for all apps on a device and it SHOULD NOT change if an app is uninstalled and re-installed.
+However, it might be resettable by the user for all apps on a device.
+Hardware IDs (e.g. vendor-specific serial number, IMEI or MAC address) MIGHT be used as values.
+
+More information about Android identifier best practices can be found [here](https://developer.android.com/training/articles/user-data-ids).
+
+> [!WARNING]
+>
+> This attribute contains sensitive (PII) information. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
+> See [`installation.id`](/docs/attributes-registry/installation.md#installation-id) as a more privacy-preserving alternative.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/model/device/registry.yaml
+++ b/model/device/registry.yaml
@@ -3,23 +3,30 @@ groups:
     type: attribute_group
     display_name: Device Attributes
     brief: >
-        Describes device attributes.
+      Describes device attributes.
     attributes:
       - id: device.id
         type: string
         stability: development
         brief: >
           A unique identifier representing the device
-        note: >
-          The device identifier MUST only be defined using the values outlined below. This value is not an advertising
-          identifier and MUST NOT be used as such.
-          On iOS (Swift or Objective-C), this value MUST be equal to the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor).
-          On Android (Java or Kotlin), this value MUST be equal to the Firebase Installation ID or a globally unique
-          UUID which is persisted across sessions in your application. More information can be found [here](https://developer.android.com/training/articles/user-data-ids)
-          on best practices and exact implementation details.
-          Caution should be taken when storing personal data or anything which can identify a user. GDPR and
-          data protection laws may apply, ensure you do your own due diligence.
-        examples: ['2ab2916d-a51f-4ac8-80ee-45ac31a28092']
+        note: |
+          **The `device.id` SHOULD NOT be used in most user-facing applications due to privacy regulations.
+          Consequently, instrumentations that provide it MUST provide it as an opt-in feature.**
+
+          Its value SHOULD be identical for all apps on a device and it SHOULD NOT change if an app is uninstalled and re-installed.
+          However, it might be resettable by the user for all apps on a device.
+          Hardware IDs (e.g. vendor-specific serial number, IMEI or MAC address) MIGHT be used as values.
+
+          More information about Android identifier best practices can be found [here](https://developer.android.com/training/articles/user-data-ids).
+
+          > [!WARNING]
+          >
+          > This attribute contains sensitive (PII) information. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
+          > See [`installation.id`](/docs/attributes-registry/installation.md#installation-id) as a more privacy-preserving alternative.
+        examples:
+          - '123456789012345'
+          - 01:23:45:67:89:AB
       - id: device.manufacturer
         type: string
         stability: development

--- a/model/device/resources.yaml
+++ b/model/device/resources.yaml
@@ -4,9 +4,10 @@ groups:
     stability: development
     name: device
     brief: >
-        The device on which the process represented by this resource is running.
+      The device on which the process represented by this resource is running.
     attributes:
       - ref: device.id
+        requirement_level: opt_in
       - ref: device.manufacturer
       - ref: device.model.identifier
       - ref: device.model.name


### PR DESCRIPTION
Fixes #1874

> [!WARNING]
> This PR must be merged together with #1897 as they are highly related.

## Changes

I have given a new definition to device.id, which now truly identifies the device. It has been marked as opt-in though, as its usage is generally discouraged due to privacy implications, and should only be enabled in special cases, when it does not violate the privacy of the user.

The old definition of `device.id` is more-or-less covered by the proposed `app.installation.id` in #1897, which is recommended for general use instead of this, as it provides more privacy to the users.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
