### PR TITLE
Rename `rpc.grpc.status_code` to `rpc.grpc.response.status_code`

### DIFF
--- a/.chloggen/rename-rpc-grpc-status-code.yaml
+++ b/.chloggen/rename-rpc-grpc-status-code.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: rpc
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename `rpc.grpc.status_code` to `rpc.grpc.response.status_code` to keep consistency.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1504]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/attributes-registry/rpc.md
+++ b/docs/attributes-registry/rpc.md
@@ -17,7 +17,7 @@ This document defines attributes for remote procedure calls.
 | <a id="rpc-connect-rpc-response-metadata" href="#rpc-connect-rpc-response-metadata">`rpc.connect_rpc.response.metadata.<key>`</a> | string[] | Connect response metadata, `<key>` being the normalized Connect Metadata key (lowercase), the value being the metadata values. [2] | `rpc.response.metadata.my-custom-metadata-attribute=["attribute_value"]` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="rpc-grpc-request-metadata" href="#rpc-grpc-request-metadata">`rpc.grpc.request.metadata.<key>`</a> | string[] | gRPC request metadata, `<key>` being the normalized gRPC Metadata key (lowercase), the value being the metadata values. [3] | `rpc.grpc.request.metadata.my-custom-metadata-attribute=["1.2.3.4", "1.2.3.5"]` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="rpc-grpc-response-metadata" href="#rpc-grpc-response-metadata">`rpc.grpc.response.metadata.<key>`</a> | string[] | gRPC response metadata, `<key>` being the normalized gRPC Metadata key (lowercase), the value being the metadata values. [4] | `rpc.grpc.response.metadata.my-custom-metadata-attribute=["attribute_value"]` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="rpc-grpc-status-code" href="#rpc-grpc-status-code">`rpc.grpc.status_code`</a> | int | The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request. | `0`; `1`; `2` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="rpc-grpc-response-status-code" href="#rpc-grpc-response-status-code">`rpc.grpc.response.status_code`</a> | int | The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request. | `0`; `1`; `2` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="rpc-jsonrpc-error-code" href="#rpc-jsonrpc-error-code">`rpc.jsonrpc.error_code`</a> | int | `error.code` property of response if it is an error response. | `-32700`; `100` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="rpc-jsonrpc-error-message" href="#rpc-jsonrpc-error-message">`rpc.jsonrpc.error_message`</a> | string | `error.message` property of response if it is an error response. | `Parse error`; `User already exists` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="rpc-jsonrpc-request-id" href="#rpc-jsonrpc-request-id">`rpc.jsonrpc.request_id`</a> | string | `id` property of request or response. Since protocol allows id to be int, string, `null` or missing (for notifications), value is expected to be cast to string for simplicity. Use empty string in case of `null` value. Omit entirely if this is a notification. | `10`; `request-7`; `` | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -69,7 +69,7 @@ This document defines attributes for remote procedure calls.
 
 ---
 
-`rpc.grpc.status_code` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`rpc.grpc.response.status_code` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/docs/attributes-registry/rpc.md
+++ b/docs/attributes-registry/rpc.md
@@ -122,6 +122,7 @@ Deprecated rpc message attributes.
 | <a id="message-id" href="#message-id">`message.id`</a> | int | Deprecated, use `rpc.message.id` instead. |  | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `rpc.message.id`. |
 | <a id="message-type" href="#message-type">`message.type`</a> | string | Deprecated, use `rpc.message.type` instead. | `SENT`; `RECEIVED` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `rpc.message.type`. |
 | <a id="message-uncompressed-size" href="#message-uncompressed-size">`message.uncompressed_size`</a> | int | Deprecated, use `rpc.message.uncompressed_size` instead. |  | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `rpc.message.uncompressed_size`. |
+| <a id="rpc-grpc-status-code" href="#rpc-grpc-status-code">`rpc.grpc.status_code`</a> | int | Deprecated, use `rpc.grpc.response.status_code` instead. | `0`; `1`; `2` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `rpc.grpc.response.status_code`. |
 
 ---
 
