### PR TITLE
Expand examples of targets in `db.query.summary`

### DIFF
--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -335,7 +335,7 @@ one is not readily available from other sources.
 The summary SHOULD preserve the following parts of query in the order they were provided:
 
 - operations such as SQL SELECT, INSERT, UPDATE, DELETE, and other commands
-- operation targets such as collections and database names
+- operation targets such as collections, stored procedures, database names, etc
 
 Instrumentations that support query parsing SHOULD parse the query and extract a
 list of operations and targets from the query. It SHOULD set `db.query.summary`


### PR DESCRIPTION
in particular I wanted to mention stored procedures, but also added the etc to make it extra clear this is not an exhaustive list