### PR TITLE
[k8s] add k8s.hpa.scaletargetref resource attributes

### DIFF
--- a/.chloggen/hpa-resource.yaml
+++ b/.chloggen/hpa-resource.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: k8s
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add new resource attributes for `k8s.hpa` to capture the `scaleTargetRef` fields
+#
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds below attributes to the `k8s.hpa` resource:
+  - `k8s.hpa.scaletarget.kind`
+  - `k8s.hpa.scaletarget.name`
+  - `k8s.hpa.scaletarget.apiversion`

--- a/.chloggen/hpa-resource.yaml
+++ b/.chloggen/hpa-resource.yaml
@@ -24,4 +24,4 @@ subtext: |
   Adds below attributes to the `k8s.hpa` resource:
   - `k8s.hpa.scaletargetref.kind`
   - `k8s.hpa.scaletargetref.name`
-  - `k8s.hpa.scaletargetref.apiversion`
+  - `k8s.hpa.scaletargetref.api_version`

--- a/.chloggen/hpa-resource.yaml
+++ b/.chloggen/hpa-resource.yaml
@@ -22,6 +22,6 @@ issues: [2008]
 # Use pipe (|) for multiline entries.
 subtext: |
   Adds below attributes to the `k8s.hpa` resource:
-  - `k8s.hpa.scaletarget.kind`
-  - `k8s.hpa.scaletarget.name`
-  - `k8s.hpa.scaletarget.apiversion`
+  - `k8s.hpa.scaletargetref.kind`
+  - `k8s.hpa.scaletargetref.name`
+  - `k8s.hpa.scaletargetref.apiversion`

--- a/.chloggen/hpa-resource.yaml
+++ b/.chloggen/hpa-resource.yaml
@@ -15,7 +15,7 @@ note: Add new resource attributes for `k8s.hpa` to capture the `scaleTargetRef` 
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.
-issues: []
+issues: [2008]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/docs/registry/attributes/k8s.md
+++ b/docs/registry/attributes/k8s.md
@@ -30,7 +30,7 @@ Kubernetes resource attributes.
 | <a id="k8s-deployment-name" href="#k8s-deployment-name">`k8s.deployment.name`</a> | string | The name of the Deployment. | `opentelemetry` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-deployment-uid" href="#k8s-deployment-uid">`k8s.deployment.uid`</a> | string | The UID of the Deployment. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-hpa-name" href="#k8s-hpa-name">`k8s.hpa.name`</a> | string | The name of the horizontal pod autoscaler. | `opentelemetry` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-hpa-scaletargetref-apiversion" href="#k8s-hpa-scaletargetref-apiversion">`k8s.hpa.scaletargetref.apiversion`</a> | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [8] | `apps/v1`; `autoscaling/v2` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-hpa-scaletargetref-api-version" href="#k8s-hpa-scaletargetref-api-version">`k8s.hpa.scaletargetref.api_version`</a> | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [8] | `apps/v1`; `autoscaling/v2` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-hpa-scaletargetref-kind" href="#k8s-hpa-scaletargetref-kind">`k8s.hpa.scaletargetref.kind`</a> | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [9] | `Deployment`; `StatefulSet` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-hpa-scaletargetref-name" href="#k8s-hpa-scaletargetref-name">`k8s.hpa.scaletargetref.name`</a> | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [10] | `my-deployment`; `my-statefulset` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-hpa-uid" href="#k8s-hpa-uid">`k8s.hpa.uid`</a> | string | The UID of the horizontal pod autoscaler. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -110,7 +110,7 @@ conflict.
 
 **[7] `k8s.deployment.label.<key>`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
 
-**[8] `k8s.hpa.scaletargetref.apiversion`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
+**[8] `k8s.hpa.scaletargetref.api_version`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
 
 **[9] `k8s.hpa.scaletargetref.kind`:** This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
 

