### PR TITLE
Remove legacy weaver flag for attribute registry on snippet generation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ table-generation:
 		--mount 'type=bind,source=$(PWD)/docs,target=/home/weaver/target' \
 		$(WEAVER_CONTAINER) registry update-markdown \
 		--registry=/home/weaver/source \
-		--attribute-registry-base-url=/docs/registry/attributes \
+		-Dregistry_base_url=/docs/registry/ \
 		--templates=/home/weaver/templates \
 		--target=markdown \
 		--future \
@@ -230,7 +230,7 @@ table-check:
 		--mount 'type=bind,source=$(PWD)/docs,target=/home/weaver/target,readonly' \
 		$(WEAVER_CONTAINER) registry update-markdown \
 		--registry=/home/weaver/source \
-		--attribute-registry-base-url=/docs/registry/attributes \
+		-Dregistry_base_url=/docs/registry/ \
 		--templates=/home/weaver/templates \
 		--target=markdown \
 		--dry-run \

--- a/templates/registry/markdown/snippet.md.j2
+++ b/templates/registry/markdown/snippet.md.j2
@@ -8,6 +8,7 @@
 {%- import 'event_macros.j2' as event -%}
 {%- import 'resource_macros.j2' as resource -%}
 {%- import 'span_macros.j2' as span %}
+{%- set attribute_registry_base_url=params.registry_base_url~"attributes" %}
 
 {% macro generate_event(group) -%}
 {{ event.header(group) }}{{ generate_attributes(group) }}{{ event.body(group.body) }}{% endmacro -%}


### PR DESCRIPTION
Moves to using generic parameters in weaver instead of deprecated attribute registry parameter.