### PR TITLE
[editorial] Ensure non-norm/k8s-attr page has a title

### DIFF
--- a/docs/non-normative/k8s-attributes.md
+++ b/docs/non-normative/k8s-attributes.md
@@ -2,7 +2,7 @@
 linkTitle: K8s attributes
 --->
 
-## Specify resource attributes using Kubernetes annotations
+# Specify resource attributes using Kubernetes annotations
 
 All annotations with the `resource.opentelemetry.io/` prefix should be translated into the corresponding resource
 attributes.
@@ -17,7 +17,7 @@ The following [service resource attributes](../attributes-registry/service.md) a
 There are different ways to calculate the service attributes.
 
 1. [Well-Known Labels](https://kubernetes.io/docs/reference/labels-annotations-taints/)
-2. Annotations on the pod template that have the `resource.opentelemetry.io/` prefix as described in  
+2. Annotations on the pod template that have the `resource.opentelemetry.io/` prefix as described in
     [resource attributes using Kubernetes annotations](#specify-resource-attributes-using-kubernetes-annotations)
 3. A function of the Kubernetes resource attributes defined above
 


### PR DESCRIPTION
- Fixes #1971
- Closes #1972 if you agree with this proposal
- Ensures that the offending page has a title, that is, a level-1 heading
- This could be detected by markdown lint, but the check was disabled in #1010, see https://github.com/open-telemetry/semantic-conventions/pull/1010/files#r1985540217. Could the check be re-enabled @lmolkova?