### PR TITLE
Update weaver to 0.14.0 and allow `_` -> `.` renames

### DIFF
--- a/dependencies.Dockerfile
+++ b/dependencies.Dockerfile
@@ -3,7 +3,7 @@
 # Dependabot can keep this file up to date with latest containers.
 
 # Weaver is used to generate markdown docs, and enforce policies on the model.
-FROM otel/weaver:v0.13.2 AS weaver
+FROM otel/weaver:v0.14.0 AS weaver
 
 # OPA is used to test policies enforced by weaver.
 FROM openpolicyagent/opa:1.3.0 AS opa

--- a/docs/dotnet/dotnet-kestrel-metrics.md
+++ b/docs/dotnet/dotnet-kestrel-metrics.md
@@ -111,7 +111,7 @@ of `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`error.type`](/docs/attributes-registry/error.md) | string | The full name of exception type. [1] | `System.OperationCanceledException`; `Contoso.MyException` | `Conditionally Required` if and only if an error has occurred. | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`error.type`](/docs/attributes-registry/error.md) | string | The full name of exception type. [1] | `connection_reset`; `invalid_handshake` | `Conditionally Required` if and only if an error has occurred. | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`network.protocol.name`](/docs/attributes-registry/network.md) | string | [OSI application layer](https://wikipedia.org/wiki/Application_layer) or non-OSI equivalent. [2] | `http`; `web_sockets` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`network.protocol.version`](/docs/attributes-registry/network.md) | string | The actual version of the protocol used for network communication. [3] | `1.1`; `2` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`network.transport`](/docs/attributes-registry/network.md) | string | [OSI transport layer](https://wikipedia.org/wiki/Transport_layer) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication). [4] | `tcp`; `unix` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |

--- a/docs/dotnet/dotnet-kestrel-metrics.md
+++ b/docs/dotnet/dotnet-kestrel-metrics.md
@@ -111,7 +111,7 @@ of `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`error.type`](/docs/attributes-registry/error.md) | string | Captures the error type when a connection fails. [1] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | `Conditionally Required` if and only if an error has occurred. | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`error.type`](/docs/attributes-registry/error.md) | string | The full name of exception type. [1] | `System.OperationCanceledException`; `Contoso.MyException` | `Conditionally Required` if and only if an error has occurred. | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`network.protocol.name`](/docs/attributes-registry/network.md) | string | [OSI application layer](https://wikipedia.org/wiki/Application_layer) or non-OSI equivalent. [2] | `http`; `web_sockets` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`network.protocol.version`](/docs/attributes-registry/network.md) | string | The actual version of the protocol used for network communication. [3] | `1.1`; `2` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`network.transport`](/docs/attributes-registry/network.md) | string | [OSI transport layer](https://wikipedia.org/wiki/Transport_layer) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication). [4] | `tcp`; `unix` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |

--- a/docs/dotnet/dotnet-kestrel-metrics.md
+++ b/docs/dotnet/dotnet-kestrel-metrics.md
@@ -111,7 +111,7 @@ of `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`error.type`](/docs/attributes-registry/error.md) | string | The full name of exception type. [1] | `System.OperationCanceledException`; `Contoso.MyException` | `Conditionally Required` if and only if an error has occurred. | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`error.type`](/docs/attributes-registry/error.md) | string | Captures the error type when a connection fails. [1] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | `Conditionally Required` if and only if an error has occurred. | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`network.protocol.name`](/docs/attributes-registry/network.md) | string | [OSI application layer](https://wikipedia.org/wiki/Application_layer) or non-OSI equivalent. [2] | `http`; `web_sockets` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`network.protocol.version`](/docs/attributes-registry/network.md) | string | The actual version of the protocol used for network communication. [3] | `1.1`; `2` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`network.transport`](/docs/attributes-registry/network.md) | string | [OSI transport layer](https://wikipedia.org/wiki/Transport_layer) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication). [4] | `tcp`; `unix` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |

--- a/model/kestrel/metrics.yaml
+++ b/model/kestrel/metrics.yaml
@@ -40,9 +40,10 @@ groups:
       - ref: tls.protocol.version
       # yamllint disable rule:line-length
       - ref: error.type
-        brief: Captures the error type when a connection fails.
+        brief: The full name of exception type.
         requirement_level:
           conditionally_required: if and only if an error has occurred.
+        examples: ['System.OperationCanceledException', 'Contoso.MyException']
         # TODO: move note to yaml once https://github.com/open-telemetry/build-tools/issues/192 is supported
         note: |
           Starting from .NET 9, Kestrel `kestrel.connection.duration` metric reports

--- a/model/kestrel/metrics.yaml
+++ b/model/kestrel/metrics.yaml
@@ -38,14 +38,11 @@ groups:
       - ref: network.protocol.version
         examples: ["1.1", "2"]
       - ref: tls.protocol.version
-      - ref: error.type
-        brief: The full name of exception type.
-        requirement_level:
-          conditionally_required: if and only if an error has occurred.
-        note: "Captures the exception type when a connection fails."
-        examples: ['System.OperationCanceledException', 'Contoso.MyException']
       # yamllint disable rule:line-length
       - ref: error.type
+        brief: Captures the error type when a connection fails.
+        requirement_level:
+          conditionally_required: if and only if an error has occurred.
         # TODO: move note to yaml once https://github.com/open-telemetry/build-tools/issues/192 is supported
         note: |
           Starting from .NET 9, Kestrel `kestrel.connection.duration` metric reports

--- a/model/kestrel/metrics.yaml
+++ b/model/kestrel/metrics.yaml
@@ -43,7 +43,7 @@ groups:
         brief: The full name of exception type.
         requirement_level:
           conditionally_required: if and only if an error has occurred.
-        examples: ['System.OperationCanceledException', 'Contoso.MyException']
+        examples: ['connection_reset', 'invalid_handshake']
         # TODO: move note to yaml once https://github.com/open-telemetry/build-tools/issues/192 is supported
         note: |
           Starting from .NET 9, Kestrel `kestrel.connection.duration` metric reports

--- a/model/messaging/deprecated/registry-deprecated.yaml
+++ b/model/messaging/deprecated/registry-deprecated.yaml
@@ -26,6 +26,9 @@ groups:
           Deprecated, use `messaging.client.id` instead.
         examples: ['client-5', 'myhost@8742@s8083jm']
         deprecated: "Replaced by `messaging.client.id`."
+        annotations:
+          code_generation:
+            exclude: true
       - id: messaging.kafka.consumer.group
         type: string
         brief: >

--- a/policies_test/attribute_name_collisions_test.rego
+++ b/policies_test/attribute_name_collisions_test.rego
@@ -29,3 +29,12 @@ test_does_not_fail_on_deprecated_namespace_collision if {
     count(deny) == 0 with input as collision
 }
 
+test_does_not_fail_on_excluded_name_collision if {
+    collision := {"groups": [
+        {"id": "test1", "attributes": [{"name": "test1.namespace.id"}, {"name": "test1.namespace_id", "annotations": {"code_generation": {"exclude": true}}}]},
+
+        {"id": "test2", "attributes": [{"name": "test2.namespace_id"}, {"name": "test2.namespace.id", "annotations": {"code_generation": {"exclude": true}}}]},
+    ]}
+    count(deny) == 0 with input as collision
+}
+


### PR DESCRIPTION
Related to #1118 and #1982

The new weaver supports excluding attributes from code generation allowing us to rename `foo_bar` to `foo.bar`!
It can be done by providing the following annotation on attribute to be excluded:

```yaml
- id: messaging.client_id
  ....
  annotations:
    code_generation:
      exclude: true
```
