### PR TITLE
[editorial] Drop page self-link, adjust prose

### DIFF
--- a/docs/non-normative/k8s-attributes.md
+++ b/docs/non-normative/k8s-attributes.md
@@ -17,8 +17,8 @@ The following [service resource attributes](../attributes-registry/service.md) a
 There are different ways to calculate the service attributes.
 
 1. [Well-Known Labels](https://kubernetes.io/docs/reference/labels-annotations-taints/)
-2. Annotations on the pod template that have the `resource.opentelemetry.io/` prefix as described in
-    [resource attributes using Kubernetes annotations](#specify-resource-attributes-using-kubernetes-annotations)
+2. Annotations on the pod template that have the `resource.opentelemetry.io/`
+   prefix as described in this page.
 3. A function of the Kubernetes resource attributes defined above
 
 This translation can typically be done by an OpenTelemetry Collector component like the


### PR DESCRIPTION
- Fixes a link-check failure:
  - Reported in https://github.com/open-telemetry/opentelemetry.io/actions/runs/13736680027/job/38421197046?pr=6122
  - https://github.com/open-telemetry/opentelemetry.io/pull/6122
- Drop the page self-link.
  - @zeitlinger - since you were the author of the text, do you agree with the suggested change?
  - Context: https://github.com/open-telemetry/semantic-conventions/blob/8698e3c5edd3f97d52776abd576fc27fd2e9dba0/docs/non-normative/k8s-attributes.md?plain=1#L19-L22

/cc @lmolkova 