### PR TITLE
[chore] enable multiple components

### DIFF
--- a/.github/scripts/prepare-new-pr.sh
+++ b/.github/scripts/prepare-new-pr.sh
@@ -36,7 +36,14 @@ if [ $COUNT -eq 1 ]; then
     gh pr edit "${PR}" --add-label "${CHANGE_TYPE}" || true
     AREA=$(awk -F': ' '/^component:/ {print $2}' "$PR_CHANGELOG_PATH/$CHLOG" | xargs)
     echo $AREA
-    gh pr edit "${PR}" --add-label "area:${AREA}" || true
+    if [[ "$AREA" == \[*\] ]]; then
+      cleaned=$(echo "$AREA" | tr -d '[]' | tr ',' '\n')
+    else
+      cleaned="$AREA"
+    fi
+    for item in $(echo "$cleaned" | tr ',' ' '); do
+      gh pr edit "${PR}" --add-label "area:${item}" || true
+    done
 else
     echo "Found multiple changelog files. Ignoring this change."
 fi


### PR DESCRIPTION
Fixes #

For this PR https://github.com/open-telemetry/semantic-conventions/pull/2125/files, it has two components as below, we need to cover this case as well.

```
component: [gcp, gen-ai]
```

## Changes

Please provide a brief description of the changes here.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