--- a/docs/registry/attributes/k8s.md
+++ b/docs/registry/attributes/k8s.md
@@ -30,6 +30,9 @@ Kubernetes resource attributes.
 | <a id="k8s-deployment-name" href="#k8s-deployment-name">`k8s.deployment.name`</a> | string | The name of the Deployment. | `opentelemetry` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-deployment-uid" href="#k8s-deployment-uid">`k8s.deployment.uid`</a> | string | The UID of the Deployment. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-hpa-name" href="#k8s-hpa-name">`k8s.hpa.name`</a> | string | The name of the horizontal pod autoscaler. | `opentelemetry` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-hpa-scaletarget-apiversion" href="#k8s-hpa-scaletarget-apiversion">`k8s.hpa.scaletarget.apiversion`</a> | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [2] | `apps/v1`; `autoscaling/v2` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-hpa-scaletarget-kind" href="#k8s-hpa-scaletarget-kind">`k8s.hpa.scaletarget.kind`</a> | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [3] | `Deployment`; `StatefulSet` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-hpa-scaletarget-name" href="#k8s-hpa-scaletarget-name">`k8s.hpa.scaletarget.name`</a> | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [4] | `my-deployment`; `my-statefulset` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-hpa-uid" href="#k8s-hpa-uid">`k8s.hpa.uid`</a> | string | The UID of the horizontal pod autoscaler. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-job-annotation" href="#k8s-job-annotation">`k8s.job.annotation.<key>`</a> | string | The annotation key-value pairs placed on the Job. [8] | `k8s.job.annotation.number=1`; `k8s.job.annotation.data=` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-job-label" href="#k8s-job-label">`k8s.job.label.<key>`</a> | string | The label key-value pairs placed on the Job. [9] | `k8s.job.label.jobtype=ci`; `k8s.job.label.automated=` | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -85,6 +88,7 @@ Which states:
 Therefore, UIDs between clusters should be extremely unlikely to
 conflict.
 
+<<<<<<< HEAD
 **[2] `k8s.cronjob.annotation.<key>`:** Examples:
 
 - An annotation `retries` with value `4` SHOULD be recorded as the
@@ -157,6 +161,20 @@ conflict.
 **[19] `k8s.statefulset.annotation.<key>`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
 
 **[20] `k8s.statefulset.label.<key>`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
