### PR TITLE
Rename `evaluation` to `result` for feature flag evaluation result attributes

### DIFF
--- a/.chloggen/ff-result-namespace.yaml
+++ b/.chloggen/ff-result-namespace.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: feature_flag
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename `evaluation` to `result` for feature flag evaluation result attributes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/attributes-registry/feature-flag.md
+++ b/docs/attributes-registry/feature-flag.md
@@ -11,21 +11,21 @@ This document defines attributes for Feature Flags.
 |---|---|---|---|---|
 | <a id="feature-flag-context-id" href="#feature-flag-context-id">`feature_flag.context.id`</a> | string | The unique identifier for the flag evaluation context. For example, the targeting key. | `5157782b-2203-4c80-a857-dbbd5e7761db` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="feature-flag-evaluation-error-message" href="#feature-flag-evaluation-error-message">`feature_flag.evaluation.error.message`</a> | string | A message explaining the nature of an error occurring during flag evaluation. | `Flag `header-color` expected type `string` but found type `number`` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="feature-flag-evaluation-reason" href="#feature-flag-evaluation-reason">`feature_flag.evaluation.reason`</a> | string | The reason code which shows how a feature flag value was determined. | `static`; `targeting_match`; `error`; `default` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="feature-flag-key" href="#feature-flag-key">`feature_flag.key`</a> | string | The lookup key of the feature flag. | `logo-color` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="feature-flag-provider-name" href="#feature-flag-provider-name">`feature_flag.provider_name`</a> | string | Identifies the feature flag provider. | `Flag Manager` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="feature-flag-result-reason" href="#feature-flag-result-reason">`feature_flag.result.reason`</a> | string | The reason code which shows how a feature flag value was determined. | `static`; `targeting_match`; `error`; `default` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="feature-flag-result-variant" href="#feature-flag-result-variant">`feature_flag.result.variant`</a> | string | A semantic identifier for an evaluated flag value. [1] | `red`; `true`; `on` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="feature-flag-set-id" href="#feature-flag-set-id">`feature_flag.set.id`</a> | string | The identifier of the [flag set](https://openfeature.dev/specification/glossary/#flag-set) to which the feature flag belongs. | `proj-1`; `ab98sgs`; `service1/dev` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="feature-flag-variant" href="#feature-flag-variant">`feature_flag.variant`</a> | string | A semantic identifier for an evaluated flag value. [1] | `red`; `true`; `on` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="feature-flag-version" href="#feature-flag-version">`feature_flag.version`</a> | string | The version of the ruleset used during the evaluation. This may be any stable value which uniquely identifies the ruleset. | `1`; `01ABCDEF` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[1] `feature_flag.variant`:** A semantic identifier, commonly referred to as a variant, provides a means
+**[1] `feature_flag.result.variant`:** A semantic identifier, commonly referred to as a variant, provides a means
 for referring to a value without including the value itself. This can
 provide additional context for understanding the meaning behind a value.
 For example, the variant `red` maybe be used for the value `#c05543`.
 
 ---
 
-`feature_flag.evaluation.reason` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`feature_flag.result.reason` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/docs/feature-flags/feature-flags-logs.md
+++ b/docs/feature-flags/feature-flags-logs.md
@@ -60,11 +60,11 @@ A `feature_flag.evaluation` event SHOULD be emitted whenever a feature flag valu
 |---|---|---|---|---|---|
 | [`feature_flag.key`](/docs/attributes-registry/feature-flag.md) | string | The lookup key of the feature flag. | `logo-color` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`error.type`](/docs/attributes-registry/error.md) | string | Describes a class of error the operation ended with. [1] | `provider_not_ready`; `targeting_key_missing`; `provider_fatal`; `general` | `Conditionally Required` [2] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| [`feature_flag.variant`](/docs/attributes-registry/feature-flag.md) | string | A semantic identifier for an evaluated flag value. [3] | `red`; `true`; `on` | `Conditionally Required` [4] | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`feature_flag.result.variant`](/docs/attributes-registry/feature-flag.md) | string | A semantic identifier for an evaluated flag value. [3] | `red`; `true`; `on` | `Conditionally Required` [4] | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`feature_flag.context.id`](/docs/attributes-registry/feature-flag.md) | string | The unique identifier for the flag evaluation context. For example, the targeting key. | `5157782b-2203-4c80-a857-dbbd5e7761db` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`feature_flag.evaluation.error.message`](/docs/attributes-registry/feature-flag.md) | string | A message explaining the nature of an error occurring during flag evaluation. | `Flag `header-color` expected type `string` but found type `number`` | `Recommended` [5] | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`feature_flag.evaluation.reason`](/docs/attributes-registry/feature-flag.md) | string | The reason code which shows how a feature flag value was determined. | `static`; `targeting_match`; `error`; `default` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`feature_flag.provider_name`](/docs/attributes-registry/feature-flag.md) | string | Identifies the feature flag provider. | `Flag Manager` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`feature_flag.result.reason`](/docs/attributes-registry/feature-flag.md) | string | The reason code which shows how a feature flag value was determined. | `static`; `targeting_match`; `error`; `default` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`feature_flag.set.id`](/docs/attributes-registry/feature-flag.md) | string | The identifier of the [flag set](https://openfeature.dev/specification/glossary/#flag-set) to which the feature flag belongs. | `proj-1`; `ab98sgs`; `service1/dev` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`feature_flag.version`](/docs/attributes-registry/feature-flag.md) | string | The version of the ruleset used during the evaluation. This may be any stable value which uniquely identifies the ruleset. | `1`; `01ABCDEF` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
@@ -83,12 +83,12 @@ A `feature_flag.evaluation` event SHOULD be emitted whenever a feature flag valu
 
 **[2] `error.type`:** If and only if an error occurred during flag evaluation.
 
-**[3] `feature_flag.variant`:** A semantic identifier, commonly referred to as a variant, provides a means
+**[3] `feature_flag.result.variant`:** A semantic identifier, commonly referred to as a variant, provides a means
 for referring to a value without including the value itself. This can
 provide additional context for understanding the meaning behind a value.
 For example, the variant `red` maybe be used for the value `#c05543`.
 
-**[4] `feature_flag.variant`:** If feature flag provider supplies a variant or equivalent concept.
+**[4] `feature_flag.result.variant`:** If feature flag provider supplies a variant or equivalent concept.
 
 **[5] `feature_flag.evaluation.error.message`:** If and only if an error occurred. It's NOT RECOMMENDED to duplicate the value of `error.type` in `feature_flag.evaluation.error.message`.
 
@@ -102,7 +102,7 @@ For example, the variant `red` maybe be used for the value `#c05543`.
 
 ---
 
-`feature_flag.evaluation.reason` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`feature_flag.result.reason` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/model/feature-flags/logs.yaml
+++ b/model/feature-flags/logs.yaml
@@ -15,7 +15,7 @@ groups:
     attributes:
       - ref: feature_flag.key
         requirement_level: required
-      - ref: feature_flag.variant
+      - ref: feature_flag.result.variant
         requirement_level:
           conditionally_required: If feature flag provider supplies a variant or equivalent concept.
       - ref: feature_flag.provider_name
@@ -26,7 +26,7 @@ groups:
         requirement_level: recommended
       - ref: feature_flag.set.id
         requirement_level: recommended
-      - ref: feature_flag.evaluation.reason
+      - ref: feature_flag.result.reason
         requirement_level: recommended
       - ref: error.type
         examples: ["provider_not_ready", "targeting_key_missing", "provider_fatal", "general"]

--- a/model/feature-flags/registry.yaml
+++ b/model/feature-flags/registry.yaml
@@ -16,7 +16,7 @@ groups:
         stability: development
         brief: Identifies the feature flag provider.
         examples: ["Flag Manager"]
-      - id: feature_flag.variant
+      - id: feature_flag.result.variant
         type: string
         stability: development
         examples: ["red", "true", "on"]
@@ -45,7 +45,7 @@ groups:
         examples: ["proj-1", "ab98sgs", "service1/dev"]
         brief: >
           The identifier of the [flag set](https://openfeature.dev/specification/glossary/#flag-set) to which the feature flag belongs.
-      - id: feature_flag.evaluation.reason
+      - id: feature_flag.result.reason
         type:
           members:
             - id: static

--- a/schema-next.yaml
+++ b/schema-next.yaml
@@ -2,6 +2,13 @@ file_format: 1.1.0
 schema_url: https://opentelemetry.io/schemas/1.31.0
 versions:
   next:
+    all:
+      changes:
+        # todo link
+        - rename_attributes:
+            attribute_map:
+              feature_flag.evaluation.reason: feature_flag.result.reason
+              feature_flag.evaluation.variant: feature_flag.result.variant
   1.31.0:
     all:
       changes:


### PR DESCRIPTION
This came as a result of @trask reviewing the feature flag semconv to consolidate the naming hierarchy. `result` is a more direct term for the result of an evaluation. The result value and value type will also be incoming in separate PRs