### PR TITLE
[chore] Move AWS berdock attributes to AWS folder, update stability to development

### DIFF
--- a/model/aws/registry.yaml
+++ b/model/aws/registry.yaml
@@ -395,7 +395,7 @@ groups:
         examples: ["arn:aws:lambda:us-east-1:123456:function:myfunction:myalias"]
       - id: aws.lambda.resource_mapping.id
         type: string
-        stability: experimental
+        stability: development
         brief: >
           The UUID of the [AWS Lambda EvenSource Mapping](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html).
           An event source is mapped to a lambda function. It's contents are read by Lambda and used to trigger a function. This isn't available in the lambda execution
@@ -498,7 +498,7 @@ groups:
     attributes:
       - id: aws.sqs.queue.url
         type: string
-        stability: experimental
+        stability: development
         brief: >
           The URL of the AWS SQS Queue. It's a unique identifier for a queue in Amazon Simple Queue Service (SQS)
           and is used to access the queue and perform actions on it.
@@ -511,7 +511,7 @@ groups:
     attributes:
       - id: aws.sns.topic.arn
         type: string
-        stability: experimental
+        stability: development
         brief: >
           The ARN of the AWS SNS Topic. An Amazon SNS [topic](https://docs.aws.amazon.com/sns/latest/dg/sns-create-topic.html) is a logical access point that acts as a communication channel.
         examples: ["arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE"]
@@ -523,7 +523,7 @@ groups:
     attributes:
       - id: aws.kinesis.stream_name
         type: string
-        stability: experimental
+        stability: development
         brief: >
           The name of the AWS Kinesis [stream](https://docs.aws.amazon.com/streams/latest/dev/introduction.html) the request refers to. Corresponds to the `--stream-name` parameter of the
           Kinesis [describe-stream](https://docs.aws.amazon.com/cli/latest/reference/kinesis/describe-stream.html) operation.
@@ -536,13 +536,13 @@ groups:
     attributes:
       - id: aws.step_functions.activity.arn
         type: string
-        stability: experimental
+        stability: development
         brief: >
           The ARN of the AWS Step Functions Activity.
         examples: ["arn:aws:states:us-east-1:123456789012:activity:get-greeting"]
       - id: aws.step_functions.state_machine.arn
         type: string
-        stability: experimental
+        stability: development
         brief: >
           The ARN of the AWS Step Functions State Machine.
         examples: ["arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1"]
@@ -554,7 +554,28 @@ groups:
     attributes:
       - id: aws.secretsmanager.secret.arn
         type: string
-        stability: experimental
+        stability: development
         brief: >
           The ARN of the Secret stored in the Secrets Mangger
         examples: ["arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters"]
+  - id: registry.aws.bedrock
+    type: attribute_group
+    display_name: Amazon Bedrock Attributes
+    brief: >
+        This document defines attributes for AWS Bedrock.
+    attributes:
+      - id: aws.bedrock.guardrail.id
+        type: string
+        stability: development
+        brief: >
+          The unique identifier of the AWS Bedrock Guardrail.
+          A [guardrail](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) helps safeguard and prevent unwanted behavior from model responses or user messages.
+        examples: ["sgi5gkybzqak"]
+      - id: aws.bedrock.knowledge_base.id
+        type: string
+        stability: development
+        brief: >
+          The unique identifier of the AWS Bedrock Knowledge base.
+          A [knowledge base](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base.html) is a bank of information
+          that can be queried by models to generate more relevant responses and augment prompts.
+        examples: ["XFWUPB9PAW"]

--- a/model/gen-ai/registry.yaml
+++ b/model/gen-ai/registry.yaml
@@ -368,24 +368,3 @@ groups:
         type: string
         brief: A fingerprint to track any eventual change in the Generative AI environment.
         examples: ["fp_44709d6fcb"]
-  - id: registry.aws.bedrock
-    type: attribute_group
-    display_name: Amazon Bedrock Attributes
-    brief: >
-        This document defines attributes for AWS Bedrock.
-    attributes:
-      - id: aws.bedrock.guardrail.id
-        type: string
-        stability: experimental
-        brief: >
-          The unique identifier of the AWS Bedrock Guardrail.
-          A [guardrail](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) helps safeguard and prevent unwanted behavior from model responses or user messages.
-        examples: ["sgi5gkybzqak"]
-      - id: aws.bedrock.knowledge_base.id
-        type: string
-        stability: experimental
-        brief: >
-          The unique identifier of the AWS Bedrock Knowledge base.
-          A [knowledge base](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base.html) is a bank of information
-          that can be queried by models to generate more relevant responses and augment prompts.
-        examples: ["XFWUPB9PAW"]

--- a/model/hardware/host-metrics.yaml
+++ b/model/hardware/host-metrics.yaml
@@ -25,7 +25,7 @@ groups:
   - id: metric.hw.host.heating_margin
     type: metric
     metric_name: hw.host.heating_margin
-    stability: experimental
+    stability: development
     brief: >
       By how many degrees Celsius the temperature of the physical host can be increased, before reaching a warning
       threshold on one of the internal sensors
@@ -36,7 +36,7 @@ groups:
   - id: metric.hw.host.power
     type: metric
     metric_name: hw.host.power
-    stability: experimental
+    stability: development
     brief: >
       Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred)
     instrument: gauge

--- a/model/system/deprecated/metrics-deprecated.yaml
+++ b/model/system/deprecated/metrics-deprecated.yaml
@@ -4,7 +4,7 @@ groups:
     metric_name: system.cpu.time
     brief: "Deprecated. Use `cpu.time` instead."
     deprecated: "Replaced by `cpu.time`."
-    stability: experimental
+    stability: development
     instrument: counter
     unit: "s"
 
@@ -13,7 +13,7 @@ groups:
     metric_name: system.cpu.utilization
     brief: "Deprecated. Use `cpu.utilization` instead."
     deprecated: "Replaced by `cpu.utilization`."
-    stability: experimental
+    stability: development
     instrument: gauge
     unit: "1"
 
@@ -22,6 +22,6 @@ groups:
     metric_name: system.cpu.frequency
     brief: "Deprecated. Use `cpu.frequency` instead."
     deprecated: "Replaced by `cpu.frequency`."
-    stability: experimental
+    stability: development
     instrument: gauge
     unit: "{Hz}"

--- a/model/system/deprecated/registry-deprecated.yaml
+++ b/model/system/deprecated/registry-deprecated.yaml
@@ -96,6 +96,6 @@ groups:
         examples: [ "close_wait" ]
       - id: system.cpu.logical_number
         type: int
-        stability: experimental
+        stability: development
         brief: "Deprecated, use `cpu.logical_number` instead."
         examples: [1]


### PR DESCRIPTION
A small follow up after https://github.com/open-telemetry/semantic-conventions/pull/1794

/cc @ppittle @AsakerMohd 