+=======
+**[2] `k8s.hpa.scaletarget.apiversion`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
+
+**[3] `k8s.hpa.scaletarget.kind`:** This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
+
+**[4] `k8s.hpa.scaletarget.name`:** This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
+
+**[5] `k8s.namespace.phase`:** This attribute aligns with the `phase` field of the
+[K8s NamespaceStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#namespacestatus-v1-core)
+
+**[6] `k8s.node.annotation`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
+
+**[7] `k8s.node.label`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
+>>>>>>> badcfb5c (add k8s.hpa.scaletarget)
 
 ---
 

--- a/docs/registry/attributes/k8s.md
+++ b/docs/registry/attributes/k8s.md
@@ -30,36 +30,36 @@ Kubernetes resource attributes.
 | <a id="k8s-deployment-name" href="#k8s-deployment-name">`k8s.deployment.name`</a> | string | The name of the Deployment. | `opentelemetry` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-deployment-uid" href="#k8s-deployment-uid">`k8s.deployment.uid`</a> | string | The UID of the Deployment. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-hpa-name" href="#k8s-hpa-name">`k8s.hpa.name`</a> | string | The name of the horizontal pod autoscaler. | `opentelemetry` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-hpa-scaletarget-apiversion" href="#k8s-hpa-scaletarget-apiversion">`k8s.hpa.scaletarget.apiversion`</a> | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [2] | `apps/v1`; `autoscaling/v2` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-hpa-scaletarget-kind" href="#k8s-hpa-scaletarget-kind">`k8s.hpa.scaletarget.kind`</a> | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [3] | `Deployment`; `StatefulSet` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-hpa-scaletarget-name" href="#k8s-hpa-scaletarget-name">`k8s.hpa.scaletarget.name`</a> | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [4] | `my-deployment`; `my-statefulset` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-hpa-scaletargetref-apiversion" href="#k8s-hpa-scaletargetref-apiversion">`k8s.hpa.scaletargetref.apiversion`</a> | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [8] | `apps/v1`; `autoscaling/v2` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-hpa-scaletargetref-kind" href="#k8s-hpa-scaletargetref-kind">`k8s.hpa.scaletargetref.kind`</a> | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [9] | `Deployment`; `StatefulSet` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-hpa-scaletargetref-name" href="#k8s-hpa-scaletargetref-name">`k8s.hpa.scaletargetref.name`</a> | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [10] | `my-deployment`; `my-statefulset` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-hpa-uid" href="#k8s-hpa-uid">`k8s.hpa.uid`</a> | string | The UID of the horizontal pod autoscaler. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-job-annotation" href="#k8s-job-annotation">`k8s.job.annotation.<key>`</a> | string | The annotation key-value pairs placed on the Job. [8] | `k8s.job.annotation.number=1`; `k8s.job.annotation.data=` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-job-label" href="#k8s-job-label">`k8s.job.label.<key>`</a> | string | The label key-value pairs placed on the Job. [9] | `k8s.job.label.jobtype=ci`; `k8s.job.label.automated=` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-job-annotation" href="#k8s-job-annotation">`k8s.job.annotation.<key>`</a> | string | The annotation key-value pairs placed on the Job. [11] | `k8s.job.annotation.number=1`; `k8s.job.annotation.data=` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-job-label" href="#k8s-job-label">`k8s.job.label.<key>`</a> | string | The label key-value pairs placed on the Job. [12] | `k8s.job.label.jobtype=ci`; `k8s.job.label.automated=` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-job-name" href="#k8s-job-name">`k8s.job.name`</a> | string | The name of the Job. | `opentelemetry` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-job-uid" href="#k8s-job-uid">`k8s.job.uid`</a> | string | The UID of the Job. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-namespace-annotation" href="#k8s-namespace-annotation">`k8s.namespace.annotation.<key>`</a> | string | The annotation key-value pairs placed on the Namespace. [10] | `k8s.namespace.annotation.ttl=0`; `k8s.namespace.annotation.data=` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-namespace-label" href="#k8s-namespace-label">`k8s.namespace.label.<key>`</a> | string | The label key-value pairs placed on the Namespace. [11] | `k8s.namespace.label.kubernetes.io/metadata.name=default`; `k8s.namespace.label.data=` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-namespace-annotation" href="#k8s-namespace-annotation">`k8s.namespace.annotation.<key>`</a> | string | The annotation key-value pairs placed on the Namespace. [13] | `k8s.namespace.annotation.ttl=0`; `k8s.namespace.annotation.data=` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-namespace-label" href="#k8s-namespace-label">`k8s.namespace.label.<key>`</a> | string | The label key-value pairs placed on the Namespace. [14] | `k8s.namespace.label.kubernetes.io/metadata.name=default`; `k8s.namespace.label.data=` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-namespace-name" href="#k8s-namespace-name">`k8s.namespace.name`</a> | string | The name of the namespace that the pod is running in. | `default` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-namespace-phase" href="#k8s-namespace-phase">`k8s.namespace.phase`</a> | string | The phase of the K8s namespace. [12] | `active`; `terminating` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-node-annotation" href="#k8s-node-annotation">`k8s.node.annotation.<key>`</a> | string | The annotation placed on the Node, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [13] | `0`; `` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-node-label" href="#k8s-node-label">`k8s.node.label.<key>`</a> | string | The label placed on the Node, the `<key>` being the label name, the value being the label value, even if the value is empty. [14] | `arm64`; `` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-namespace-phase" href="#k8s-namespace-phase">`k8s.namespace.phase`</a> | string | The phase of the K8s namespace. [15] | `active`; `terminating` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-node-annotation" href="#k8s-node-annotation">`k8s.node.annotation.<key>`</a> | string | The annotation placed on the Node, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [16] | `0`; `` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-node-label" href="#k8s-node-label">`k8s.node.label.<key>`</a> | string | The label placed on the Node, the `<key>` being the label name, the value being the label value, even if the value is empty. [17] | `arm64`; `` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-node-name" href="#k8s-node-name">`k8s.node.name`</a> | string | The name of the Node. | `node-1` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-node-uid" href="#k8s-node-uid">`k8s.node.uid`</a> | string | The UID of the Node. | `1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-pod-annotation" href="#k8s-pod-annotation">`k8s.pod.annotation.<key>`</a> | string | The annotation placed on the Pod, the `<key>` being the annotation name, the value being the annotation value. [15] | `true`; `x64`; `` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-pod-label" href="#k8s-pod-label">`k8s.pod.label.<key>`</a> | string | The label placed on the Pod, the `<key>` being the label name, the value being the label value. [16] | `my-app`; `x64`; `` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-pod-annotation" href="#k8s-pod-annotation">`k8s.pod.annotation.<key>`</a> | string | The annotation placed on the Pod, the `<key>` being the annotation name, the value being the annotation value. [18] | `true`; `x64`; `` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-pod-label" href="#k8s-pod-label">`k8s.pod.label.<key>`</a> | string | The label placed on the Pod, the `<key>` being the label name, the value being the label value. [19] | `my-app`; `x64`; `` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-pod-name" href="#k8s-pod-name">`k8s.pod.name`</a> | string | The name of the Pod. | `opentelemetry-pod-autoconf` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-pod-uid" href="#k8s-pod-uid">`k8s.pod.uid`</a> | string | The UID of the Pod. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-replicaset-annotation" href="#k8s-replicaset-annotation">`k8s.replicaset.annotation.<key>`</a> | string | The annotation key-value pairs placed on the ReplicaSet. [17] | `k8s.replicaset.annotation.replicas=0`; `k8s.replicaset.annotation.data=` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-replicaset-label" href="#k8s-replicaset-label">`k8s.replicaset.label.<key>`</a> | string | The label key-value pairs placed on the ReplicaSet. [18] | `k8s.replicaset.label.app=guestbook`; `k8s.replicaset.label.injected=` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-replicaset-annotation" href="#k8s-replicaset-annotation">`k8s.replicaset.annotation.<key>`</a> | string | The annotation key-value pairs placed on the ReplicaSet. [20] | `k8s.replicaset.annotation.replicas=0`; `k8s.replicaset.annotation.data=` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-replicaset-label" href="#k8s-replicaset-label">`k8s.replicaset.label.<key>`</a> | string | The label key-value pairs placed on the ReplicaSet. [21] | `k8s.replicaset.label.app=guestbook`; `k8s.replicaset.label.injected=` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-replicaset-name" href="#k8s-replicaset-name">`k8s.replicaset.name`</a> | string | The name of the ReplicaSet. | `opentelemetry` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-replicaset-uid" href="#k8s-replicaset-uid">`k8s.replicaset.uid`</a> | string | The UID of the ReplicaSet. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-replicationcontroller-name" href="#k8s-replicationcontroller-name">`k8s.replicationcontroller.name`</a> | string | The name of the replication controller. | `opentelemetry` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-replicationcontroller-uid" href="#k8s-replicationcontroller-uid">`k8s.replicationcontroller.uid`</a> | string | The UID of the replication controller. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-resourcequota-name" href="#k8s-resourcequota-name">`k8s.resourcequota.name`</a> | string | The name of the resource quota. | `opentelemetry` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-resourcequota-uid" href="#k8s-resourcequota-uid">`k8s.resourcequota.uid`</a> | string | The UID of the resource quota. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-statefulset-annotation" href="#k8s-statefulset-annotation">`k8s.statefulset.annotation.<key>`</a> | string | The annotation key-value pairs placed on the StatefulSet. [19] | `k8s.statefulset.annotation.replicas=1`; `k8s.statefulset.annotation.data=` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="k8s-statefulset-label" href="#k8s-statefulset-label">`k8s.statefulset.label.<key>`</a> | string | The label key-value pairs placed on the StatefulSet. [20] | `k8s.statefulset.label.app=guestbook`; `k8s.statefulset.label.injected=` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-statefulset-annotation" href="#k8s-statefulset-annotation">`k8s.statefulset.annotation.<key>`</a> | string | The annotation key-value pairs placed on the StatefulSet. [22] | `k8s.statefulset.annotation.replicas=1`; `k8s.statefulset.annotation.data=` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="k8s-statefulset-label" href="#k8s-statefulset-label">`k8s.statefulset.label.<key>`</a> | string | The label key-value pairs placed on the StatefulSet. [23] | `k8s.statefulset.label.app=guestbook`; `k8s.statefulset.label.injected=` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-statefulset-name" href="#k8s-statefulset-name">`k8s.statefulset.name`</a> | string | The name of the StatefulSet. | `opentelemetry` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-statefulset-uid" href="#k8s-statefulset-uid">`k8s.statefulset.uid`</a> | string | The UID of the StatefulSet. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="k8s-volume-name" href="#k8s-volume-name">`k8s.volume.name`</a> | string | The name of the K8s volume. | `volume0` | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -88,7 +88,6 @@ Which states:
 Therefore, UIDs between clusters should be extremely unlikely to
 conflict.
 
-<<<<<<< HEAD
 **[2] `k8s.cronjob.annotation.<key>`:** Examples:
 
 - An annotation `retries` with value `4` SHOULD be recorded as the
@@ -111,32 +110,38 @@ conflict.
 
 **[7] `k8s.deployment.label.<key>`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
 
-**[8] `k8s.job.annotation.<key>`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
+**[8] `k8s.hpa.scaletargetref.apiversion`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
 
-**[9] `k8s.job.label.<key>`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
+**[9] `k8s.hpa.scaletargetref.kind`:** This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
 
-**[10] `k8s.namespace.annotation.<key>`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
+**[10] `k8s.hpa.scaletargetref.name`:** This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
 
-**[11] `k8s.namespace.label.<key>`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
+**[11] `k8s.job.annotation.<key>`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
 
-**[12] `k8s.namespace.phase`:** This attribute aligns with the `phase` field of the
+**[12] `k8s.job.label.<key>`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
+
+**[13] `k8s.namespace.annotation.<key>`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
+
+**[14] `k8s.namespace.label.<key>`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
+
+**[15] `k8s.namespace.phase`:** This attribute aligns with the `phase` field of the
 [K8s NamespaceStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#namespacestatus-v1-core)
 
-**[13] `k8s.node.annotation.<key>`:** Examples:
+**[16] `k8s.node.annotation.<key>`:** Examples:
 
 - An annotation `node.alpha.kubernetes.io/ttl` with value `0` SHOULD be recorded as
   the `k8s.node.annotation.node.alpha.kubernetes.io/ttl` attribute with value `"0"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.node.annotation.data` attribute with value `""`.
 
-**[14] `k8s.node.label.<key>`:** Examples:
+**[17] `k8s.node.label.<key>`:** Examples:
 
 - A label `kubernetes.io/arch` with value `arm64` SHOULD be recorded
   as the `k8s.node.label.kubernetes.io/arch` attribute with value `"arm64"`.
 - A label `data` with empty string value SHOULD be recorded as
   the `k8s.node.label.data` attribute with value `""`.
 
-**[15] `k8s.pod.annotation.<key>`:** Examples:
+**[18] `k8s.pod.annotation.<key>`:** Examples:
 
 - An annotation `kubernetes.io/enforce-mountable-secrets` with value `true` SHOULD be recorded as
   the `k8s.pod.annotation.kubernetes.io/enforce-mountable-secrets` attribute with value `"true"`.
@@ -145,7 +150,7 @@ conflict.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.pod.annotation.data` attribute with value `""`.
 
-**[16] `k8s.pod.label.<key>`:** Examples:
+**[19] `k8s.pod.label.<key>`:** Examples:
 
 - A label `app` with value `my-app` SHOULD be recorded as
   the `k8s.pod.label.app` attribute with value `"my-app"`.
@@ -154,27 +159,13 @@ conflict.
 - A label `data` with empty string value SHOULD be recorded as
   the `k8s.pod.label.data` attribute with value `""`.
 
-**[17] `k8s.replicaset.annotation.<key>`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
+**[20] `k8s.replicaset.annotation.<key>`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
 
-**[18] `k8s.replicaset.label.<key>`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
+**[21] `k8s.replicaset.label.<key>`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
 
-**[19] `k8s.statefulset.annotation.<key>`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
+**[22] `k8s.statefulset.annotation.<key>`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
 
-**[20] `k8s.statefulset.label.<key>`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
-=======
-**[2] `k8s.hpa.scaletarget.apiversion`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
-
-**[3] `k8s.hpa.scaletarget.kind`:** This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
-
-**[4] `k8s.hpa.scaletarget.name`:** This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
-
-**[5] `k8s.namespace.phase`:** This attribute aligns with the `phase` field of the
-[K8s NamespaceStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#namespacestatus-v1-core)
-
-**[6] `k8s.node.annotation`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
-
-**[7] `k8s.node.label`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
->>>>>>> badcfb5c (add k8s.hpa.scaletarget)
+**[23] `k8s.statefulset.label.<key>`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
 
 ---
 

--- a/docs/resource/k8s.md
+++ b/docs/resource/k8s.md
@@ -489,12 +489,12 @@ A HorizontalPodAutoscaler (HPA for short) automatically updates a workload resou
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`k8s.hpa.name`](/docs/registry/attributes/k8s.md) | string | The name of the horizontal pod autoscaler. | `opentelemetry` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`k8s.hpa.scaletargetref.apiversion`](/docs/registry/attributes/k8s.md) | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [1] | `apps/v1`; `autoscaling/v2` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.scaletargetref.api_version`](/docs/registry/attributes/k8s.md) | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [1] | `apps/v1`; `autoscaling/v2` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`k8s.hpa.scaletargetref.kind`](/docs/registry/attributes/k8s.md) | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [2] | `Deployment`; `StatefulSet` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`k8s.hpa.scaletargetref.name`](/docs/registry/attributes/k8s.md) | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [3] | `my-deployment`; `my-statefulset` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`k8s.hpa.uid`](/docs/registry/attributes/k8s.md) | string | The UID of the horizontal pod autoscaler. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[1] `k8s.hpa.scaletargetref.apiversion`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
+**[1] `k8s.hpa.scaletargetref.api_version`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
 
 **[2] `k8s.hpa.scaletargetref.kind`:** This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
 