@@ -131,3 +132,27 @@ Deprecated rpc message attributes.
 |---|---|---|
 | `RECEIVED` | received | ![Development](https://img.shields.io/badge/-development-blue) |
 | `SENT` | sent | ![Development](https://img.shields.io/badge/-development-blue) |
+
+---
+
+`rpc.grpc.status_code` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `0` | OK | ![Development](https://img.shields.io/badge/-development-blue) |
+| `1` | CANCELLED | ![Development](https://img.shields.io/badge/-development-blue) |
+| `2` | UNKNOWN | ![Development](https://img.shields.io/badge/-development-blue) |
+| `3` | INVALID_ARGUMENT | ![Development](https://img.shields.io/badge/-development-blue) |
+| `4` | DEADLINE_EXCEEDED | ![Development](https://img.shields.io/badge/-development-blue) |
+| `5` | NOT_FOUND | ![Development](https://img.shields.io/badge/-development-blue) |
+| `6` | ALREADY_EXISTS | ![Development](https://img.shields.io/badge/-development-blue) |
+| `7` | PERMISSION_DENIED | ![Development](https://img.shields.io/badge/-development-blue) |
+| `8` | RESOURCE_EXHAUSTED | ![Development](https://img.shields.io/badge/-development-blue) |
+| `9` | FAILED_PRECONDITION | ![Development](https://img.shields.io/badge/-development-blue) |
+| `10` | ABORTED | ![Development](https://img.shields.io/badge/-development-blue) |
+| `11` | OUT_OF_RANGE | ![Development](https://img.shields.io/badge/-development-blue) |
+| `12` | UNIMPLEMENTED | ![Development](https://img.shields.io/badge/-development-blue) |
+| `13` | INTERNAL | ![Development](https://img.shields.io/badge/-development-blue) |
+| `14` | UNAVAILABLE | ![Development](https://img.shields.io/badge/-development-blue) |
+| `15` | DATA_LOSS | ![Development](https://img.shields.io/badge/-development-blue) |
+| `16` | UNAUTHENTICATED | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/rpc/grpc.md
+++ b/docs/rpc/grpc.md
@@ -25,7 +25,7 @@ Below is a table of attributes that SHOULD be included on client and server gRPC
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`rpc.grpc.status_code`](/docs/attributes-registry/rpc.md) | int | The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request. | `0`; `1`; `2` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`rpc.grpc.response.status_code`](/docs/attributes-registry/rpc.md) | int | The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request. | `0`; `1`; `2` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`rpc.grpc.request.metadata.<key>`](/docs/attributes-registry/rpc.md) | string[] | gRPC request metadata, `<key>` being the normalized gRPC Metadata key (lowercase), the value being the metadata values. [1] | `rpc.grpc.request.metadata.my-custom-metadata-attribute=["1.2.3.4", "1.2.3.5"]` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`rpc.grpc.response.metadata.<key>`](/docs/attributes-registry/rpc.md) | string[] | gRPC response metadata, `<key>` being the normalized gRPC Metadata key (lowercase), the value being the metadata values. [2] | `rpc.grpc.response.metadata.my-custom-metadata-attribute=["attribute_value"]` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 
@@ -35,7 +35,7 @@ Below is a table of attributes that SHOULD be included on client and server gRPC
 
 ---
 
-`rpc.grpc.status_code` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`rpc.grpc.response.status_code` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/model/rpc/deprecated/registry-deprecated.yaml
+++ b/model/rpc/deprecated/registry-deprecated.yaml
@@ -31,3 +31,77 @@ groups:
         stability: development
         brief: "Deprecated, use `rpc.message.uncompressed_size` instead."
         deprecated: "Replaced by `rpc.message.uncompressed_size`."
+      - id: rpc.grpc.status_code
+        type:
+          members:
+            - id: ok
+              brief: OK
+              stability: development
+              value: 0
+            - id: cancelled
+              brief: CANCELLED
+              stability: development
+              value: 1
+            - id: unknown
+              brief: UNKNOWN
+              stability: development
+              value: 2
+            - id: invalid_argument
+              brief: INVALID_ARGUMENT
+              stability: development
+              value: 3
+            - id: deadline_exceeded
+              brief: DEADLINE_EXCEEDED
+              stability: development
+              value: 4
+            - id: not_found
+              brief: NOT_FOUND
+              stability: development
+              value: 5
+            - id: already_exists
+              brief: ALREADY_EXISTS
+              stability: development
+              value: 6
+            - id: permission_denied
+              brief: PERMISSION_DENIED
+              stability: development
+              value: 7
+            - id: resource_exhausted
+              brief: RESOURCE_EXHAUSTED
+              stability: development
+              value: 8
+            - id: failed_precondition
+              brief: FAILED_PRECONDITION
+              stability: development
+              value: 9
+            - id: aborted
+              brief: ABORTED
+              stability: development
+              value: 10
+            - id: out_of_range
+              brief: OUT_OF_RANGE
+              stability: development
+              value: 11
+            - id: unimplemented
+              brief: UNIMPLEMENTED
+              stability: development
+              value: 12
+            - id: internal
+              brief: INTERNAL
+              stability: development
+              value: 13
+            - id: unavailable
+              brief: UNAVAILABLE
+              stability: development
+              value: 14
+            - id: data_loss
+              brief: DATA_LOSS
+              stability: development
+              value: 15
+            - id: unauthenticated
+              brief: UNAUTHENTICATED
+              stability: development
+              value: 16
+        stability: development
+        brief: "Deprecated, use `rpc.grpc.response.status_code` instead."
+        deprecated: "Replaced by `rpc.grpc.response.status_code`."

--- a/model/rpc/registry.yaml
+++ b/model/rpc/registry.yaml
@@ -75,7 +75,7 @@ groups:
           Instrumentations SHOULD require an explicit configuration of which metadata values are to be captured.
           Including all response metadata values can be a security risk - explicit configuration helps avoid leaking sensitive information.
         examples: ['rpc.response.metadata.my-custom-metadata-attribute=["attribute_value"]']
-      - id: rpc.grpc.status_code
+      - id: rpc.grpc.response.status_code
         type:
           members:
             - id: ok

--- a/model/rpc/spans.yaml
+++ b/model/rpc/spans.yaml
@@ -66,7 +66,7 @@ groups:
     type: attribute_group
     brief: 'Tech-specific attributes for gRPC.'
     attributes:
-      - ref: rpc.grpc.status_code
+      - ref: rpc.grpc.response.status_code
         requirement_level: required
       - ref: rpc.grpc.request.metadata
         requirement_level: opt_in


### PR DESCRIPTION
Fixes #1504

## Changes

Rename `rpc.grpc.status_code` to `rpc.grpc.response.status_code`

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
