### PR TITLE
[chore][workflow/changelog] Fix comparisons to main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,6 +18,8 @@ concurrency:
 jobs:
   changelog:
     runs-on: ubuntu-latest
+    env:
+      PR_HEAD: ${{ github.event.pull_request.head.sha }}
     if: >-
       ${{
         github.event_name == 'pull_request' &&
@@ -45,7 +47,7 @@ jobs:
 
       - name: Ensure no changes to the CHANGELOG.md
         run: |
-          if [[ $(git diff --name-only origin/main HEAD ./CHANGELOG*.md) ]]
+          if [[ $(git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD ./CHANGELOG*.md) ]]
           then
           echo "CHANGELOG.md should not be directly modified."
             echo "Please add a .yaml file to the ./.chloggen/ directory."
@@ -58,7 +60,7 @@ jobs:
 
       - name: Ensure ./.chloggen/*.yaml addition(s)
         run: |
-          if [[ 1 -gt $(git diff --diff-filter=A --name-only origin/main HEAD ./.chloggen | grep -c \\.yaml) ]]
+          if [[ 1 -gt $(git diff --diff-filter=A --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD ./.chloggen | grep -c \\.yaml) ]]
           then
             echo "No changelog entry was added to the ./.chloggen/ directory."
             echo "Please add a .yaml file to the ./.chloggen/ directory."


### PR DESCRIPTION
## Changes

[Changelog checks are failing](https://github.com/open-telemetry/semantic-conventions/actions/runs/15187441564/job/43124065964#step:6:18) on a [recent PR](https://github.com/open-telemetry/semantic-conventions/pull/2294) with an error saying no changelog file has been added. The PR however has added a changelog file.

The error is occurring because the changelog workflow is comparing the PR's branch against `origin/main` directly. When a branch is not up to date with `main`, as is the case with the referenced PR, files added to `main` that aren't in the PR's branch show up as renamed in `git`, rather than new files. The check then fails because no new files were detected.

The solution here is to compare the PR's branch to the best common ancestor (`git merge-base`) with `origin/main`. This takes into account the branch being out of date and properly detects new files.

Note that this change is simply being copied over from [opentelemetry-collector](https://github.com/open-telemetry/opentelemetry-collector/blob/4a3717978a51e6929c90bdaccfba3ea369044629/.github/workflows/changelog.yml) and [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c665dd39ac44ac7b80f963a377b5bd171705cc0b/.github/workflows/changelog.yml)

## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [X] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [X] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