--- a/docs/resource/k8s.md
+++ b/docs/resource/k8s.md
@@ -489,16 +489,16 @@ A HorizontalPodAutoscaler (HPA for short) automatically updates a workload resou
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`k8s.hpa.name`](/docs/attributes-registry/k8s.md) | string | The name of the horizontal pod autoscaler. | `opentelemetry` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`k8s.hpa.scaletarget.apiversion`](/docs/attributes-registry/k8s.md) | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [1] | `apps/v1`; `autoscaling/v2` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`k8s.hpa.scaletarget.kind`](/docs/attributes-registry/k8s.md) | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [2] | `Deployment`; `StatefulSet` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`k8s.hpa.scaletarget.name`](/docs/attributes-registry/k8s.md) | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [3] | `my-deployment`; `my-statefulset` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.scaletargetref.apiversion`](/docs/attributes-registry/k8s.md) | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [1] | `apps/v1`; `autoscaling/v2` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.scaletargetref.kind`](/docs/attributes-registry/k8s.md) | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [2] | `Deployment`; `StatefulSet` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.scaletargetref.name`](/docs/attributes-registry/k8s.md) | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [3] | `my-deployment`; `my-statefulset` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`k8s.hpa.uid`](/docs/attributes-registry/k8s.md) | string | The UID of the horizontal pod autoscaler. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[1] `k8s.hpa.scaletarget.apiversion`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
+**[1] `k8s.hpa.scaletargetref.apiversion`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
 
-**[2] `k8s.hpa.scaletarget.kind`:** This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
+**[2] `k8s.hpa.scaletargetref.kind`:** This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
 
-**[3] `k8s.hpa.scaletarget.name`:** This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
+**[3] `k8s.hpa.scaletargetref.name`:** This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/docs/resource/k8s.md
+++ b/docs/resource/k8s.md
@@ -488,11 +488,11 @@ A HorizontalPodAutoscaler (HPA for short) automatically updates a workload resou
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`k8s.hpa.name`](/docs/attributes-registry/k8s.md) | string | The name of the horizontal pod autoscaler. | `opentelemetry` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`k8s.hpa.scaletargetref.apiversion`](/docs/attributes-registry/k8s.md) | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [1] | `apps/v1`; `autoscaling/v2` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`k8s.hpa.scaletargetref.kind`](/docs/attributes-registry/k8s.md) | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [2] | `Deployment`; `StatefulSet` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`k8s.hpa.scaletargetref.name`](/docs/attributes-registry/k8s.md) | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [3] | `my-deployment`; `my-statefulset` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`k8s.hpa.uid`](/docs/attributes-registry/k8s.md) | string | The UID of the horizontal pod autoscaler. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.name`](/docs/registry/attributes/k8s.md) | string | The name of the horizontal pod autoscaler. | `opentelemetry` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.scaletargetref.apiversion`](/docs/registry/attributes/k8s.md) | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [1] | `apps/v1`; `autoscaling/v2` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.scaletargetref.kind`](/docs/registry/attributes/k8s.md) | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [2] | `Deployment`; `StatefulSet` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.scaletargetref.name`](/docs/registry/attributes/k8s.md) | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [3] | `my-deployment`; `my-statefulset` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.uid`](/docs/registry/attributes/k8s.md) | string | The UID of the horizontal pod autoscaler. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 **[1] `k8s.hpa.scaletargetref.apiversion`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
 

