### PR TITLE
[chore] properly define entity_associations for k8s metrics

### DIFF
--- a/docs/system/k8s-metrics.md
+++ b/docs/system/k8s-metrics.md
@@ -103,7 +103,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.uptime` | Gauge | `s` | The time the Pod has been running [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.pod.uptime` | Gauge | `s` | The time the Pod has been running [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.pod` |
 
 **[1]:** Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
 The actual accuracy would depend on the instrumentation and operating system.
@@ -126,7 +126,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.cpu.time` | Counter | `s` | Total CPU time consumed [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.pod.cpu.time` | Counter | `s` | Total CPU time consumed [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.pod` |
 
 **[1]:** Total CPU time consumed by the specific Pod on all available CPU cores
 
@@ -170,7 +170,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.memory.usage` | Gauge | `By` | Memory usage of the Pod [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.pod.memory.usage` | Gauge | `By` | Memory usage of the Pod [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.pod` |
 
 **[1]:** Total memory usage of the Pod
 
@@ -192,7 +192,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.network.io` | Counter | `By` | Network bytes for the Pod | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.pod.network.io` | Counter | `By` | Network bytes for the Pod | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.pod` |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -226,7 +226,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.network.errors` | Counter | `{error}` | Pod network errors | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.pod.network.errors` | Counter | `{error}` | Pod network errors | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.pod` |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -264,7 +264,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.status.state` | UpDownCounter | `{container}` | Describes the number of K8s containers that are currently in a given state [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.container.status.state` | UpDownCounter | `{container}` | Describes the number of K8s containers that are currently in a given state [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.container` |
 
 **[1]:** All possible container states will be reported at each time interval to avoid missing metrics.
 Only the value corresponding to the current state will be non-zero.
@@ -301,7 +301,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.status.reason` | UpDownCounter | `{container}` | Describes the number of K8s containers that are currently in a state for a given reason [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.container.status.reason` | UpDownCounter | `{container}` | Describes the number of K8s containers that are currently in a state for a given reason [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.container` |
 
 **[1]:** All possible container state reasons will be reported at each time interval to avoid missing metrics.
 Only the value corresponding to the current state reason will be non-zero.
@@ -348,7 +348,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.uptime` | Gauge | `s` | The time the Node has been running [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.node.uptime` | Gauge | `s` | The time the Node has been running [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.node` |
 
 **[1]:** Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
 The actual accuracy would depend on the instrumentation and operating system.
@@ -451,7 +451,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.cpu.time` | Counter | `s` | Total CPU time consumed [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.node.cpu.time` | Counter | `s` | Total CPU time consumed [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.node` |
 
 **[1]:** Total CPU time consumed by the specific Node on all available CPU cores
 
@@ -473,7 +473,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.cpu.usage` | Gauge | `{cpu}` | Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.node.cpu.usage` | Gauge | `{cpu}` | Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.node` |
 
 **[1]:** CPU usage of the specific Node on all available CPU cores, averaged over the sample window
 
@@ -495,7 +495,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.memory.usage` | Gauge | `By` | Memory usage of the Node [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.node.memory.usage` | Gauge | `By` | Memory usage of the Node [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.node` |
 
 **[1]:** Total memory usage of the Node
 
@@ -517,7 +517,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.network.io` | Counter | `By` | Network bytes for the Node | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.node.network.io` | Counter | `By` | Network bytes for the Node | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.node` |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -551,7 +551,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.network.errors` | Counter | `{error}` | Node network errors | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.node.network.errors` | Counter | `{error}` | Node network errors | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.node` |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -589,13 +589,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.deployment.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this deployment [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.deployment.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this deployment [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.deployment` |
 
 **[1]:** This metric aligns with the `replicas` field of the
 [K8s DeploymentSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#deploymentspec-v1-apps).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.deployment`](../resource/k8s.md#deployment) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -615,13 +612,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.deployment.available_pods` | UpDownCounter | `{pod}` | Total number of available replica pods (ready for at least minReadySeconds) targeted by this deployment [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.deployment.available_pods` | UpDownCounter | `{pod}` | Total number of available replica pods (ready for at least minReadySeconds) targeted by this deployment [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.deployment` |
 
 **[1]:** This metric aligns with the `availableReplicas` field of the
 [K8s DeploymentStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#deploymentstatus-v1-apps).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.deployment`](../resource/k8s.md#deployment) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -645,13 +639,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.replicaset.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this replicaset [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.replicaset.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this replicaset [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.replicaset` |
 
 **[1]:** This metric aligns with the `replicas` field of the
 [K8s ReplicaSetSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicasetspec-v1-apps).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.replicaset`](../resource/k8s.md#replicaset) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -671,13 +662,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.replicaset.available_pods` | UpDownCounter | `{pod}` | Total number of available replica pods (ready for at least minReadySeconds) targeted by this replicaset [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.replicaset.available_pods` | UpDownCounter | `{pod}` | Total number of available replica pods (ready for at least minReadySeconds) targeted by this replicaset [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.replicaset` |
 
 **[1]:** This metric aligns with the `availableReplicas` field of the
 [K8s ReplicaSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicasetstatus-v1-apps).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.replicaset`](../resource/k8s.md#replicaset) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -701,13 +689,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.replicationcontroller.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this replication controller [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.replicationcontroller.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this replication controller [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.replicationcontroller` |
 
 **[1]:** This metric aligns with the `replicas` field of the
 [K8s ReplicationControllerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerspec-v1-core)
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.replicationcontroller`](../resource/k8s.md#replicationcontroller) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -727,13 +712,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.replicationcontroller.available_pods` | UpDownCounter | `{pod}` | Total number of available replica pods (ready for at least minReadySeconds) targeted by this replication controller [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.replicationcontroller.available_pods` | UpDownCounter | `{pod}` | Total number of available replica pods (ready for at least minReadySeconds) targeted by this replication controller [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.replicationcontroller` |
 
 **[1]:** This metric aligns with the `availableReplicas` field of the
 [K8s ReplicationControllerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerstatus-v1-core)
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.replicationcontroller`](../resource/k8s.md#replicationcontroller) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -757,13 +739,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.statefulset.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this statefulset [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.statefulset.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this statefulset [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.statefulset` |
 
 **[1]:** This metric aligns with the `replicas` field of the
 [K8s StatefulSetSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetspec-v1-apps).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.statefulset`](../resource/k8s.md#statefulset) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -783,13 +762,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.statefulset.ready_pods` | UpDownCounter | `{pod}` | The number of replica pods created for this statefulset with a Ready Condition [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.statefulset.ready_pods` | UpDownCounter | `{pod}` | The number of replica pods created for this statefulset with a Ready Condition [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.statefulset` |
 
 **[1]:** This metric aligns with the `readyReplicas` field of the
 [K8s StatefulSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.statefulset`](../resource/k8s.md#statefulset) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -809,13 +785,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.statefulset.current_pods` | UpDownCounter | `{pod}` | The number of replica pods created by the statefulset controller from the statefulset version indicated by currentRevision [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.statefulset.current_pods` | UpDownCounter | `{pod}` | The number of replica pods created by the statefulset controller from the statefulset version indicated by currentRevision [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.statefulset` |
 
 **[1]:** This metric aligns with the `currentReplicas` field of the
 [K8s StatefulSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.statefulset`](../resource/k8s.md#statefulset) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -835,13 +808,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.statefulset.updated_pods` | UpDownCounter | `{pod}` | Number of replica pods created by the statefulset controller from the statefulset version indicated by updateRevision [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.statefulset.updated_pods` | UpDownCounter | `{pod}` | Number of replica pods created by the statefulset controller from the statefulset version indicated by updateRevision [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.statefulset` |
 
 **[1]:** This metric aligns with the `updatedReplicas` field of the
 [K8s StatefulSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.statefulset`](../resource/k8s.md#statefulset) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -865,13 +835,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.hpa.desired_pods` | UpDownCounter | `{pod}` | Desired number of replica pods managed by this horizontal pod autoscaler, as last calculated by the autoscaler [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.hpa.desired_pods` | UpDownCounter | `{pod}` | Desired number of replica pods managed by this horizontal pod autoscaler, as last calculated by the autoscaler [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.hpa` |
 
 **[1]:** This metric aligns with the `desiredReplicas` field of the
 [K8s HorizontalPodAutoscalerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerstatus-v2-autoscaling)
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.hpa`](../resource/k8s.md#horizontalpodautoscaler) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -891,13 +858,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.hpa.current_pods` | UpDownCounter | `{pod}` | Current number of replica pods managed by this horizontal pod autoscaler, as last seen by the autoscaler [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.hpa.current_pods` | UpDownCounter | `{pod}` | Current number of replica pods managed by this horizontal pod autoscaler, as last seen by the autoscaler [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.hpa` |
 
 **[1]:** This metric aligns with the `currentReplicas` field of the
 [K8s HorizontalPodAutoscalerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerstatus-v2-autoscaling)
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.hpa`](../resource/k8s.md#horizontalpodautoscaler) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -917,13 +881,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.hpa.max_pods` | UpDownCounter | `{pod}` | The upper limit for the number of replica pods to which the autoscaler can scale up [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.hpa.max_pods` | UpDownCounter | `{pod}` | The upper limit for the number of replica pods to which the autoscaler can scale up [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.hpa` |
 
 **[1]:** This metric aligns with the `maxReplicas` field of the
 [K8s HorizontalPodAutoscalerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerspec-v2-autoscaling)
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.hpa`](../resource/k8s.md#horizontalpodautoscaler) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -943,13 +904,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.hpa.min_pods` | UpDownCounter | `{pod}` | The lower limit for the number of replica pods to which the autoscaler can scale down [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.hpa.min_pods` | UpDownCounter | `{pod}` | The lower limit for the number of replica pods to which the autoscaler can scale down [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.hpa` |
 
 **[1]:** This metric aligns with the `minReplicas` field of the
 [K8s HorizontalPodAutoscalerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerspec-v2-autoscaling)
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.hpa`](../resource/k8s.md#horizontalpodautoscaler) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -973,13 +931,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.daemonset.current_scheduled_nodes` | UpDownCounter | `{node}` | Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.daemonset.current_scheduled_nodes` | UpDownCounter | `{node}` | Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.daemonset` |
 
 **[1]:** This metric aligns with the `currentNumberScheduled` field of the
 [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.daemonset`](../resource/k8s.md#daemonset) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -999,13 +954,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.daemonset.desired_scheduled_nodes` | UpDownCounter | `{node}` | Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod) [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.daemonset.desired_scheduled_nodes` | UpDownCounter | `{node}` | Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod) [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.daemonset` |
 
 **[1]:** This metric aligns with the `desiredNumberScheduled` field of the
 [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.daemonset`](../resource/k8s.md#daemonset) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -1025,13 +977,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.daemonset.misscheduled_nodes` | UpDownCounter | `{node}` | Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.daemonset.misscheduled_nodes` | UpDownCounter | `{node}` | Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.daemonset` |
 
 **[1]:** This metric aligns with the `numberMisscheduled` field of the
 [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.daemonset`](../resource/k8s.md#daemonset) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -1051,13 +1000,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.daemonset.ready_nodes` | UpDownCounter | `{node}` | Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.daemonset.ready_nodes` | UpDownCounter | `{node}` | Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.daemonset` |
 
 **[1]:** This metric aligns with the `numberReady` field of the
 [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.daemonset`](../resource/k8s.md#daemonset) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -1081,13 +1027,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.job.active_pods` | UpDownCounter | `{pod}` | The number of pending and actively running pods for a job [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.job.active_pods` | UpDownCounter | `{pod}` | The number of pending and actively running pods for a job [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.job` |
 
 **[1]:** This metric aligns with the `active` field of the
 [K8s JobStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.job`](../resource/k8s.md#job) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -1107,13 +1050,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.job.failed_pods` | UpDownCounter | `{pod}` | The number of pods which reached phase Failed for a job [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.job.failed_pods` | UpDownCounter | `{pod}` | The number of pods which reached phase Failed for a job [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.job` |
 
 **[1]:** This metric aligns with the `failed` field of the
 [K8s JobStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.job`](../resource/k8s.md#job) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -1133,13 +1073,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.job.successful_pods` | UpDownCounter | `{pod}` | The number of pods which reached phase Succeeded for a job [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.job.successful_pods` | UpDownCounter | `{pod}` | The number of pods which reached phase Succeeded for a job [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.job` |
 
 **[1]:** This metric aligns with the `succeeded` field of the
 [K8s JobStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.job`](../resource/k8s.md#job) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -1159,13 +1096,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.job.desired_successful_pods` | UpDownCounter | `{pod}` | The desired number of successfully finished pods the job should be run with [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.job.desired_successful_pods` | UpDownCounter | `{pod}` | The desired number of successfully finished pods the job should be run with [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.job` |
 
 **[1]:** This metric aligns with the `completions` field of the
-[K8s JobSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobspec-v1-batch).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.job`](../resource/k8s.md#job) resource.
+[K8s JobSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobspec-v1-batch)..
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -1185,13 +1119,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.job.max_parallel_pods` | UpDownCounter | `{pod}` | The max desired number of pods the job should run at any given time [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.job.max_parallel_pods` | UpDownCounter | `{pod}` | The max desired number of pods the job should run at any given time [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.job` |
 
 **[1]:** This metric aligns with the `parallelism` field of the
 [K8s JobSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobspec-v1-batch).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.job`](../resource/k8s.md#job) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -1215,13 +1146,10 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.cronjob.active_jobs` | UpDownCounter | `{job}` | The number of actively running jobs for a cronjob [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.cronjob.active_jobs` | UpDownCounter | `{job}` | The number of actively running jobs for a cronjob [1] | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.cronjob` |
 
 **[1]:** This metric aligns with the `active` field of the
 [K8s CronJobStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#cronjobstatus-v1-batch).
-
-This metric SHOULD, at a minimum, be reported against a
-[`k8s.cronjob`](../resource/k8s.md#cronjob) resource.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -1245,10 +1173,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.namespace.phase` | UpDownCounter | `{namespace}` | Describes number of K8s namespaces that are currently in a given phase. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
-
-**[1]:** This metric SHOULD, at a minimum, be reported against a
-[`k8s.namespace`](../resource/k8s.md#namespace) resource.
+| `k8s.namespace.phase` | UpDownCounter | `{namespace}` | Describes number of K8s namespaces that are currently in a given phase. | ![Development](https://img.shields.io/badge/-development-blue) | `k8s.namespace` |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|

--- a/model/k8s/metrics.yaml
+++ b/model/k8s/metrics.yaml
@@ -5,6 +5,8 @@ groups:
     metric_name: k8s.pod.uptime
     stability: development
     brief: "The time the Pod has been running"
+    entity_associations:
+      - k8s.pod
     note: |
       Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
       The actual accuracy would depend on the instrumentation and operating system.
@@ -16,6 +18,8 @@ groups:
     metric_name: k8s.pod.cpu.time
     stability: development
     brief: "Total CPU time consumed"
+    entity_associations:
+      - k8s.pod
     note: >
       Total CPU time consumed by the specific Pod on all available CPU cores
     instrument: counter
@@ -36,6 +40,8 @@ groups:
     metric_name: k8s.pod.memory.usage
     stability: development
     brief: "Memory usage of the Pod"
+    entity_associations:
+      - k8s.pod
     note: >
       Total memory usage of the Pod
     instrument: gauge
@@ -49,6 +55,8 @@ groups:
     brief: "Network bytes for the Pod"
     instrument: counter
     unit: "By"
+    entity_associations:
+      - k8s.pod
     attributes:
       - ref: network.interface.name
       - ref: network.io.direction
@@ -58,6 +66,8 @@ groups:
     stability: development
     brief: "Pod network errors"
     instrument: counter
+    entity_associations:
+      - k8s.pod
     unit: "{error}"
     attributes:
       - ref: network.interface.name
@@ -74,6 +84,8 @@ groups:
       Only the value corresponding to the current state will be non-zero.
     instrument: updowncounter
     unit: "{container}"
+    entity_associations:
+      - k8s.container
     attributes:
       - ref: k8s.container.status.state
         requirement_level: required
@@ -84,6 +96,8 @@ groups:
     brief: "Describes the number of K8s containers that are currently in a state for a given reason"
     instrument: updowncounter
     unit: "{container}"
+    entity_associations:
+      - k8s.container
     note: |
       All possible container state reasons will be reported at each time interval to avoid missing metrics.
       Only the value corresponding to the current state reason will be non-zero.
@@ -102,6 +116,8 @@ groups:
       The actual accuracy would depend on the instrumentation and operating system.
     instrument: gauge
     unit: "s"
+    entity_associations:
+      - k8s.node
   - id: metric.k8s.node.allocatable.cpu
     type: metric
     metric_name: k8s.node.allocatable.cpu
@@ -147,6 +163,8 @@ groups:
     note: >
       Total CPU time consumed by the specific Node on all available CPU cores
     instrument: counter
+    entity_associations:
+      - k8s.node
     unit: "s"
   - id: metric.k8s.node.cpu.usage
     type: metric
@@ -156,6 +174,8 @@ groups:
     note: >
       CPU usage of the specific Node on all available CPU cores, averaged over the sample window
     instrument: gauge
+    entity_associations:
+      - k8s.node
     unit: "{cpu}"
 
   # k8s.node.memory.* metrics
@@ -167,6 +187,8 @@ groups:
     note: >
       Total memory usage of the Node
     instrument: gauge
+    entity_associations:
+      - k8s.node
     unit: "By"
 
   # k8s.node.network.* metrics
@@ -177,6 +199,8 @@ groups:
     brief: "Network bytes for the Node"
     instrument: counter
     unit: "By"
+    entity_associations:
+      - k8s.node
     attributes:
       - ref: network.interface.name
       - ref: network.io.direction
@@ -187,6 +211,8 @@ groups:
     brief: "Node network errors"
     instrument: counter
     unit: "{error}"
+    entity_associations:
+      - k8s.node
     attributes:
       - ref: network.interface.name
       - ref: network.io.direction
@@ -197,25 +223,23 @@ groups:
     metric_name: k8s.deployment.desired_pods
     stability: development
     brief: "Number of desired replica pods in this deployment"
+    entity_associations:
+      - k8s.deployment
     note: |
       This metric aligns with the `replicas` field of the
       [K8s DeploymentSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#deploymentspec-v1-apps).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.deployment`](../resource/k8s.md#deployment) resource.
     instrument: updowncounter
     unit: "{pod}"
   - id: metric.k8s.deployment.available_pods
     type: metric
     metric_name: k8s.deployment.available_pods
     stability: development
+    entity_associations:
+      - k8s.deployment
     brief: "Total number of available replica pods (ready for at least minReadySeconds) targeted by this deployment"
     note: |
       This metric aligns with the `availableReplicas` field of the
       [K8s DeploymentStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#deploymentstatus-v1-apps).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.deployment`](../resource/k8s.md#deployment) resource.
     instrument: updowncounter
     unit: "{pod}"
 
@@ -225,25 +249,23 @@ groups:
     metric_name: k8s.replicaset.desired_pods
     stability: development
     brief: "Number of desired replica pods in this replicaset"
+    entity_associations:
+      - k8s.replicaset
     note: |
       This metric aligns with the `replicas` field of the
       [K8s ReplicaSetSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicasetspec-v1-apps).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.replicaset`](../resource/k8s.md#replicaset) resource.
     instrument: updowncounter
     unit: "{pod}"
   - id: metric.k8s.replicaset.available_pods
     type: metric
     metric_name: k8s.replicaset.available_pods
     stability: development
+    entity_associations:
+      - k8s.replicaset
     brief: "Total number of available replica pods (ready for at least minReadySeconds) targeted by this replicaset"
     note: |
       This metric aligns with the `availableReplicas` field of the
       [K8s ReplicaSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicasetstatus-v1-apps).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.replicaset`](../resource/k8s.md#replicaset) resource.
     instrument: updowncounter
     unit: "{pod}"
 
@@ -253,25 +275,23 @@ groups:
     metric_name: k8s.replicationcontroller.desired_pods
     stability: development
     brief: "Number of desired replica pods in this replication controller"
+    entity_associations:
+      - k8s.replicationcontroller
     note: |
       This metric aligns with the `replicas` field of the
       [K8s ReplicationControllerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerspec-v1-core)
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.replicationcontroller`](../resource/k8s.md#replicationcontroller) resource.
     instrument: updowncounter
     unit: "{pod}"
   - id: metric.k8s.replicationcontroller.available_pods
     type: metric
     metric_name: k8s.replicationcontroller.available_pods
     stability: development
+    entity_associations:
+      - k8s.replicationcontroller
     brief: "Total number of available replica pods (ready for at least minReadySeconds) targeted by this replication controller"
     note: |
       This metric aligns with the `availableReplicas` field of the
       [K8s ReplicationControllerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerstatus-v1-core)
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.replicationcontroller`](../resource/k8s.md#replicationcontroller) resource.
     instrument: updowncounter
     unit: "{pod}"
 
@@ -281,51 +301,47 @@ groups:
     metric_name: k8s.statefulset.desired_pods
     stability: development
     brief: "Number of desired replica pods in this statefulset"
+    entity_associations:
+      - k8s.statefulset
     note: |
       This metric aligns with the `replicas` field of the
       [K8s StatefulSetSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetspec-v1-apps).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.statefulset`](../resource/k8s.md#statefulset) resource.
     instrument: updowncounter
     unit: "{pod}"
   - id: metric.k8s.statefulset.ready_pods
     type: metric
     metric_name: k8s.statefulset.ready_pods
     stability: development
+    entity_associations:
+      - k8s.statefulset
     brief: "The number of replica pods created for this statefulset with a Ready Condition"
     note: |
       This metric aligns with the `readyReplicas` field of the
       [K8s StatefulSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.statefulset`](../resource/k8s.md#statefulset) resource.
     instrument: updowncounter
     unit: "{pod}"
   - id: metric.k8s.statefulset.current_pods
     type: metric
     metric_name: k8s.statefulset.current_pods
     stability: development
+    entity_associations:
+      - k8s.statefulset
     brief: "The number of replica pods created by the statefulset controller from the statefulset version indicated by currentRevision"
     note: |
       This metric aligns with the `currentReplicas` field of the
       [K8s StatefulSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.statefulset`](../resource/k8s.md#statefulset) resource.
     instrument: updowncounter
     unit: "{pod}"
   - id: metric.k8s.statefulset.updated_pods
     type: metric
     metric_name: k8s.statefulset.updated_pods
     stability: development
+    entity_associations:
+      - k8s.statefulset
     brief: "Number of replica pods created by the statefulset controller from the statefulset version indicated by updateRevision"
     note: |
       This metric aligns with the `updatedReplicas` field of the
       [K8s StatefulSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.statefulset`](../resource/k8s.md#statefulset) resource.
     instrument: updowncounter
     unit: "{pod}"
 
@@ -338,10 +354,9 @@ groups:
     note: |
       This metric aligns with the `desiredReplicas` field of the
       [K8s HorizontalPodAutoscalerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerstatus-v2-autoscaling)
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.hpa`](../resource/k8s.md#horizontalpodautoscaler) resource.
     instrument: updowncounter
+    entity_associations:
+      - k8s.hpa
     unit: "{pod}"
   - id: metric.k8s.hpa.current_pods
     type: metric
@@ -351,10 +366,9 @@ groups:
     note: |
       This metric aligns with the `currentReplicas` field of the
       [K8s HorizontalPodAutoscalerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerstatus-v2-autoscaling)
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.hpa`](../resource/k8s.md#horizontalpodautoscaler) resource.
     instrument: updowncounter
+    entity_associations:
+      - k8s.hpa
     unit: "{pod}"
   - id: metric.k8s.hpa.max_pods
     type: metric
@@ -364,10 +378,9 @@ groups:
     note: |
       This metric aligns with the `maxReplicas` field of the
       [K8s HorizontalPodAutoscalerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerspec-v2-autoscaling)
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.hpa`](../resource/k8s.md#horizontalpodautoscaler) resource.
     instrument: updowncounter
+    entity_associations:
+      - k8s.hpa
     unit: "{pod}"
   - id: metric.k8s.hpa.min_pods
     type: metric
@@ -377,10 +390,9 @@ groups:
     note: |
       This metric aligns with the `minReplicas` field of the
       [K8s HorizontalPodAutoscalerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerspec-v2-autoscaling)
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.hpa`](../resource/k8s.md#horizontalpodautoscaler) resource.
     instrument: updowncounter
+    entity_associations:
+      - k8s.hpa
     unit: "{pod}"
 
   # k8s.daemonset.* metrics
@@ -392,10 +404,9 @@ groups:
     note: |
       This metric aligns with the `currentNumberScheduled` field of the
       [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.daemonset`](../resource/k8s.md#daemonset) resource.
     instrument: updowncounter
+    entity_associations:
+      - k8s.daemonset
     unit: "{node}"
   - id: metric.k8s.daemonset.desired_scheduled_nodes
     type: metric
@@ -405,10 +416,9 @@ groups:
     note: |
       This metric aligns with the `desiredNumberScheduled` field of the
       [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.daemonset`](../resource/k8s.md#daemonset) resource.
     instrument: updowncounter
+    entity_associations:
+      - k8s.daemonset
     unit: "{node}"
   - id: metric.k8s.daemonset.misscheduled_nodes
     type: metric
@@ -418,10 +428,9 @@ groups:
     note: |
       This metric aligns with the `numberMisscheduled` field of the
       [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.daemonset`](../resource/k8s.md#daemonset) resource.
     instrument: updowncounter
+    entity_associations:
+      - k8s.daemonset
     unit: "{node}"
   - id: metric.k8s.daemonset.ready_nodes
     type: metric
@@ -431,10 +440,9 @@ groups:
     note: |
       This metric aligns with the `numberReady` field of the
       [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.daemonset`](../resource/k8s.md#daemonset) resource.
     instrument: updowncounter
+    entity_associations:
+      - k8s.daemonset
     unit: "{node}"
 
   # k8s.job.* metrics
@@ -445,12 +453,11 @@ groups:
     brief: "The number of pending and actively running pods for a job"
     instrument: updowncounter
     unit: "{pod}"
+    entity_associations:
+      - k8s.job
     note: |
       This metric aligns with the `active` field of the
       [K8s JobStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.job`](../resource/k8s.md#job) resource.
   - id: metric.k8s.job.failed_pods
     type: metric
     metric_name: k8s.job.failed_pods
@@ -458,12 +465,11 @@ groups:
     brief: "The number of pods which reached phase Failed for a job"
     instrument: updowncounter
     unit: "{pod}"
+    entity_associations:
+      - k8s.job
     note: |
       This metric aligns with the `failed` field of the
       [K8s JobStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.job`](../resource/k8s.md#job) resource.
   - id: metric.k8s.job.successful_pods
     type: metric
     metric_name: k8s.job.successful_pods
@@ -471,12 +477,11 @@ groups:
     brief: "The number of pods which reached phase Succeeded for a job"
     instrument: updowncounter
     unit: "{pod}"
+    entity_associations:
+      - k8s.job
     note: |
       This metric aligns with the `succeeded` field of the
       [K8s JobStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.job`](../resource/k8s.md#job) resource.
   - id: metric.k8s.job.desired_successful_pods
     type: metric
     metric_name: k8s.job.desired_successful_pods
@@ -484,12 +489,11 @@ groups:
     brief: "The desired number of successfully finished pods the job should be run with"
     instrument: updowncounter
     unit: "{pod}"
+    entity_associations:
+      - k8s.job
     note: |
       This metric aligns with the `completions` field of the
-      [K8s JobSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobspec-v1-batch).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.job`](../resource/k8s.md#job) resource.
+      [K8s JobSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobspec-v1-batch)..
   - id: metric.k8s.job.max_parallel_pods
     type: metric
     metric_name: k8s.job.max_parallel_pods
@@ -497,14 +501,13 @@ groups:
     brief: "The max desired number of pods the job should run at any given time"
     instrument: updowncounter
     unit: "{pod}"
+    entity_associations:
+      - k8s.job
     note: |
       This metric aligns with the `parallelism` field of the
       [K8s JobSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobspec-v1-batch).
 
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.job`](../resource/k8s.md#job) resource.
-
-  # k8s.job.* metrics
+  # k8s.cronjob.* metrics
   - id: metric.k8s.cronjob.active_jobs
     type: metric
     metric_name: k8s.cronjob.active_jobs
@@ -512,12 +515,11 @@ groups:
     brief: "The number of actively running jobs for a cronjob"
     instrument: updowncounter
     unit: "{job}"
+    entity_associations:
+      - k8s.cronjob
     note: |
       This metric aligns with the `active` field of the
       [K8s CronJobStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#cronjobstatus-v1-batch).
-
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.cronjob`](../resource/k8s.md#cronjob) resource.
 
   # k8s.namespace.* metrics
   - id: metric.k8s.namespace.phase
@@ -527,9 +529,8 @@ groups:
     brief: "Describes number of K8s namespaces that are currently in a given phase."
     instrument: updowncounter
     unit: "{namespace}"
-    note: |
-      This metric SHOULD, at a minimum, be reported against a
-      [`k8s.namespace`](../resource/k8s.md#namespace) resource.
+    entity_associations:
+      - k8s.namespace
     attributes:
       - ref: k8s.namespace.phase
         requirement_level: required


### PR DESCRIPTION
## Changes

We can now define how metrics are associated with entities using the `entity_associations` key. This PR updates the k8s metrics properly.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
