### PR TITLE
Allow entity group type  in addition to resource.

### DIFF
--- a/templates/registry/markdown/snippet.md.j2
+++ b/templates/registry/markdown/snippet.md.j2
@@ -23,7 +23,7 @@
 
 {% if group.type == "event" -%}
 {{ generate_event(group) -}}
-{%- elif group.type == "resource" -%}
+{%- elif group.type == "resource" or group.type == "entity" -%}
 {{ generate_resource(group) }}
 {%- elif group.type == "metric" -%}
 {{ generate_metric(group) }}


### PR DESCRIPTION
Adds support for `entity` group type, preventing future breaking change with weaver.

See: https://github.com/open-telemetry/weaver/pull/714