### PR TITLE
[chore] Remove usages of 'Publish' spans and adapt example tables

### DIFF
--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -274,10 +274,10 @@ The "Send" span SHOULD always link to the creation context that was injected
 into a message either from a "Create" span or as a custom creation context.
 
 When instrumenting a library API that always sends a single message, it is
-RECOMMENDED to create "Publish" span without "Create" span.
+RECOMMENDED to create "Send" span without "Create" span.
 
 When instrumenting a library API that usually operate with batches, it is
-RECOMMENDED to create a "Create" span for each message along with the "Publish" span.
+RECOMMENDED to create a "Create" span for each message along with the "Send" span.
 It is also RECOMMENDED to provide a configuration option allowing to disable "Create"
 span creation.
 
@@ -543,7 +543,8 @@ relationships.
 
 ### Topic with multiple consumers
 
-Given is a publisher that publishes a message to a topic exchange "T" on RabbitMQ, and two consumers which both get the message delivered.
+Given is a publisher that publishes a message to a topic exchange "T" on RabbitMQ,
+and two consumers which both get the message delivered.
 
 ```mermaid
 flowchart LR;
@@ -585,7 +586,8 @@ flowchart LR;
 
 ### Batch receiving
 
-Given is a producer that publishes two messages to a topic "Q" on Kafka, and a consumer which receives both messages in one batch.
+Given is a producer that publishes two messages to a topic "Q" on Kafka,
+and a consumer which receives both messages in one batch.
 
 ```mermaid
 flowchart LR;
@@ -608,7 +610,7 @@ flowchart LR;
 
 | Field or Attribute | Producer Span A | Producer Span B | Consumer |
 |-|-|-|-|
-| Span name | `send Q` | `send Q` | `poll Q` |
+| Span name | `publish Q` | `publish Q` | `poll Q` |
 | Parent |  |  |  |
 | Links |  |  | Span Send A, Span Send B |
 | Link attributes |  |  | Span Send A: `messaging.message.id`: `"a1"`  |
@@ -618,7 +620,7 @@ flowchart LR;
 | `server.port` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` |
 | `messaging.destination.name` | `"Q"` | `"Q"` | `"Q"` |
-| `messaging.operation.name` | `"send"` | `"send"` | `"poll"` |
+| `messaging.operation.name` | `"publish"` | `"publish"` | `"poll"` |
 | `messaging.operation.type` | `"send"` | `"send"` | `"receive"` |
 | `messaging.message.id` | `"a1"` | `"a2"` | |
 | `messaging.batch.message_count` |  |  | 2 |
@@ -628,7 +630,7 @@ flowchart LR;
 Given is a producer that publishes a batch with two messages to a topic "Q" on
 Kafka, and two different consumers receiving one of the messages.
 
-Instrumentation in this case reports "Create" span for each message and a "Publish"
+Instrumentation in this case reports "Create" span for each message and a "Send"
 span that's linked to a "Create" span.
 
 ```mermaid
@@ -659,7 +661,7 @@ flowchart LR;
 
 | Field or Attribute | Producer Span Create A | Producer Span Create B | Producer Span Send | Consumer 1 | Consumer 2 |
 |-|-|-|-|-|-|
-| Span name | `create Q` | `create Q` | `send Q` | `poll Q` | `poll Q` |
+| Span name | `create Q` | `create Q` | `publish Q` | `poll Q` | `poll Q` |
 | Parent |  | | | | |
 | Links |  |  |  | Span Create A | Span Create B |
 | SpanKind | `PRODUCER` | `PRODUCER` | `CLIENT` | `CLIENT` | `CLIENT` |
@@ -667,7 +669,7 @@ flowchart LR;
 | `server.port` | `1234` | `1234` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` |
 | `messaging.destination.name` | `"Q"` | `"Q"` | `"Q"` | `"Q"` | `"Q"` |
-| `messaging.operation.name` | `"create"` | `"create"` | `"send"` | `"poll"` | `"poll"` |
+| `messaging.operation.name` | `"create"` | `"create"` | `"publish"` | `"poll"` | `"poll"` |
 | `messaging.operation.type` | `"create"` | `"create"` | `"send"` | `"receive"` | `"receive"` |
 | `messaging.message.id` | `"a1"` | `"a2"` | | `"a1"` | `"a2"` |
 | `messaging.batch.message_count` | | | 2 | | |
@@ -678,13 +680,13 @@ Given is a producer that publishes a batch with two messages to a topic "Q" on
 Kafka, and two different consumers receiving one of the messages.
 
 Based on the configuration provided by user, instrumentation in this case reports
-"Publish" span only. It injects "Publish" span context into both messages.
+"Send" span only. It injects "Send" span context into both messages.
 
 ```mermaid
 flowchart LR;
   subgraph PRODUCER
   direction TB
-  P[Span Publish]
+  P[Span Send]
   end
   subgraph CONSUMER1
   direction TB
