### PR TITLE
[k8s] make k8s Node and Pod labels optional

### DIFF
--- a/.chloggen/node-label-opt.yaml
+++ b/.chloggen/node-label-opt.yaml
@@ -4,7 +4,7 @@
 # your pull request title with [chore] or use the "Skip Changelog" label.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
 component: k8s

--- a/.chloggen/node-label-opt.yaml
+++ b/.chloggen/node-label-opt.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: k8s
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Make k8s Node labels optional"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2079]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/node-label-opt.yaml
+++ b/.chloggen/node-label-opt.yaml
@@ -10,7 +10,7 @@ change_type: enhancement
 component: k8s
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Make k8s Node labels optional"
+note: "Make k8s Node and Pod labels optional"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/docs/resource/k8s.md
+++ b/docs/resource/k8s.md
@@ -145,10 +145,10 @@ containers on your cluster.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`k8s.pod.label.<key>`](/docs/attributes-registry/k8s.md) | string | The label key-value pairs placed on the Pod, the `<key>` being the label name, the value being the label value. | `k8s.pod.label.app=my-app`; `k8s.pod.label.mycompany.io/arch=x64`; `k8s.pod.label.data=` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`k8s.pod.name`](/docs/attributes-registry/k8s.md) | string | The name of the Pod. | `opentelemetry-pod-autoconf` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`k8s.pod.uid`](/docs/attributes-registry/k8s.md) | string | The UID of the Pod. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`k8s.pod.annotation.<key>`](/docs/attributes-registry/k8s.md) | string | The annotation key-value pairs placed on the Pod, the `<key>` being the annotation name, the value being the annotation value. | `k8s.pod.annotation.kubernetes.io/enforce-mountable-secrets=true`; `k8s.pod.annotation.mycompany.io/arch=x64`; `k8s.pod.annotation.data=` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.pod.label.<key>`](/docs/attributes-registry/k8s.md) | string | The label key-value pairs placed on the Pod, the `<key>` being the label name, the value being the label value. | `k8s.pod.label.app=my-app`; `k8s.pod.label.mycompany.io/arch=x64`; `k8s.pod.label.data=` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/docs/resource/k8s.md
+++ b/docs/resource/k8s.md
@@ -82,14 +82,14 @@ conflict.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`k8s.node.label.<key>`](/docs/attributes-registry/k8s.md) | string | The label key-value pairs placed on the Node. [1] | `k8s.node.label.kubernetes.io/arch=arm64`; `k8s.node.label.data=` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`k8s.node.name`](/docs/attributes-registry/k8s.md) | string | The name of the Node. | `node-1` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`k8s.node.uid`](/docs/attributes-registry/k8s.md) | string | The UID of the Node. | `1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`k8s.node.annotation.<key>`](/docs/attributes-registry/k8s.md) | string | The annotation key-value pairs placed on the Node. [2] | `k8s.node.annotation.node.alpha.kubernetes.io/ttl=0`; `k8s.node.annotation.data=` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.node.annotation.<key>`](/docs/attributes-registry/k8s.md) | string | The annotation key-value pairs placed on the Node. [1] | `k8s.node.annotation.node.alpha.kubernetes.io/ttl=0`; `k8s.node.annotation.data=` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`k8s.node.label.<key>`](/docs/attributes-registry/k8s.md) | string | The label key-value pairs placed on the Node. [2] | `k8s.node.label.kubernetes.io/arch=arm64`; `k8s.node.label.data=` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[1] `k8s.node.label`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
+**[1] `k8s.node.annotation`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
 
-**[2] `k8s.node.annotation`:** The `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
+**[2] `k8s.node.label`:** The `<key>` being the label name, the value being the label value, even if the value is empty.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/model/k8s/resources.yaml
+++ b/model/k8s/resources.yaml
@@ -19,6 +19,7 @@ groups:
       - ref: k8s.node.name
       - ref: k8s.node.uid
       - ref: k8s.node.label
+        requirement_level: opt_in
       - ref: k8s.node.annotation
         requirement_level: opt_in
 

--- a/model/k8s/resources.yaml
+++ b/model/k8s/resources.yaml
@@ -42,6 +42,7 @@ groups:
       - ref: k8s.pod.uid
       - ref: k8s.pod.name
       - ref: k8s.pod.label
+        requirement_level: opt_in
       - ref: k8s.pod.annotation
         requirement_level: opt_in
 


### PR DESCRIPTION
Fixes #2079 

## Changes

Make k8s Node and Pod labels optional (context [here](https://github.com/open-telemetry/semantic-conventions/pull/2168#discussion_r2055650318))

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
