### PR TITLE
Update recording errors doc - document when to use `error`, `exception` (or both) attributes

### DIFF
--- a/docs/general/recording-errors.md
+++ b/docs/general/recording-errors.md
@@ -5,16 +5,24 @@
 <!-- toc -->
 
 - [What constitutes an error](#what-constitutes-an-error)
+- [Error vs exception](#error-vs-exception)
 - [Recording errors on spans](#recording-errors-on-spans)
 - [Recording errors on metrics](#recording-errors-on-metrics)
+- [Recording errors on logs and events](#recording-errors-on-logs-and-events)
 - [Recording exceptions](#recording-exceptions)
 
 <!-- tocstop -->
 
 This document provides recommendations to semantic convention and instrumentation authors
-on how to record errors on spans and metrics.
+on how to record errors on spans, metrics, and logs.
 
 Individual semantic conventions are encouraged to provide additional guidance.
+
+In the scope of this document, the terms error and exception are defined as follows:
+
+- *Error* refers to a general concept describing any non-success condition. This may include an, non-success status code, or an invalid response.
+
+- *Exception* specifically refers to runtime exceptions and their associated stack traces.
 
 ## What constitutes an error
 
@@ -39,6 +47,50 @@ An operation SHOULD be considered as failed if any of the following is true:
 Errors that were retried or handled (allowing an operation to complete gracefully) SHOULD NOT
 be recorded on spans or metrics that describe this operation.
 
+## Error vs exception
+
+When recording errors that also associated with an exception, instrumentation
+MAY record applicable [error](/docs/registry/attributes/error.md) *and*
+[exception](/docs/registry/attributes/exception.md) attributes.
+
+Semantic conventions SHOULD document the applicable set of attributes, which may
+include only `error`, only `exception`, or both, depending on the signal and
+convention.
+
+General recommendations:
+
+- Semantic conventions intended for cross-language applicability SHOULD use
+  `error.*` attributes.
+
+- `exception` attributes SHOULD be documented for conventions that target
+  exceptions directly such as [`exception` events](/docs/exceptions/exceptions-logs.md).
+
+- when the error and exception details are identical, and both sets
+  of attributes are documented by the convention, it's RECOMMENDED to
+  populate `error.type` and `error.message` (when applicable) instead
+  of the corresponding `exception.*` attributes.
+
+  **Example:**
+
+  The instrumentation catches network-related exception that does
+  not include any structured information about the failure. The instrumentation
+  should set `error.type` to the fully qualified exception type and omit
+  `exception.type`.
+
+- when the error and exception details differ, and both sets of
+  attributes are documented by the convention, it's RECOMMENDED to
+  populate the `error` attributes along with any `exception`
+  attributes that differ from the corresponding `error` ones.
+
+  **Example:**
+
+  The instrumentation catches a network-related exception that exposes a status
+  code.
+  The instrumentation should set `error.type` to the status code provided in the
+  exception. If the corresponding convention documents `exception` attributes,
+  the instrumentation also sets `exception.type` to the fully qualified
+  exception type.
+
 ## Recording errors on spans
 
 [Span Status Code][SpanStatus] MUST be left unset if the instrumented operation has
@@ -52,10 +104,12 @@ When the operation ends with an error, instrumentation:
   about the error which is not expected to contain sensitive details and aligns
   with [Span Status Description][SpanStatus] definition.
 
-  It's NOT RECOMMENDED to duplicate status code or `error.type` in span status description.
+  It's NOT RECOMMENDED to duplicate status code, `error.type`, `error.message`,
+  or `exception.message` in the span status description.
 
-  When the operation fails with an exception, the span status description SHOULD be set to
-  the exception message.
+  When an operation fails due to an exception, the span status description
+  SHOULD be set to the exception message, unless a more precise description is
+  available through other means.
 
 Refer to the [recording exceptions](#recording-exceptions) on capturing exception
 details.
@@ -81,7 +135,28 @@ and metrics when both are reported. A span and its corresponding metric for a si
 operation SHOULD have the same `error.type` value if the operation failed and SHOULD NOT
 include it if the operation succeeded.
 
+## Recording errors on logs and events
+
+Semantic conventions describing events SHOULD include `error.type` and
+`error.message` when applicable. For example, if an event represents the outcome
+of an operation, it SHOULD include `error` attributes when the operation fails.
+
+Similar to metrics, it is RECOMMENDED to define a single event type representing
+both successful and failed outcomes, rather than using two distinct event types.
+
+When instrumentation also records spans or metrics for the same operation,
+`error.type` SHOULD be populated consistently across all signals. The
+`error.message` on the event SHOULD generally match the status description on the
+corresponding span.
+
 ## Recording exceptions
+
+> [!WARNING]
+>
+> Span events [are being deprecated](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/4430-span-event-api-deprecation-plan.md)
+> and the guidance below is likely to change in the future. See
+> [Recording exceptions as logs records OTEP](https://github.com/open-telemetry/opentelemetry-specification/pull/4333)
+> for more details.
 
 When an instrumented operation fails with an exception, instrumentation SHOULD record
 this exception as a [span event](/docs/exceptions/exceptions-spans.md) or a [log record](/docs/exceptions/exceptions-logs.md).
@@ -117,6 +192,8 @@ public boolean createIfNotExists(String resourceId) throws IOException {
     span.setAttribute(AttributeKey.stringKey("error.type"), e.getClass().getCanonicalName())
     span.setStatus(StatusCode.ERROR, e.getMessage());
     throw e;
+  } finally {
+    span.end();
   }
 }
 ```

--- a/docs/registry/attributes/error.md
+++ b/docs/registry/attributes/error.md
@@ -18,6 +18,8 @@ It is also NOT RECOMMENDED to duplicate the value of `exception.message` in `err
 
 `error.message` is NOT RECOMMENDED for metrics or spans due to its unbounded cardinality and overlap with span status.
 
+See [Recording errors](/docs/general/recording-errors.md) for more information.
+
 **[2] `error.type`:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
 
 When `error.type` is set to a type (e.g., an exception type), its

--- a/model/error/registry.yaml
+++ b/model/error/registry.yaml
@@ -48,3 +48,5 @@ groups:
           It is also NOT RECOMMENDED to duplicate the value of `exception.message` in `error.message`.
 
           `error.message` is NOT RECOMMENDED for metrics or spans due to its unbounded cardinality and overlap with span status.
+
+          See [Recording errors](/docs/general/recording-errors.md) for more information.


### PR DESCRIPTION
Fixes #2001

Updates errors guidance to cover:
- errors vs exceptions and when to use which set of attributes
- reporting errors on logs/events
- reporting `error.message` attribute