@@ -704,16 +706,16 @@ flowchart LR;
 
 | Field or Attribute | Producer | Consumer 1 | Consumer 2 |
 |-|-|-|-|
-| Span name | `send Q` | `poll Q` | `poll Q` |
+| Span name | `publish Q` | `poll Q` | `poll Q` |
 | Parent | | | |
-| Links |  | Span Publish | Span Publish |
+| Links |  | Span Send | Span Send |
 | SpanKind | `PRODUCER` | `CLIENT` | `CLIENT` |
 | `server.address` | `"ms"` | `"ms"` | `"ms"` |
 | `server.port` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` |
 | `messaging.destination.name` | `"Q"` | `"Q"` | `"Q"` |
-| `messaging.operation.name` | `"send"` | `"poll"` | `"poll"` |
-| `messaging.operation.type` | `"publish"` | `"receive"` | `"receive"` |
+| `messaging.operation.name` | `"publish"` | `"poll"` | `"poll"` |
+| `messaging.operation.type` | `"send"` | `"receive"` | `"receive"` |
 | `messaging.message.id` | | `"a1"` | `"a2"` |
 | `messaging.batch.message_count`| 2 | | |
 

--- a/docs/messaging/messaging-spans.md
+++ b/docs/messaging/messaging-spans.md
@@ -610,7 +610,7 @@ flowchart LR;
 
 | Field or Attribute | Producer Span A | Producer Span B | Consumer |
 |-|-|-|-|
-| Span name | `publish Q` | `publish Q` | `poll Q` |
+| Span name | `send Q` | `send Q` | `poll Q` |
 | Parent |  |  |  |
 | Links |  |  | Span Send A, Span Send B |
 | Link attributes |  |  | Span Send A: `messaging.message.id`: `"a1"`  |
@@ -620,7 +620,7 @@ flowchart LR;
 | `server.port` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` |
 | `messaging.destination.name` | `"Q"` | `"Q"` | `"Q"` |
-| `messaging.operation.name` | `"publish"` | `"publish"` | `"poll"` |
+| `messaging.operation.name` | `"send"` | `"send"` | `"poll"` |
 | `messaging.operation.type` | `"send"` | `"send"` | `"receive"` |
 | `messaging.message.id` | `"a1"` | `"a2"` | |
 | `messaging.batch.message_count` |  |  | 2 |
@@ -661,7 +661,7 @@ flowchart LR;
 
 | Field or Attribute | Producer Span Create A | Producer Span Create B | Producer Span Send | Consumer 1 | Consumer 2 |
 |-|-|-|-|-|-|
-| Span name | `create Q` | `create Q` | `publish Q` | `poll Q` | `poll Q` |
+| Span name | `create Q` | `create Q` | `send Q` | `poll Q` | `poll Q` |
 | Parent |  | | | | |
 | Links |  |  |  | Span Create A | Span Create B |
 | SpanKind | `PRODUCER` | `PRODUCER` | `CLIENT` | `CLIENT` | `CLIENT` |
@@ -669,7 +669,7 @@ flowchart LR;
 | `server.port` | `1234` | `1234` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` |
 | `messaging.destination.name` | `"Q"` | `"Q"` | `"Q"` | `"Q"` | `"Q"` |
-| `messaging.operation.name` | `"create"` | `"create"` | `"publish"` | `"poll"` | `"poll"` |
+| `messaging.operation.name` | `"create"` | `"create"` | `"send"` | `"poll"` | `"poll"` |
 | `messaging.operation.type` | `"create"` | `"create"` | `"send"` | `"receive"` | `"receive"` |
 | `messaging.message.id` | `"a1"` | `"a2"` | | `"a1"` | `"a2"` |
 | `messaging.batch.message_count` | | | 2 | | |
@@ -706,7 +706,7 @@ flowchart LR;
 
 | Field or Attribute | Producer | Consumer 1 | Consumer 2 |
 |-|-|-|-|
-| Span name | `publish Q` | `poll Q` | `poll Q` |
+| Span name | `send Q` | `poll Q` | `poll Q` |
 | Parent | | | |
 | Links |  | Span Send | Span Send |
 | SpanKind | `PRODUCER` | `CLIENT` | `CLIENT` |
@@ -714,7 +714,7 @@ flowchart LR;
 | `server.port` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` |
 | `messaging.destination.name` | `"Q"` | `"Q"` | `"Q"` |
-| `messaging.operation.name` | `"publish"` | `"poll"` | `"poll"` |
+| `messaging.operation.name` | `"send"` | `"poll"` | `"poll"` |
 | `messaging.operation.type` | `"send"` | `"receive"` | `"receive"` |
 | `messaging.message.id` | | `"a1"` | `"a2"` |
 | `messaging.batch.message_count`| 2 | | |


### PR DESCRIPTION
Fixes #2302

## Changes

- Change left over "Publish" wording for send spans
- Adapt example tables to use `publish` for `messaging.operation.name` and span names where applicable (for pub/sub systems) and sopa

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
