### PR TITLE
Clarify `db.query.summary` for stored procedures

### DIFF
--- a/.chloggen/2218.yaml
+++ b/.chloggen/2218.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: db
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update stored procedure summary example
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [ 2218 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/2218.yaml
+++ b/.chloggen/2218.yaml
@@ -10,7 +10,7 @@ change_type: bug_fix
 component: db
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Update stored procedure summary example
+note: Clarify `db.query.summary` for stored procedures
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -456,8 +456,8 @@ name or target).
   connection.prepareCall("{call some_stored_procedure}");
   ```
 
-  the corresponding `db.query.summary` is `CALL some_stored_procedure`,
-  `db.query.text` is not populated. `CALL` in this case is the ANSI SQL standard
+  the corresponding `db.query.summary` is `call some_stored_procedure`,
+  `db.query.text` is not populated. Note that `CALL` is the SQL standard
   keyword to invoke a stored procedure.
 
 - Stored procedure is executed using Microsoft SQL Server driver's convenience API

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -452,8 +452,12 @@ name or target).
 - Stored procedure is executed using a convenience API such as one available in
   [JDBC](https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#prepareCall-java.lang.String-):
 
+  ```java
+  connection.prepareCall("{call some_stored_procedure}");
+  ```
+
   the corresponding `db.query.summary` is `CALL some_stored_procedure`,
-  `db.query.text` is not populated. `CALL` in this case is the SQL standard
+  `db.query.text` is not populated. `CALL` in this case is the ANSI SQL standard
   keyword to invoke a stored procedure.
 
 - Stored procedure is executed using Microsoft SQL Server driver's convenience API
@@ -466,8 +470,9 @@ name or target).
     ```
 
   the corresponding `db.query.summary` is `EXECUTE some_stored_procedure`,
-  `db.query.text` is not populated. `EXECUTE` in this case is Microsoft
-  SQL Server's keyword to invoke a stored procedure.
+  `db.query.text` is not populated. Note that Microsoft SQL Server does not
+  support the SQL Standard `CALL` keyword, but uses instead `EXECUTE`
+  to invoke a stored procedure.
 
 Semantic conventions for individual database systems or specialized instrumentations
 MAY specify a different `db.query.summary` format as long as produced summary remains

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -458,7 +458,11 @@ name or target).
     command.CommandText = "some_stored_procedure";
     ```
 
-    the corresponding `db.query.summary` is `EXECUTE some_stored_procedure`, `db.query.text` is not populated. The `EXECUTE` statement is SQL Server's means to invoke a stored procedure. If the database system uses a different keyword for executing a stored procedure then that keyword SHOULD be used (e.g., `CALL some_stored_procedure`). 
+    the corresponding `db.query.summary` is `EXECUTE some_stored_procedure`,
+    `db.query.text` is not populated. The `EXECUTE` statement in this case is
+    SQL Server's means to invoke a stored procedure.
+    If the database system uses a different keyword for executing a stored procedure
+    then that keyword SHOULD be used (e.g., `CALL some_stored_procedure`).
 
 Semantic conventions for individual database systems or specialized instrumentations
 MAY specify a different `db.query.summary` format as long as produced summary remains

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -469,10 +469,10 @@ name or target).
     command.CommandText = "some_stored_procedure";
     ```
 
-  the corresponding `db.query.summary` is `EXECUTE some_stored_procedure`,
-  `db.query.text` is not populated. Note that Microsoft SQL Server does not
-  support the SQL Standard `CALL` keyword, but uses instead `EXECUTE`
-  to invoke a stored procedure.
+    the corresponding `db.query.summary` is `EXECUTE some_stored_procedure`,
+    `db.query.text` is not populated. Note that Microsoft SQL Server does not
+    support the SQL Standard `CALL` keyword, but uses instead `EXECUTE`
+    to invoke a stored procedure.
 
 Semantic conventions for individual database systems or specialized instrumentations
 MAY specify a different `db.query.summary` format as long as produced summary remains

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -458,7 +458,7 @@ name or target).
     command.CommandText = "some_stored_procedure";
     ```
 
-    the corresponding `db.query.summary` is `EXECUTE some_stored_procedure`, `db.query.text` is not populated.
+    the corresponding `db.query.summary` is `CALL some_stored_procedure`, `db.query.text` is not populated.
 
 Semantic conventions for individual database systems or specialized instrumentations
 MAY specify a different `db.query.summary` format as long as produced summary remains

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -449,8 +449,15 @@ name or target).
 
     the corresponding `db.query.summary` is `SELECT "song list" 'artists'`.
 
-- Stored procedure is executed using convenience API such as one available in
-   [Microsoft.Data.SqlClient](https://learn.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlcommand.commandtype):
+- Stored procedure is executed using a convenience API such as one available in
+  [JDBC](https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#prepareCall-java.lang.String-):
+
+  the corresponding `db.query.summary` is `CALL some_stored_procedure`,
+  `db.query.text` is not populated. `CALL` in this case is the SQL standard
+  keyword to invoke a stored procedure.
+
+- Stored procedure is executed using Microsoft SQL Server driver's convenience API
+  [Microsoft.Data.SqlClient](https://learn.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlcommand.commandtype):
 
     ```csharp
     var command = new SqlCommand();
@@ -458,11 +465,9 @@ name or target).
     command.CommandText = "some_stored_procedure";
     ```
 
-    the corresponding `db.query.summary` is `EXECUTE some_stored_procedure`,
-    `db.query.text` is not populated. The `EXECUTE` statement in this case is
-    SQL Server's means to invoke a stored procedure.
-    If the database system uses a different keyword for executing a stored procedure
-    then that keyword SHOULD be used (e.g., `CALL some_stored_procedure`).
+  the corresponding `db.query.summary` is `EXECUTE some_stored_procedure`,
+  `db.query.text` is not populated. `EXECUTE` in this case is Microsoft
+  SQL Server's keyword to invoke a stored procedure.
 
 Semantic conventions for individual database systems or specialized instrumentations
 MAY specify a different `db.query.summary` format as long as produced summary remains

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -458,7 +458,7 @@ name or target).
     command.CommandText = "some_stored_procedure";
     ```
 
-    the corresponding `db.query.summary` is `CALL some_stored_procedure`, `db.query.text` is not populated.
+    the corresponding `db.query.summary` is `EXECUTE some_stored_procedure`, `db.query.text` is not populated. The `EXECUTE` statement is SQL Server's means to invoke a stored procedure. If the database system uses a different keyword for executing a stored procedure then that keyword SHOULD be used (e.g., `CALL some_stored_procedure`). 
 
 Semantic conventions for individual database systems or specialized instrumentations
 MAY specify a different `db.query.summary` format as long as produced summary remains


### PR DESCRIPTION
@matt-hensley dug out https://web.cecs.pdx.edu/~len/sql1999.pdf and found that the ANSI SQL standard is CALL