### PR TITLE
[chore] Clarify .count for updowncounters guidance

### DIFF
--- a/docs/general/naming.md
+++ b/docs/general/naming.md
@@ -290,18 +290,17 @@ Examples:
 
 #### Do not pluralize UpDownCounter names
 
-If the value being recorded represents the count of concepts signified
-by the namespace then the metric SHOULD be named `count` within that namespace.
+UpDownCounter names MUST NOT be pluralized.
+
+If the value being recorded represents a count of the concepts defined by the namespace,
+a suffix such as `count`, `active`, etc. SHOULD be used within that namespace.
 
 For example if we have a namespace `system.process` which contains all metrics related
 to the processes then to represent the count of the processes we can have a metric named
 `system.process.count` instead of `system.processes`.
 
-It's not always necessary to use `count`.
-For example, a suffix like `active` should be enough when the metric represents the number of concepts
-in `active` state, i.e. `cicd.pipeline.run.active`.
-
-What is required, is to not pluralize UpDownCounter metric names.
+Similarly, a suffix like `active` SHOULD be used when the metric represents the number of
+concepts in an active state — for example, `cicd.pipeline.run.active`.
 
 #### Do not use `total`
 

--- a/docs/general/naming.md
+++ b/docs/general/naming.md
@@ -24,7 +24,7 @@ aliases: [attribute-naming]
 - [Metrics](#metrics)
   - [Naming rules for counters and UpDownCounters](#naming-rules-for-counters-and-updowncounters)
     - [Pluralization](#pluralization)
-    - [Use `count` instead of pluralization for UpDownCounters](#use-count-instead-of-pluralization-for-updowncounters)
+    - [Use `count` instead of pluralization for UpDownCounters (when a namespace exists)](#use-count-instead-of-pluralization-for-updowncounters-when-a-namespace-exists)
     - [Do not use `total`](#do-not-use-total)
   - [Instrument naming](#instrument-naming)
   - [Client and server metrics](#client-and-server-metrics)
@@ -288,14 +288,18 @@ Examples:
 - `system.paging.faults`, `system.disk.operations`, and `system.network.packets`
   should be pluralized, even if only a single data point is recorded.
 
-#### Use `count` instead of pluralization for UpDownCounters
+#### Use `count` instead of pluralization for UpDownCounters (when a namespace exists)
 
 If the value being recorded represents the count of concepts signified
-by the namespace then the metric should be named `count` (within its namespace).
+by the namespace then the metric SHOULD be named `count` within that namespace.
 
 For example if we have a namespace `system.process` which contains all metrics related
 to the processes then to represent the count of the processes we can have a metric named
 `system.process.count`.
+
+Using `count` is not required for UpDownCounters when there is no meaningful namespace to preserve.
+For instance, `k8s.deployment.desired_pods` is acceptable, as there is no need to use singular
+`k8s.deployment.desired_pod.*` as a namespace.
 
 #### Do not use `total`
 

--- a/docs/general/naming.md
+++ b/docs/general/naming.md
@@ -24,7 +24,7 @@ aliases: [attribute-naming]
 - [Metrics](#metrics)
   - [Naming rules for counters and UpDownCounters](#naming-rules-for-counters-and-updowncounters)
     - [Pluralization](#pluralization)
-    - [Use `count` instead of pluralization for UpDownCounters (when a namespace exists)](#use-count-instead-of-pluralization-for-updowncounters-when-a-namespace-exists)
+    - [Do not pluralize UpDownCounter names](#do-not-pluralize-updowncounter-names)
     - [Do not use `total`](#do-not-use-total)
   - [Instrument naming](#instrument-naming)
   - [Client and server metrics](#client-and-server-metrics)
@@ -288,18 +288,20 @@ Examples:
 - `system.paging.faults`, `system.disk.operations`, and `system.network.packets`
   should be pluralized, even if only a single data point is recorded.
 
-#### Use `count` instead of pluralization for UpDownCounters (when a namespace exists)
+#### Do not pluralize UpDownCounter names
 
 If the value being recorded represents the count of concepts signified
 by the namespace then the metric SHOULD be named `count` within that namespace.
 
 For example if we have a namespace `system.process` which contains all metrics related
 to the processes then to represent the count of the processes we can have a metric named
-`system.process.count`.
+`system.process.count` instead of `system.processes`.
 
-Using `count` is not required for UpDownCounters when there is no meaningful namespace to preserve.
-For instance, `k8s.deployment.desired_pods` is acceptable, as there is no need to use singular
-`k8s.deployment.desired_pod.*` as a namespace.
+It's not always necessary to use `count`.
+For example, a suffix like `active` should be enough when the metric represents the number of concepts
+in `active` state, i.e. `cicd.pipeline.run.active`.
+
+What is required, is to not pluralize UpDownCounter metric names.
 
 #### Do not use `total`
 

--- a/docs/general/naming.md
+++ b/docs/general/naming.md
@@ -290,17 +290,12 @@ Examples:
 
 #### Do not pluralize UpDownCounter names
 
-UpDownCounter names MUST NOT be pluralized.
-
-If the value being recorded represents a count of the concepts defined by the namespace,
-a suffix such as `count`, `active`, etc. SHOULD be used within that namespace.
+UpDownCounter names SHOULD NOT be pluralized.
 
 For example if we have a namespace `system.process` which contains all metrics related
 to the processes then to represent the count of the processes we can have a metric named
-`system.process.count` instead of `system.processes`.
-
-Similarly, a suffix like `active` SHOULD be used when the metric represents the number of
-concepts in an active state — for example, `cicd.pipeline.run.active`.
+`system.process.count` instead of `system.processes`. Similarly, `cicd.pipeline.run.active` is preferred
+over the `cicd.pipeline.active_runs`.
 
 #### Do not use `total`
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/2306

## Changes

This PR tries to clarfiy the guidance regarding the usage of `.count` for `UpDownCounter`s as it was described at https://github.com/open-telemetry/semantic-conventions/issues/2306.

/cc @trask @lmolkova @braydonk 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
