### PR TITLE
Add top-level heading into k8s non-normative doc

### DIFF
--- a/docs/non-normative/k8s-attributes.md
+++ b/docs/non-normative/k8s-attributes.md
@@ -1,6 +1,10 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: K8s attributes
+linkTitle: Resource attributes in K8s
 --->
+
+# Populating resources attributes in Kubernetes
+
+This document describes how to specify resource attributes for Kubernetes services.
 
 ## Specify resource attributes using Kubernetes annotations
 
@@ -17,7 +21,7 @@ The following [service resource attributes](../attributes-registry/service.md) a
 There are different ways to calculate the service attributes.
 
 1. [Well-Known Labels](https://kubernetes.io/docs/reference/labels-annotations-taints/)
-2. Annotations on the pod template that have the `resource.opentelemetry.io/` prefix as described in  
+2. Annotations on the pod template that have the `resource.opentelemetry.io/` prefix as described in
     [resource attributes using Kubernetes annotations](#specify-resource-attributes-using-kubernetes-annotations)
 3. A function of the Kubernetes resource attributes defined above
 


### PR DESCRIPTION
Fixes #1971
(🤞 )

Attempt to fix https://github.com/open-telemetry/opentelemetry.io/actions/runs/13718790997/job/38369381823?pr=6122

For some reason K8s attributes doc does not appear in the preview - https://deploy-preview-6122--opentelemetry.netlify.app/docs/specs/semconv/non-normative/k8s-migration/

<img width="336" alt="image" src="https://github.com/user-attachments/assets/4f108ea8-c62e-4cf5-81e6-de8b2240988b" />

The assumption is that something is broken in that doc since because of it not having a top-level heading.

