### PR TITLE
Add GC causes to jvm GC related metric

### DIFF
--- a/.chloggen/add-jvm-gc-cause-attribute.yaml
+++ b/.chloggen/add-jvm-gc-cause-attribute.yaml
@@ -10,7 +10,7 @@ change_type: enhancement
 component: jvm
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `jvm.gc.cause` to metric `jvm.gc.duration` as an attribute to track gc cause.
+note: Add `jvm.gc.cause` to metric `jvm.gc.duration` as an opt-in attribute to track gc cause.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/.chloggen/add-jvm-gc-cause-attribute.yaml
+++ b/.chloggen/add-jvm-gc-cause-attribute.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: jvm
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `jvm.gc.cause` to metric `jvm.gc.duration` as an attribute to track gc cause.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2065]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/attributes-registry/jvm.md
+++ b/docs/attributes-registry/jvm.md
@@ -11,8 +11,9 @@ This document defines Java Virtual machine related attributes.
 |---|---|---|---|---|
 | <a id="jvm-buffer-pool-name" href="#jvm-buffer-pool-name">`jvm.buffer.pool.name`</a> | string | Name of the buffer pool. [1] | `mapped`; `direct` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="jvm-gc-action" href="#jvm-gc-action">`jvm.gc.action`</a> | string | Name of the garbage collector action. [2] | `end of minor GC`; `end of major GC` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| <a id="jvm-gc-name" href="#jvm-gc-name">`jvm.gc.name`</a> | string | Name of the garbage collector. [3] | `G1 Young Generation`; `G1 Old Generation` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| <a id="jvm-memory-pool-name" href="#jvm-memory-pool-name">`jvm.memory.pool.name`</a> | string | Name of the memory pool. [4] | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| <a id="jvm-gc-cause" href="#jvm-gc-cause">`jvm.gc.cause`</a> | string | Name of the garbage collector cause. [3] | `System.gc()`; `Allocation Failure` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="jvm-gc-name" href="#jvm-gc-name">`jvm.gc.name`</a> | string | Name of the garbage collector. [4] | `G1 Young Generation`; `G1 Old Generation` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| <a id="jvm-memory-pool-name" href="#jvm-memory-pool-name">`jvm.memory.pool.name`</a> | string | Name of the memory pool. [5] | `G1 Old Gen`; `G1 Eden space`; `G1 Survivor Space` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | <a id="jvm-memory-type" href="#jvm-memory-type">`jvm.memory.type`</a> | string | The type of memory. | `heap`; `non_heap` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | <a id="jvm-thread-daemon" href="#jvm-thread-daemon">`jvm.thread.daemon`</a> | boolean | Whether the thread is daemon or not. |  | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | <a id="jvm-thread-state" href="#jvm-thread-state">`jvm.thread.state`</a> | string | State of the thread. | `runnable`; `blocked` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
@@ -21,9 +22,11 @@ This document defines Java Virtual machine related attributes.
 
 **[2] `jvm.gc.action`:** Garbage collector action is generally obtained via [GarbageCollectionNotificationInfo#getGcAction()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()).
 
-**[3] `jvm.gc.name`:** Garbage collector name is generally obtained via [GarbageCollectionNotificationInfo#getGcName()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcName()).
+**[3] `jvm.gc.cause`:** Garbage collector cause is generally obtained via [GarbageCollectionNotificationInfo#getGcCause()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcCause()).
 
-**[4] `jvm.memory.pool.name`:** Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()).
+**[4] `jvm.gc.name`:** Garbage collector name is generally obtained via [GarbageCollectionNotificationInfo#getGcName()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcName()).
+
+**[5] `jvm.memory.pool.name`:** Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()).
 
 ---
 

--- a/docs/runtime/jvm-metrics.md
+++ b/docs/runtime/jvm-metrics.md
@@ -223,10 +223,13 @@ of `[ 0.01, 0.1, 1, 10 ]`.
 |---|---|---|---|---|---|
 | [`jvm.gc.action`](/docs/attributes-registry/jvm.md) | string | Name of the garbage collector action. [1] | `end of minor GC`; `end of major GC` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`jvm.gc.name`](/docs/attributes-registry/jvm.md) | string | Name of the garbage collector. [2] | `G1 Young Generation`; `G1 Old Generation` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`jvm.gc.cause`](/docs/attributes-registry/jvm.md) | string | Name of the garbage collector cause. [3] | `System.gc()`; `Allocation Failure` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 **[1] `jvm.gc.action`:** Garbage collector action is generally obtained via [GarbageCollectionNotificationInfo#getGcAction()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()).
 
 **[2] `jvm.gc.name`:** Garbage collector name is generally obtained via [GarbageCollectionNotificationInfo#getGcName()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcName()).
+
+**[3] `jvm.gc.cause`:** Garbage collector cause is generally obtained via [GarbageCollectionNotificationInfo#getGcCause()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcCause()).
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/model/jvm/metrics.yaml
+++ b/model/jvm/metrics.yaml
@@ -56,6 +56,8 @@ groups:
         requirement_level: recommended
       - ref: jvm.gc.action
         requirement_level: recommended
+      - ref: jvm.gc.cause
+        requirement_level: opt_in
     stability: stable
 
   - id: metric.jvm.thread.count

--- a/model/jvm/registry.yaml
+++ b/model/jvm/registry.yaml
@@ -13,6 +13,14 @@ groups:
         note: >
           Garbage collector action is generally obtained via
           [GarbageCollectionNotificationInfo#getGcAction()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()).
+      - id: jvm.gc.cause
+        stability: development
+        type: string
+        brief: Name of the garbage collector cause.
+        examples: [ "System.gc()", "Allocation Failure" ]
+        note: >
+          Garbage collector cause is generally obtained via
+          [GarbageCollectionNotificationInfo#getGcCause()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcCause()).
       - id: jvm.gc.name
         stability: stable
         type: string


### PR DESCRIPTION
Resolves #2065

## Changes

Please provide a brief description of the changes here.

Based on the discussion with @trask during the Java SIG APAC Meeting on April 17, add garbage collection (GC) causes to the JVM GC-related metrics and ensure they are set to "opt-in."

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