--- a/docs/resource/k8s.md
+++ b/docs/resource/k8s.md
@@ -488,8 +488,17 @@ A HorizontalPodAutoscaler (HPA for short) automatically updates a workload resou
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`k8s.hpa.name`](/docs/registry/attributes/k8s.md) | string | The name of the horizontal pod autoscaler. | `opentelemetry` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`k8s.hpa.uid`](/docs/registry/attributes/k8s.md) | string | The UID of the horizontal pod autoscaler. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.name`](/docs/attributes-registry/k8s.md) | string | The name of the horizontal pod autoscaler. | `opentelemetry` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.scaletarget.apiversion`](/docs/attributes-registry/k8s.md) | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [1] | `apps/v1`; `autoscaling/v2` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.scaletarget.kind`](/docs/attributes-registry/k8s.md) | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [2] | `Deployment`; `StatefulSet` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.scaletarget.name`](/docs/attributes-registry/k8s.md) | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [3] | `my-deployment`; `my-statefulset` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.hpa.uid`](/docs/attributes-registry/k8s.md) | string | The UID of the horizontal pod autoscaler. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+
+**[1] `k8s.hpa.scaletarget.apiversion`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
+
+**[2] `k8s.hpa.scaletarget.kind`:** This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
+
+**[3] `k8s.hpa.scaletarget.name`:** This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/model/k8s/entities.yaml
+++ b/model/k8s/entities.yaml
@@ -164,6 +164,12 @@ groups:
     attributes:
       - ref: k8s.hpa.uid
       - ref: k8s.hpa.name
+      - ref: k8s.hpa.scaletargetref.kind
+        requirement_level: recommended
+      - ref: k8s.hpa.scaletargetref.name
+        requirement_level: recommended
+      - ref: k8s.hpa.scaletargetref.apiversion
+        requirement_level: recommended
 
   - id: entity.k8s.resourcequota
     type: entity

--- a/model/k8s/entities.yaml
+++ b/model/k8s/entities.yaml
@@ -168,7 +168,7 @@ groups:
         requirement_level: recommended
       - ref: k8s.hpa.scaletargetref.name
         requirement_level: recommended
-      - ref: k8s.hpa.scaletargetref.apiversion
+      - ref: k8s.hpa.scaletargetref.api_version
         requirement_level: recommended
 
   - id: entity.k8s.resourcequota

--- a/model/k8s/registry.yaml
+++ b/model/k8s/registry.yaml
@@ -313,7 +313,7 @@ groups:
         brief: >
           The name of the horizontal pod autoscaler.
         examples: ['opentelemetry']
-      - id: k8s.hpa.scaletarget.kind
+      - id: k8s.hpa.scaletargetref.kind
         type: string
         stability: development
         brief: >
@@ -321,7 +321,7 @@ groups:
         note: |
           This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
         examples: ["Deployment", "StatefulSet"]
-      - id: k8s.hpa.scaletarget.name
+      - id: k8s.hpa.scaletargetref.name
         type: string
         stability: development
         brief: >
@@ -329,7 +329,7 @@ groups:
         note: |
           This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
         examples: ["my-deployment", "my-statefulset"]
-      - id: k8s.hpa.scaletarget.apiversion
+      - id: k8s.hpa.scaletargetref.apiversion
         type: string
         stability: development
         brief: >

--- a/model/k8s/registry.yaml
+++ b/model/k8s/registry.yaml
@@ -329,7 +329,7 @@ groups:
         note: |
           This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
         examples: ["my-deployment", "my-statefulset"]
-      - id: k8s.hpa.scaletargetref.apiversion
+      - id: k8s.hpa.scaletargetref.api_version
         type: string
         stability: development
         brief: >

--- a/model/k8s/registry.yaml
+++ b/model/k8s/registry.yaml
@@ -313,6 +313,30 @@ groups:
         brief: >
           The name of the horizontal pod autoscaler.
         examples: ['opentelemetry']
+      - id: k8s.hpa.scaletarget.kind
+        type: string
+        stability: development
+        brief: >
+          The kind of the target resource to scale for the HorizontalPodAutoscaler.
+        note: |
+          This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
+        examples: ["Deployment", "StatefulSet"]
+      - id: k8s.hpa.scaletarget.name
+        type: string
+        stability: development
+        brief: >
+          The name of the target resource to scale for the HorizontalPodAutoscaler.
+        note: |
+          This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
+        examples: ["my-deployment", "my-statefulset"]
+      - id: k8s.hpa.scaletarget.apiversion
+        type: string
+        stability: development
+        brief: >
+          The API version of the target resource to scale for the HorizontalPodAutoscaler.
+        note: |
+          This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
+        examples: ["apps/v1", "autoscaling/v2"]
       - id: k8s.job.uid
         type: string
         stability: development


### PR DESCRIPTION
Fixes #2008

## Changes

Please provide a brief description of the changes here.

Intorduces new attributes for the `k8s.hpa` resource to capture the `scaleTargetRef` fields. 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
