### PR TITLE
Provide guidance on modeling lat/lon, x/y, etc

### DIFF
--- a/.chloggen/2145.yaml
+++ b/.chloggen/2145.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component:
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Provide guidance on modeling lat/lon, x/y, etc
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [ 2145 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/2145.yaml
+++ b/.chloggen/2145.yaml
@@ -7,7 +7,7 @@
 change_type: enhancement
 
 # The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
-component:
+component: general
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Provide guidance on modeling lat/lon, x/y, etc

--- a/docs/general/how-to-define-semantic-conventions.md
+++ b/docs/general/how-to-define-semantic-conventions.md
@@ -78,6 +78,10 @@ When defining a new attribute:
   - If the value has a reasonably short (open or closed) set of possible values, define it as an enum.
   - If the value is a timestamp, record it as a string in ISO 8601 format.
   - For arrays of primitives, use the array type. Avoid recording arrays as a single string.
+  - Arrays should be homogeneous, meaning all elements share the same type and represent the same concept.
+    For example:
+    - Latitude and longitude should be defined as separate attributes (`geo.lat` and `geo.lon`)
+      rather than combining them into a single array, as they represent distinct concepts.
   - Use the template type to define attributes with dynamic names (only the last segment of the name should be dynamic).
     This is useful for capturing user-defined key-value pairs, such as HTTP headers.
   - Represent complex values as a set of flat attributes. <!-- This may change, check out https://github.com/open-telemetry/semantic-conventions/issues/1669 to monitor the progress -->


### PR DESCRIPTION
Discussed with @open-telemetry/specs-semconv-maintainers in order to provide more explicit guidance around unblocking #1941 and #2070.

Note that this document (and guidance) is non-normative, and there may be valid reasons to deviate, but it at least makes the preference clear when it comes to modeling these sorts of things.