### PR TITLE
[vcs] remove fallback value for vcs provider name attribute

### DIFF
--- a/.chloggen/2020.yaml
+++ b/.chloggen/2020.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: vcs
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove fallback value for VCS provider name attribute
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2020]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/attributes-registry/vcs.md
+++ b/docs/attributes-registry/vcs.md
@@ -106,7 +106,6 @@ the `.git` extension.
 | `github` | [GitHub](https://github.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gitlab` | [GitLab](https://gitlab.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gittea` | [Gitea](https://gitea.io) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `other_provider` | Some other version control system provider. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 

--- a/docs/cicd/cicd-metrics.md
+++ b/docs/cicd/cicd-metrics.md
@@ -355,7 +355,6 @@ the same backends.
 | `github` | [GitHub](https://github.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gitlab` | [GitLab](https://gitlab.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gittea` | [Gitea](https://gitea.io) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `other_provider` | Some other version control system provider. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -417,7 +416,6 @@ the same backends.
 | `github` | [GitHub](https://github.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gitlab` | [GitLab](https://gitlab.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gittea` | [Gitea](https://gitea.io) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `other_provider` | Some other version control system provider. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -500,7 +498,6 @@ revision based on the VCS system and situational context.
 | `github` | [GitHub](https://github.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gitlab` | [GitLab](https://gitlab.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gittea` | [Gitea](https://gitea.io) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `other_provider` | Some other version control system provider. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -583,7 +580,6 @@ revision based on the VCS system and situational context.
 | `github` | [GitHub](https://github.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gitlab` | [GitLab](https://gitlab.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gittea` | [Gitea](https://gitea.io) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `other_provider` | Some other version control system provider. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -620,7 +616,6 @@ This metric is [recommended][MetricRecommended].
 | `github` | [GitHub](https://github.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gitlab` | [GitLab](https://gitlab.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gittea` | [Gitea](https://gitea.io) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `other_provider` | Some other version control system provider. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -667,7 +662,6 @@ the same backends.
 | `github` | [GitHub](https://github.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gitlab` | [GitLab](https://gitlab.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gittea` | [Gitea](https://gitea.io) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `other_provider` | Some other version control system provider. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
@@ -755,7 +749,6 @@ the same backends.
 | `github` | [GitHub](https://github.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gitlab` | [GitLab](https://gitlab.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gittea` | [Gitea](https://gitea.io) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `other_provider` | Some other version control system provider. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
@@ -842,7 +835,6 @@ the same backends.
 | `github` | [GitHub](https://github.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gitlab` | [GitLab](https://gitlab.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gittea` | [Gitea](https://gitea.io) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `other_provider` | Some other version control system provider. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
@@ -923,7 +915,6 @@ the same backends.
 | `github` | [GitHub](https://github.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gitlab` | [GitLab](https://gitlab.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gittea` | [Gitea](https://gitea.io) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `other_provider` | Some other version control system provider. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
@@ -978,7 +969,6 @@ the same backends.
 | `github` | [GitHub](https://github.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gitlab` | [GitLab](https://gitlab.com) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gittea` | [Gitea](https://gitea.io) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `other_provider` | Some other version control system provider. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/model/vcs/registry.yaml
+++ b/model/vcs/registry.yaml
@@ -253,10 +253,6 @@ groups:
       - id: vcs.provider.name
         type:
           members:
-            - id: other_provider
-              value: other_provider
-              brief: "Some other version control system provider. Fallback only."
-              stability: development
             - id: github
               value: github
               brief: "[GitHub](https://github.com)"


### PR DESCRIPTION
## Changes

Remove fallback value for vcs provider name attribute because custom values are allowed to be set without the fallback value
Follow up on https://github.com/open-telemetry/semantic-conventions/pull/1997

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
