### PR TITLE
(chore) Remove build-tools from semconv build.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -126,10 +126,3 @@ jobs:
     - name: verify semantic conventions yaml definitions
       run: make test-policies
 
-  # TODO: Remove this once policies-check is the only enforcement on github.
-  semantic-conventions-compatibility:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: verify semantic convention compatibility with latest released version
-      run: make compatibility-check

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ CONTAINER_REPOSITORY=docker.io
 
 # Per container overrides for the repository resolution.
 WEAVER_CONTAINER_REPOSITORY=$(CONTAINER_REPOSITORY)
-SEMCONVGEN_CONTAINER_REPOSITORY=$(CONTAINER_REPOSITORY)
 OPA_CONTAINER_REPOSITORY=$(CONTAINER_REPOSITORY)
 LYCHEE_CONTAINER_REPOSITORY=$(CONTAINER_REPOSITORY)
 
@@ -40,7 +39,6 @@ LYCHEE_CONTAINER_REPOSITORY=$(CONTAINER_REPOSITORY)
 # These are parsed from dependencies.Dockerfile so dependabot will autoupdate
 # the versions of docker files we use.
 VERSIONED_WEAVER_CONTAINER_NO_REPO=$(shell cat dependencies.Dockerfile | awk '$$4=="weaver" {print $$2}')
-VERSIONED_SEMCONVGEN_CONTAINER_NO_REPO=$(shell cat dependencies.Dockerfile | awk '$$4=="semconvgen" {print $$2}')
 VERSIONED_OPA_CONTAINER_NO_REPO=$(shell cat dependencies.Dockerfile | awk '$$4=="opa" {print $$2}')
 VERSIONED_LYCHEE_CONTAINER_NO_REPO=$(shell cat dependencies.Dockerfile | awk '$$4=="lychee" {print $$2}')
 
@@ -53,11 +51,10 @@ VERSIONED_LYCHEE_CONTAINER_NO_REPO=$(shell cat dependencies.Dockerfile | awk '$$
 #    Error: short-name "otel/weaver:v1.2.3" did not resolve to an alias
 #    and no unqualified-search registries are defined in "/etc/containers/registries.conf"
 WEAVER_CONTAINER=$(WEAVER_CONTAINER_REPOSITORY)/$(VERSIONED_WEAVER_CONTAINER_NO_REPO)
-SEMCONVGEN_CONTAINER=$(SEMCONVGEN_CONTAINER_REPOSITORY)/$(VERSIONED_SEMCONVGEN_CONTAINER_NO_REPO)
 OPA_CONTAINER=$(OPA_CONTAINER_REPOSITORY)/$(VERSIONED_OPA_CONTAINER_NO_REPO)
 LYCHEE_CONTAINER=$(LYCHEE_CONTAINER_REPOSITORY)/$(VERSIONED_LYCHEE_CONTAINER_NO_REPO)
 
-CHECK_TARGETS=install-tools markdownlint misspell table-check compatibility-check \
+CHECK_TARGETS=install-tools markdownlint misspell table-check \
 			schema-check check-file-and-folder-names-in-docs
 
 # Determine if "docker" is actually podman
@@ -332,9 +329,3 @@ test-policies:
 	/policies \
 	/policies_test
 
-# TODO: This is now duplicative with weaver policy checks.  We can remove
-# once github action requirements are updated.
-.PHONY: compatibility-check
-compatibility-check:
-	$(DOCKER_RUN) --rm $(DOCKER_USER_IS_HOST_USER_ARG) -v $(PWD)/model:/source -v $(PWD)/docs:/spec --pull=always \
-		$(SEMCONVGEN_CONTAINER) --continue-on-validation-errors -f /source compatibility --previous-version $(LATEST_RELEASED_SEMCONV_VERSION)

--- a/dependencies.Dockerfile
+++ b/dependencies.Dockerfile
@@ -8,9 +8,5 @@ FROM otel/weaver:v0.15.0@sha256:1cf1c72eaed57dad813c2e359133b8a15bd4facf305aae5b
 # OPA is used to test policies enforced by weaver.
 FROM openpolicyagent/opa:1.4.2@sha256:35a093d9ae828373cf88f68ecaa8189ab26287468074a3b78f0601d9c8b7a4f5 AS opa
 
-# Semconv gen is used for backwards compatibility checks.
-# TODO(jsuereth): Remove this when no longer used.
-FROM otel/semconvgen:0.25.0@sha256:9df7b8cbaa732277d64d0c0a8604d96bb6f5a36d0e96338cba5dced720c16485 AS semconvgen
-
 # Lychee is used for checking links in documentation.
 FROM lycheeverse/lychee:sha-2aa22f8@sha256:2e3786630482c41f9f2dd081e06d7da1c36d66996e8cf6573409b8bc418d48c4 AS lychee


### PR DESCRIPTION
Removes build-tools backwards compatibility check from Semconv.  This is now replaced by weaver, and starting to prevent future development of Semantic Conventions due to erosion of the `build-tools` featureset.

Related: https://github.com/open-telemetry/weaver/issues/227