### PR TITLE
Mark feature flag semantic conventions as release candidate

### DIFF
--- a/.chloggen/ff-logs-rc.yaml
+++ b/.chloggen/ff-logs-rc.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: feature_flags
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark feature flag semantic convention as release candidate.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2277]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/feature-flags/README.md
+++ b/docs/feature-flags/README.md
@@ -7,7 +7,7 @@ linkTitle: Feature flags
 **Status**: [Development][DocumentStatus]
 
 This document defines semantic conventions for recording dynamic feature flag
-evaluations in spans and logs.
+evaluations in logs.
 
 Semantic conventions for feature flags are defined for the following signals:
 

--- a/docs/feature-flags/feature-flags-logs.md
+++ b/docs/feature-flags/feature-flags-logs.md
@@ -48,7 +48,7 @@ The table below indicates which attributes should be added to the
 <!-- markdownlint-capture -->
 <!-- markdownlint-disable -->
 
-**Status:** ![Development](https://img.shields.io/badge/-development-blue)
+**Status:** ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid)
 
 The event name MUST be `feature_flag.evaluation`.
 
@@ -58,29 +58,29 @@ A `feature_flag.evaluation` event SHOULD be emitted whenever a feature flag valu
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`feature_flag.key`](/docs/registry/attributes/feature-flag.md) | string | The lookup key of the feature flag. | `logo-color` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`feature_flag.key`](/docs/registry/attributes/feature-flag.md) | string | The lookup key of the feature flag. | `logo-color` | `Required` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
 | [`error.type`](/docs/registry/attributes/error.md) | string | Describes a class of error the operation ended with. [1] | `provider_not_ready`; `targeting_key_missing`; `provider_fatal`; `general` | `Conditionally Required` [2] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| [`feature_flag.result.value`](/docs/registry/attributes/feature-flag.md) | any | The evaluated value of the feature flag. [3] | `#ff0000`; `true`; `3` | `Conditionally Required` [4] | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`feature_flag.result.variant`](/docs/registry/attributes/feature-flag.md) | string | A semantic identifier for an evaluated flag value. [5] | `red`; `true`; `on` | `Conditionally Required` [6] | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`feature_flag.result.value`](/docs/registry/attributes/feature-flag.md) | any | The evaluated value of the feature flag. [3] | `#ff0000`; `true`; `3` | `Conditionally Required` [4] | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| [`feature_flag.result.variant`](/docs/registry/attributes/feature-flag.md) | string | A semantic identifier for an evaluated flag value. [5] | `red`; `true`; `on` | `Conditionally Required` [6] | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
 | [`error.message`](/docs/registry/attributes/error.md) | string | A message providing more detail about an error in human-readable form. [7] | `Unexpected input type: string`; `The user has exceeded their storage quota` | `Recommended` [8] | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`feature_flag.context.id`](/docs/registry/attributes/feature-flag.md) | string | The unique identifier for the flag evaluation context. For example, the targeting key. | `5157782b-2203-4c80-a857-dbbd5e7761db` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`feature_flag.provider.name`](/docs/registry/attributes/feature-flag.md) | string | Identifies the feature flag provider. | `Flag Manager` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`feature_flag.result.reason`](/docs/registry/attributes/feature-flag.md) | string | The reason code which shows how a feature flag value was determined. | `static`; `targeting_match`; `error`; `default` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`feature_flag.set.id`](/docs/registry/attributes/feature-flag.md) | string | The identifier of the [flag set](https://openfeature.dev/specification/glossary/#flag-set) to which the feature flag belongs. | `proj-1`; `ab98sgs`; `service1/dev` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`feature_flag.version`](/docs/registry/attributes/feature-flag.md) | string | The version of the ruleset used during the evaluation. This may be any stable value which uniquely identifies the ruleset. | `1`; `01ABCDEF` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`feature_flag.context.id`](/docs/registry/attributes/feature-flag.md) | string | The unique identifier for the flag evaluation context. For example, the targeting key. | `5157782b-2203-4c80-a857-dbbd5e7761db` | `Recommended` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| [`feature_flag.provider.name`](/docs/registry/attributes/feature-flag.md) | string | Identifies the feature flag provider. | `Flag Manager` | `Recommended` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| [`feature_flag.result.reason`](/docs/registry/attributes/feature-flag.md) | string | The reason code which shows how a feature flag value was determined. | `static`; `targeting_match`; `error`; `default` | `Recommended` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| [`feature_flag.set.id`](/docs/registry/attributes/feature-flag.md) | string | The identifier of the [flag set](https://openfeature.dev/specification/glossary/#flag-set) to which the feature flag belongs. | `proj-1`; `ab98sgs`; `service1/dev` | `Recommended` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| [`feature_flag.version`](/docs/registry/attributes/feature-flag.md) | string | The version of the ruleset used during the evaluation. This may be any stable value which uniquely identifies the ruleset. | `1`; `01ABCDEF` | `Recommended` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
 
 **[1] `error.type`:** If one of these values applies, then it MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|
-| `flag_not_found` | The flag could not be found. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `invalid_context` | The evaluation context does not meet provider requirements. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `parse_error` | An error was encountered parsing data, such as a flag configuration. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `provider_fatal` | The provider has entered an irrecoverable error state. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `provider_not_ready` | The value was resolved before the provider was initialized. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `targeting_key_missing` | The provider requires a targeting key and one was not provided in the evaluation context. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `type_mismatch` | The type of the flag value does not match the expected type. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `general` | The error was for a reason not enumerated above. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `flag_not_found` | The flag could not be found. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `invalid_context` | The evaluation context does not meet provider requirements. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `parse_error` | An error was encountered parsing data, such as a flag configuration. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `provider_fatal` | The provider has entered an irrecoverable error state. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `provider_not_ready` | The value was resolved before the provider was initialized. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `targeting_key_missing` | The provider requires a targeting key and one was not provided in the evaluation context. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `type_mismatch` | The type of the flag value does not match the expected type. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `general` | The error was for a reason not enumerated above. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
 
 **[2] `error.type`:** If and only if an error occurred during flag evaluation.
 
@@ -117,15 +117,15 @@ For example, the variant `red` maybe be used for the value `#c05543`.
 
 | Value  | Description | Stability |
 |---|---|---|
-| `cached` | The resolved value was retrieved from cache. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `default` | The resolved value fell back to a pre-configured value (no dynamic evaluation occurred or dynamic evaluation yielded no result). | ![Development](https://img.shields.io/badge/-development-blue) |
-| `disabled` | The resolved value was the result of the flag being disabled in the management system. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `error` | The resolved value was the result of an error. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `split` | The resolved value was the result of pseudorandom assignment. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `stale` | The resolved value is non-authoritative or possibly out of date | ![Development](https://img.shields.io/badge/-development-blue) |
-| `static` | The resolved value is static (no dynamic evaluation). | ![Development](https://img.shields.io/badge/-development-blue) |
-| `targeting_match` | The resolved value was the result of a dynamic evaluation, such as a rule or specific user-targeting. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `unknown` | The reason for the resolved value could not be determined. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `cached` | The resolved value was retrieved from cache. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `default` | The resolved value fell back to a pre-configured value (no dynamic evaluation occurred or dynamic evaluation yielded no result). | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `disabled` | The resolved value was the result of the flag being disabled in the management system. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `error` | The resolved value was the result of an error. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `split` | The resolved value was the result of pseudorandom assignment. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `stale` | The resolved value is non-authoritative or possibly out of date | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `static` | The resolved value is static (no dynamic evaluation). | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `targeting_match` | The resolved value was the result of a dynamic evaluation, such as a rule or specific user-targeting. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `unknown` | The reason for the resolved value could not be determined. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/docs/registry/attributes/feature-flag.md
+++ b/docs/registry/attributes/feature-flag.md
@@ -12,14 +12,14 @@ This document defines attributes for Feature Flags.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
-| <a id="feature-flag-context-id" href="#feature-flag-context-id">`feature_flag.context.id`</a> | string | The unique identifier for the flag evaluation context. For example, the targeting key. | `5157782b-2203-4c80-a857-dbbd5e7761db` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="feature-flag-key" href="#feature-flag-key">`feature_flag.key`</a> | string | The lookup key of the feature flag. | `logo-color` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="feature-flag-provider-name" href="#feature-flag-provider-name">`feature_flag.provider.name`</a> | string | Identifies the feature flag provider. | `Flag Manager` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="feature-flag-result-reason" href="#feature-flag-result-reason">`feature_flag.result.reason`</a> | string | The reason code which shows how a feature flag value was determined. | `static`; `targeting_match`; `error`; `default` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="feature-flag-result-value" href="#feature-flag-result-value">`feature_flag.result.value`</a> | any | The evaluated value of the feature flag. [1] | `#ff0000`; `true`; `3` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="feature-flag-result-variant" href="#feature-flag-result-variant">`feature_flag.result.variant`</a> | string | A semantic identifier for an evaluated flag value. [2] | `red`; `true`; `on` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="feature-flag-set-id" href="#feature-flag-set-id">`feature_flag.set.id`</a> | string | The identifier of the [flag set](https://openfeature.dev/specification/glossary/#flag-set) to which the feature flag belongs. | `proj-1`; `ab98sgs`; `service1/dev` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="feature-flag-version" href="#feature-flag-version">`feature_flag.version`</a> | string | The version of the ruleset used during the evaluation. This may be any stable value which uniquely identifies the ruleset. | `1`; `01ABCDEF` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="feature-flag-context-id" href="#feature-flag-context-id">`feature_flag.context.id`</a> | string | The unique identifier for the flag evaluation context. For example, the targeting key. | `5157782b-2203-4c80-a857-dbbd5e7761db` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| <a id="feature-flag-key" href="#feature-flag-key">`feature_flag.key`</a> | string | The lookup key of the feature flag. | `logo-color` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| <a id="feature-flag-provider-name" href="#feature-flag-provider-name">`feature_flag.provider.name`</a> | string | Identifies the feature flag provider. | `Flag Manager` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| <a id="feature-flag-result-reason" href="#feature-flag-result-reason">`feature_flag.result.reason`</a> | string | The reason code which shows how a feature flag value was determined. | `static`; `targeting_match`; `error`; `default` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| <a id="feature-flag-result-value" href="#feature-flag-result-value">`feature_flag.result.value`</a> | any | The evaluated value of the feature flag. [1] | `#ff0000`; `true`; `3` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| <a id="feature-flag-result-variant" href="#feature-flag-result-variant">`feature_flag.result.variant`</a> | string | A semantic identifier for an evaluated flag value. [2] | `red`; `true`; `on` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| <a id="feature-flag-set-id" href="#feature-flag-set-id">`feature_flag.set.id`</a> | string | The identifier of the [flag set](https://openfeature.dev/specification/glossary/#flag-set) to which the feature flag belongs. | `proj-1`; `ab98sgs`; `service1/dev` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| <a id="feature-flag-version" href="#feature-flag-version">`feature_flag.version`</a> | string | The version of the ruleset used during the evaluation. This may be any stable value which uniquely identifies the ruleset. | `1`; `01ABCDEF` | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
 
 **[1] `feature_flag.result.value`:** With some feature flag providers, feature flag results can be quite large or contain private or sensitive details.
 Because of this, `feature_flag.result.variant` is often the preferred attribute if it is available.
@@ -38,15 +38,15 @@ For example, the variant `red` maybe be used for the value `#c05543`.
 
 | Value  | Description | Stability |
 |---|---|---|
-| `cached` | The resolved value was retrieved from cache. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `default` | The resolved value fell back to a pre-configured value (no dynamic evaluation occurred or dynamic evaluation yielded no result). | ![Development](https://img.shields.io/badge/-development-blue) |
-| `disabled` | The resolved value was the result of the flag being disabled in the management system. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `error` | The resolved value was the result of an error. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `split` | The resolved value was the result of pseudorandom assignment. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `stale` | The resolved value is non-authoritative or possibly out of date | ![Development](https://img.shields.io/badge/-development-blue) |
-| `static` | The resolved value is static (no dynamic evaluation). | ![Development](https://img.shields.io/badge/-development-blue) |
-| `targeting_match` | The resolved value was the result of a dynamic evaluation, such as a rule or specific user-targeting. | ![Development](https://img.shields.io/badge/-development-blue) |
-| `unknown` | The reason for the resolved value could not be determined. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `cached` | The resolved value was retrieved from cache. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `default` | The resolved value fell back to a pre-configured value (no dynamic evaluation occurred or dynamic evaluation yielded no result). | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `disabled` | The resolved value was the result of the flag being disabled in the management system. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `error` | The resolved value was the result of an error. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `split` | The resolved value was the result of pseudorandom assignment. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `stale` | The resolved value is non-authoritative or possibly out of date | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `static` | The resolved value is static (no dynamic evaluation). | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `targeting_match` | The resolved value was the result of a dynamic evaluation, such as a rule or specific user-targeting. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+| `unknown` | The reason for the resolved value could not be determined. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
 
 ## Deprecated Feature Flag Attributes
 

--- a/model/feature-flags/events.yaml
+++ b/model/feature-flags/events.yaml
@@ -2,7 +2,7 @@ groups:
   - id: event.feature_flag.evaluation
     type: event
     name: feature_flag.evaluation
-    stability: development
+    stability: release_candidate
     brief: >
       Defines feature flag evaluation as an event.
     note: >
@@ -43,14 +43,14 @@ groups:
 
           | Value  | Description | Stability |
           |---|---|---|
-          | `flag_not_found` | The flag could not be found. | ![Development](https://img.shields.io/badge/-development-blue) |
-          | `invalid_context` | The evaluation context does not meet provider requirements. | ![Development](https://img.shields.io/badge/-development-blue) |
-          | `parse_error` | An error was encountered parsing data, such as a flag configuration. | ![Development](https://img.shields.io/badge/-development-blue) |
-          | `provider_fatal` | The provider has entered an irrecoverable error state. | ![Development](https://img.shields.io/badge/-development-blue) |
-          | `provider_not_ready` | The value was resolved before the provider was initialized. | ![Development](https://img.shields.io/badge/-development-blue) |
-          | `targeting_key_missing` | The provider requires a targeting key and one was not provided in the evaluation context. | ![Development](https://img.shields.io/badge/-development-blue) |
-          | `type_mismatch` | The type of the flag value does not match the expected type. | ![Development](https://img.shields.io/badge/-development-blue) |
-          | `general` | The error was for a reason not enumerated above. | ![Development](https://img.shields.io/badge/-development-blue) |
+          | `flag_not_found` | The flag could not be found. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+          | `invalid_context` | The evaluation context does not meet provider requirements. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+          | `parse_error` | An error was encountered parsing data, such as a flag configuration. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+          | `provider_fatal` | The provider has entered an irrecoverable error state. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+          | `provider_not_ready` | The value was resolved before the provider was initialized. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+          | `targeting_key_missing` | The provider requires a targeting key and one was not provided in the evaluation context. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+          | `type_mismatch` | The type of the flag value does not match the expected type. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
+          | `general` | The error was for a reason not enumerated above. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) |
       - ref: error.message
         requirement_level:
           recommended: If and only if an error occurred during flag evaluation and `error.type` does not sufficiently describe the error.

--- a/model/feature-flags/registry.yaml
+++ b/model/feature-flags/registry.yaml
@@ -1,24 +1,24 @@
 groups:
   - id: registry.feature_flag
     type: attribute_group
-    stability: development
+    stability: release_candidate
     display_name: Feature Flag Attributes
     brief: >
         This document defines attributes for Feature Flags.
     attributes:
       - id: feature_flag.key
         type: string
-        stability: development
+        stability: release_candidate
         brief: The lookup key of the feature flag.
         examples: ["logo-color"]
       - id: feature_flag.provider.name
         type: string
-        stability: development
+        stability: release_candidate
         brief: Identifies the feature flag provider.
         examples: ["Flag Manager"]
       - id: feature_flag.result.variant
         type: string
-        stability: development
+        stability: release_candidate
         examples: ["red", "true", "on"]
         brief: >
           A semantic identifier for an evaluated flag value.
@@ -29,19 +29,19 @@ groups:
           For example, the variant `red` maybe be used for the value `#c05543`.
       - id: feature_flag.context.id
         type: string
-        stability: development
+        stability: release_candidate
         examples: ["5157782b-2203-4c80-a857-dbbd5e7761db"]
         brief: >
           The unique identifier for the flag evaluation context. For example, the targeting key.
       - id: feature_flag.version
         type: string
-        stability: development
+        stability: release_candidate
         examples: ["1", "01ABCDEF"]
         brief: >
           The version of the ruleset used during the evaluation. This may be any stable value which uniquely identifies the ruleset.
       - id: feature_flag.set.id
         type: string
-        stability: development
+        stability: release_candidate
         examples: ["proj-1", "ab98sgs", "service1/dev"]
         brief: >
           The identifier of the [flag set](https://openfeature.dev/specification/glossary/#flag-set) to which the feature flag belongs.
@@ -51,46 +51,46 @@ groups:
             - id: static
               value: "static"
               brief: The resolved value is static (no dynamic evaluation).
-              stability: development
+              stability: release_candidate
             - id: default
               value: "default"
               brief: The resolved value fell back to a pre-configured value (no dynamic evaluation occurred or dynamic evaluation yielded no result).
-              stability: development
+              stability: release_candidate
             - id: targeting_match
               value: "targeting_match"
               brief: The resolved value was the result of a dynamic evaluation, such as a rule or specific user-targeting.
-              stability: development
+              stability: release_candidate
             - id: split
               value: "split"
               brief: The resolved value was the result of pseudorandom assignment.
-              stability: development
+              stability: release_candidate
             - id: cached
               value: "cached"
               brief: The resolved value was retrieved from cache.
-              stability: development
+              stability: release_candidate
             - id: disabled
               value: "disabled"
               brief: The resolved value was the result of the flag being disabled in the management system.
-              stability: development
+              stability: release_candidate
             - id: unknown
               value: "unknown"
               brief: The reason for the resolved value could not be determined.
-              stability: development
+              stability: release_candidate
             - id: stale
               value: "stale"
               brief: The resolved value is non-authoritative or possibly out of date
-              stability: development
+              stability: release_candidate
             - id: error
               value: "error"
               brief: The resolved value was the result of an error.
-              stability: development
-        stability: development
+              stability: release_candidate
+        stability: release_candidate
         examples: ["static", "targeting_match", "error", "default"]
         brief: >
           The reason code which shows how a feature flag value was determined.
       - id: feature_flag.result.value
         type: any
-        stability: development
+        stability: release_candidate
         examples: ["#ff0000", true, 3]
         brief: The evaluated value of the feature flag.
         note: |


### PR DESCRIPTION
Fixes #2249

## Changes

Mark feature flag logs semantic conventions and all associated attributes as Release Candidate

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
* ~~[ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.~~
