### PR TITLE
Add k8s.container.ready metric

### DIFF
--- a/.chloggen/add_k8s_container_ready.yaml
+++ b/.chloggen/add_k8s_container_ready.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: k8s
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add k8s.container.ready metric
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2074]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/non-normative/k8s-migration.md
+++ b/docs/non-normative/k8s-migration.md
@@ -292,6 +292,7 @@ receiver were introduced as semantic conventions in:
 - [#2178](https://github.com/open-telemetry/semantic-conventions/pull/2178) (TODO: replace with SemConv version once
 available)
 - [#2074](https://github.com/open-telemetry/semantic-conventions/issues/2074)
+- [#2197](https://github.com/open-telemetry/semantic-conventions/issues/2197)
 
 The changes in their metrics are the following:
 
@@ -308,5 +309,6 @@ The changes in their metrics are the following:
 | `k8s.container.ephemeralstorage_limit`                                                       | `k8s.container.ephemeral_storage.limit`   |
 | `k8s.container.ephemeralstorage_request`                                                     | `k8s.container.ephemeral_storage.request` |
 | `k8s.container.restarts`                  (type: `gauge`)                          | `k8s.container.restart.count` (type: `updowncounter`) |
+| `k8s.container.ready`                  (type: `gauge`)                             | `k8s.container.ready` (type: `updowncounter`) |
 
 <!-- prettier-ignore-end -->

--- a/model/k8s/metrics.yaml
+++ b/model/k8s/metrics.yaml
@@ -579,13 +579,12 @@ groups:
     metric_name: k8s.container.ready
     stability: development
     brief: >
-      Specifies whether the container is currently passing its readiness check,
-      and is ready to accept traffic (0 for no, 1 for yes).
+      Indicates whether the container is currently marked as ready to accept traffic,
+      based on its readiness probe (1 = ready, 0 = not ready)
     instrument: updowncounter
     unit: "{container}"
+    entity_associations:
+      - k8s.container
     note: |
-      This metric aligns with the `ready` field of the
+      This metric SHOULD reflect the value of the `ready` field in the
       [K8s ContainerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstatus-v1-core).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.container`](../resource/k8s.md#container) resource.

--- a/model/k8s/metrics.yaml
+++ b/model/k8s/metrics.yaml
@@ -574,3 +574,18 @@ groups:
       It is best to not depend too much on the exact value but rather look at it as
       either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case
       you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.
+  - id: metric.k8s.container.ready
+    type: metric
+    metric_name: k8s.container.ready
+    stability: development
+    brief: >
+      Specifies whether the container is currently passing its readiness check,
+      and is ready to accept traffic (0 for no, 1 for yes).
+    instrument: updowncounter
+    unit: "{container}"
+    note: |
+      This metric aligns with the `ready` field of the
+      [K8s ContainerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstatus-v1-core).
+
+      This metric SHOULD, at a minimum, be reported against a
+      [`k8s.container`](../resource/k8s.md#container) resource.


### PR DESCRIPTION
Part of https://github.com/open-telemetry/semantic-conventions/issues/2074.

## Changes

Adds `k8s.container.ready` as defined at https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.111.0/receiver/k8sclusterreceiver/documentation.md#k8scontainerready.

| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New                                           |
|------------------------------------------------------------------------------------|-----------------------------------------------|
| `k8s.container.ready`                  (type: `gauge`)                             | `k8s.container.ready` (type: `updowncounter`) |

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
