### PR TITLE
Remove RC status from deprecated `db.system`

### DIFF
--- a/model/database/deprecated/registry-deprecated.yaml
+++ b/model/database/deprecated/registry-deprecated.yaml
@@ -436,8 +436,8 @@ groups:
               stability: development
             - id: mariadb
               value: "mariadb"
-              brief: "MariaDB (This value has stability level RELEASE CANDIDATE)"
-              stability: release_candidate
+              brief: "MariaDB"
+              stability: development
             - id: maxdb
               value: "maxdb"
               brief: "SAP MaxDB"
@@ -452,8 +452,8 @@ groups:
               stability: development
             - id: mssql
               value: "mssql"
-              brief: "Microsoft SQL Server (This value has stability level RELEASE CANDIDATE)"
-              stability: release_candidate
+              brief: "Microsoft SQL Server"
+              stability: development
             - id: mssqlcompact
               value: "mssqlcompact"
               deprecated: "Removed, use `other_sql` instead."
@@ -461,8 +461,8 @@ groups:
               stability: development
             - id: mysql
               value: "mysql"
-              brief: "MySQL (This value has stability level RELEASE CANDIDATE)"
-              stability: release_candidate
+              brief: "MySQL"
+              stability: development
             - id: neo4j
               value: "neo4j"
               brief: "Neo4j"
@@ -489,8 +489,8 @@ groups:
               stability: development
             - id: postgresql
               value: "postgresql"
-              brief: "PostgreSQL (This value has stability level RELEASE CANDIDATE)"
-              stability: release_candidate
+              brief: "PostgreSQL"
+              stability: development
             - id: progress
               value: "progress"
               brief: "Progress Database"
@@ -527,7 +527,7 @@ groups:
               value: "vertica"
               brief: "Vertica"
               stability: development
-        stability: release_candidate
+        stability: development
 
   - id: registry.db.metrics.deprecated
     type: attribute_group


### PR DESCRIPTION
This was just missed when we deprecated `db.system`.