### PR TITLE
Fix system name for MySQL

### DIFF
--- a/.chloggen/2276.yaml
+++ b/.chloggen/2276.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: db
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the `db.system.name` attribute value for MySQL which was incorrectly pointing to `microsoft.sql_server`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [ 2276 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/database/mysql.md
+++ b/docs/database/mysql.md
@@ -28,7 +28,7 @@ The Semantic Conventions for *MySQL* extend and override the [Database Semantic 
 
 Spans representing calls to a MySQL Server adhere to the general [Semantic Conventions for Database Client Spans](database-spans.md).
 
-`db.system.name` MUST be set to `"microsoft.sql_server"` and SHOULD be provided **at span creation time**.
+`db.system.name` MUST be set to `"mysql"` and SHOULD be provided **at span creation time**.
 
 **Span kind** SHOULD be `CLIENT`.
 

--- a/model/database/spans.yaml
+++ b/model/database/spans.yaml
@@ -229,7 +229,7 @@ groups:
     brief: >
       Spans representing calls to a MySQL Server adhere to the general [Semantic Conventions for Database Client Spans](database-spans.md).
     note: |
-      `db.system.name` MUST be set to `"microsoft.sql_server"` and SHOULD be provided **at span creation time**.
+      `db.system.name` MUST be set to `"mysql"` and SHOULD be provided **at span creation time**.
     attributes:
       - ref: db.namespace
         sampling_relevant: true


### PR DESCRIPTION
## Changes

MySQL should be identified as `"mysql"`, not `"microsoft.sql_server"`.

This fixes a regression introduced in https://github.com/open-telemetry/semantic-conventions/commit/a86a51c9325a2ed43b4dc363b008b4bc485b7158#diff-8b7054e134a55e0a1ec2dbd60371b69ee98213984c9973587f428e8f3695ec7a.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
