### PR TITLE
Adds in lmdb #1107

### DIFF
--- a/.chloggen/add_db_systems.yaml
+++ b/.chloggen/add_db_systems.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: db
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: This adds ArangoDB, DocumentDB, RavenDB & SurrealDB as db systems.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1107]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/add_db_systems.yaml
+++ b/.chloggen/add_db_systems.yaml
@@ -10,7 +10,7 @@ change_type: enhancement
 component: db
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: This adds ArangoDB, DocumentDB, RavenDB & SurrealDB as db systems.
+note: This adds lmdb as db systems as used by ruby.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -179,7 +179,6 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -214,13 +213,11 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 
@@ -362,7 +359,6 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -397,13 +393,11 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -179,7 +179,6 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `aerospike` | [Aerospike](https://aerospike.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -190,8 +189,6 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `derby` | [Apache Derby](https://db.apache.org/derby/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `documentdb` | [DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `druid` | [Apache Druid](https://druid.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `elasticsearch` | [Elasticsearch](https://www.elastic.co/elasticsearch) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `firebirdsql` | [Firebird](https://www.firebirdsql.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp.spanner` | [Google Cloud Spanner](https://cloud.google.com/spanner) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -204,12 +201,8 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `ibm.informix` | [IBM Informix](https://www.ibm.com/products/informix) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.netezza` | [IBM Netezza](https://www.ibm.com/products/netezza) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `influxdb` | [InfluxDB](https://www.influxdata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `inmemory` | In-memory | ![Development](https://img.shields.io/badge/-development-blue) |
 | `instantdb` | [Instant](https://www.instantdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `intersystems.cache` | [InterSystems Caché](https://www.intersystems.com/products/cache/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `iotdb` | [Apache IoTDB](https://iotdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `kdb+` | [KDB+](https://kx.com/products/kdb/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `kurrentdb` | [KurrentDB](https://www.kurrent.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `lmdb` | [Lightning Memory-Mapped Database](https://www.symas.com/mdb) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mariadb` | [MariaDB](https://mariadb.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `memcached` | [Memcached](https://memcached.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -218,19 +211,16 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `mysql` | [MySQL](https://www.mysql.com/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `neo4j` | [Neo4j](https://neo4j.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `opensearch` | [OpenSearch](https://opensearch.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `opentsdb` | [OpenTSDB](https://opentsdb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `rethinkdb+` | [RethinkDB+](https://rethinkdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `tarantool+` | [Tarantool](https://www.tarantool.io/en/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 
@@ -372,7 +362,6 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `aerospike` | [Aerospike](https://aerospike.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -383,8 +372,6 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `derby` | [Apache Derby](https://db.apache.org/derby/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `documentdb` | [DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `druid` | [Apache Druid](https://druid.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `elasticsearch` | [Elasticsearch](https://www.elastic.co/elasticsearch) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `firebirdsql` | [Firebird](https://www.firebirdsql.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp.spanner` | [Google Cloud Spanner](https://cloud.google.com/spanner) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -397,12 +384,8 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `ibm.informix` | [IBM Informix](https://www.ibm.com/products/informix) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.netezza` | [IBM Netezza](https://www.ibm.com/products/netezza) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `influxdb` | [InfluxDB](https://www.influxdata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `inmemory` | In-memory | ![Development](https://img.shields.io/badge/-development-blue) |
 | `instantdb` | [Instant](https://www.instantdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `intersystems.cache` | [InterSystems Caché](https://www.intersystems.com/products/cache/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `iotdb` | [Apache IoTDB](https://iotdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `kdb+` | [KDB+](https://kx.com/products/kdb/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `kurrentdb` | [KurrentDB](https://www.kurrent.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `lmdb` | [Lightning Memory-Mapped Database](https://www.symas.com/mdb) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mariadb` | [MariaDB](https://mariadb.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `memcached` | [Memcached](https://memcached.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -411,19 +394,16 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `mysql` | [MySQL](https://www.mysql.com/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `neo4j` | [Neo4j](https://neo4j.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `opensearch` | [OpenSearch](https://opensearch.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `opentsdb` | [OpenTSDB](https://opentsdb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `rethinkdb+` | [RethinkDB+](https://rethinkdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `tarantool+` | [Tarantool](https://www.tarantool.io/en/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -179,6 +179,7 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -188,6 +189,7 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `derby` | [Apache Derby](https://db.apache.org/derby/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `documentdb` | [DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `elasticsearch` | [Elasticsearch](https://www.elastic.co/elasticsearch) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `firebirdsql` | [Firebird](https://www.firebirdsql.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp.spanner` | [Google Cloud Spanner](https://cloud.google.com/spanner) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -212,11 +214,13 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 
@@ -358,6 +362,7 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -367,6 +372,7 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `derby` | [Apache Derby](https://db.apache.org/derby/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `documentdb` | [DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `elasticsearch` | [Elasticsearch](https://www.elastic.co/elasticsearch) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `firebirdsql` | [Firebird](https://www.firebirdsql.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp.spanner` | [Google Cloud Spanner](https://cloud.google.com/spanner) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -391,11 +397,13 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -204,11 +204,13 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `ibm.informix` | [IBM Informix](https://www.ibm.com/products/informix) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.netezza` | [IBM Netezza](https://www.ibm.com/products/netezza) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `influxdb` | [InfluxDB](https://www.influxdata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `inmemory` | In-memory | ![Development](https://img.shields.io/badge/-development-blue) |
 | `instantdb` | [Instant](https://www.instantdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `intersystems.cache` | [InterSystems Caché](https://www.intersystems.com/products/cache/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `iotdb` | [Apache IoTDB](https://iotdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `kdb+` | [KDB+](https://kx.com/products/kdb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `kurrentdb` | [KurrentDB](https://www.kurrent.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `lmdb` | [Lightning Memory-Mapped Database](https://www.symas.com/mdb) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mariadb` | [MariaDB](https://mariadb.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `memcached` | [Memcached](https://memcached.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `microsoft.sql_server` | [Microsoft SQL Server](https://www.microsoft.com/sql-server) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
@@ -395,11 +397,13 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `ibm.informix` | [IBM Informix](https://www.ibm.com/products/informix) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.netezza` | [IBM Netezza](https://www.ibm.com/products/netezza) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `influxdb` | [InfluxDB](https://www.influxdata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `inmemory` | In-memory | ![Development](https://img.shields.io/badge/-development-blue) |
 | `instantdb` | [Instant](https://www.instantdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `intersystems.cache` | [InterSystems Caché](https://www.intersystems.com/products/cache/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `iotdb` | [Apache IoTDB](https://iotdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `kdb+` | [KDB+](https://kx.com/products/kdb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `kurrentdb` | [KurrentDB](https://www.kurrent.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `lmdb` | [Lightning Memory-Mapped Database](https://www.symas.com/mdb) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mariadb` | [MariaDB](https://mariadb.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `memcached` | [Memcached](https://memcached.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `microsoft.sql_server` | [Microsoft SQL Server](https://www.microsoft.com/sql-server) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -186,7 +186,6 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cassandra` | [Apache Cassandra](https://cassandra.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `clickhouse` | [ClickHouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `clickhouse` | [Clickhouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cockroachdb` | [CockroachDB](https://www.cockroachlabs.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -378,7 +377,6 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cassandra` | [Apache Cassandra](https://cassandra.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `clickhouse` | [ClickHouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `clickhouse` | [Clickhouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cockroachdb` | [CockroachDB](https://www.cockroachlabs.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -179,17 +179,20 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `aerospike` | [Aerospike](https://aerospike.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cassandra` | [Apache Cassandra](https://cassandra.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `clickhouse` | [ClickHouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `clickhouse` | [Clickhouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cockroachdb` | [CockroachDB](https://www.cockroachlabs.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `derby` | [Apache Derby](https://db.apache.org/derby/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `documentdb` | [DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `druid` | [Apache Druid](https://druid.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `elasticsearch` | [Elasticsearch](https://www.elastic.co/elasticsearch) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `firebirdsql` | [Firebird](https://www.firebirdsql.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp.spanner` | [Google Cloud Spanner](https://cloud.google.com/spanner) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -204,6 +207,9 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `influxdb` | [InfluxDB](https://www.influxdata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `instantdb` | [Instant](https://www.instantdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `intersystems.cache` | [InterSystems Caché](https://www.intersystems.com/products/cache/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `iotdb` | [Apache IoTDB](https://iotdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `kdb+` | [KDB+](https://kx.com/products/kdb/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `kurrentdb` | [KurrentDB](https://www.kurrent.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mariadb` | [MariaDB](https://mariadb.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `memcached` | [Memcached](https://memcached.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `microsoft.sql_server` | [Microsoft SQL Server](https://www.microsoft.com/sql-server) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
@@ -211,16 +217,19 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `mysql` | [MySQL](https://www.mysql.com/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `neo4j` | [Neo4j](https://neo4j.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `opensearch` | [OpenSearch](https://opensearch.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `opentsdb` | [OpenTSDB](https://opentsdb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `rethinkdb+` | [RethinkDB+](https://rethinkdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `tarantool+` | [Tarantool](https://www.tarantool.io/en/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 
@@ -362,17 +371,20 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `aerospike` | [Aerospike](https://aerospike.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cassandra` | [Apache Cassandra](https://cassandra.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `clickhouse` | [ClickHouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `clickhouse` | [Clickhouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cockroachdb` | [CockroachDB](https://www.cockroachlabs.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `derby` | [Apache Derby](https://db.apache.org/derby/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `documentdb` | [DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `druid` | [Apache Druid](https://druid.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `elasticsearch` | [Elasticsearch](https://www.elastic.co/elasticsearch) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `firebirdsql` | [Firebird](https://www.firebirdsql.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp.spanner` | [Google Cloud Spanner](https://cloud.google.com/spanner) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -387,6 +399,9 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `influxdb` | [InfluxDB](https://www.influxdata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `instantdb` | [Instant](https://www.instantdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `intersystems.cache` | [InterSystems Caché](https://www.intersystems.com/products/cache/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `iotdb` | [Apache IoTDB](https://iotdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `kdb+` | [KDB+](https://kx.com/products/kdb/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `kurrentdb` | [KurrentDB](https://www.kurrent.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mariadb` | [MariaDB](https://mariadb.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `memcached` | [Memcached](https://memcached.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `microsoft.sql_server` | [Microsoft SQL Server](https://www.microsoft.com/sql-server) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
@@ -394,16 +409,19 @@ Parameterized query text SHOULD NOT be sanitized. Even though parameterized quer
 | `mysql` | [MySQL](https://www.mysql.com/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `neo4j` | [Neo4j](https://neo4j.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `opensearch` | [OpenSearch](https://opensearch.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `opentsdb` | [OpenTSDB](https://opentsdb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `rethinkdb+` | [RethinkDB+](https://rethinkdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `tarantool+` | [Tarantool](https://www.tarantool.io/en/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -245,7 +245,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -280,13 +279,11 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -252,7 +252,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cassandra` | [Apache Cassandra](https://cassandra.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `clickhouse` | [ClickHouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `clickhouse` | [Clickhouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cockroachdb` | [CockroachDB](https://www.cockroachlabs.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -245,17 +245,20 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `aerospike` | [Aerospike](https://aerospike.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cassandra` | [Apache Cassandra](https://cassandra.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `clickhouse` | [ClickHouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `clickhouse` | [Clickhouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cockroachdb` | [CockroachDB](https://www.cockroachlabs.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `derby` | [Apache Derby](https://db.apache.org/derby/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `documentdb` | [DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `druid` | [Apache Druid](https://druid.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `elasticsearch` | [Elasticsearch](https://www.elastic.co/elasticsearch) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `firebirdsql` | [Firebird](https://www.firebirdsql.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp.spanner` | [Google Cloud Spanner](https://cloud.google.com/spanner) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -270,6 +273,9 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | `influxdb` | [InfluxDB](https://www.influxdata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `instantdb` | [Instant](https://www.instantdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `intersystems.cache` | [InterSystems Caché](https://www.intersystems.com/products/cache/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `iotdb` | [Apache IoTDB](https://iotdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `kdb+` | [KDB+](https://kx.com/products/kdb/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `kurrentdb` | [KurrentDB](https://www.kurrent.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mariadb` | [MariaDB](https://mariadb.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `memcached` | [Memcached](https://memcached.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `microsoft.sql_server` | [Microsoft SQL Server](https://www.microsoft.com/sql-server) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
@@ -277,16 +283,19 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | `mysql` | [MySQL](https://www.mysql.com/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `neo4j` | [Neo4j](https://neo4j.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `opensearch` | [OpenSearch](https://opensearch.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `opentsdb` | [OpenTSDB](https://opentsdb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `rethinkdb+` | [RethinkDB+](https://rethinkdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `tarantool+` | [Tarantool](https://www.tarantool.io/en/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -270,11 +270,13 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | `ibm.informix` | [IBM Informix](https://www.ibm.com/products/informix) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.netezza` | [IBM Netezza](https://www.ibm.com/products/netezza) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `influxdb` | [InfluxDB](https://www.influxdata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `inmemory` | In-memory | ![Development](https://img.shields.io/badge/-development-blue) |
 | `instantdb` | [Instant](https://www.instantdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `intersystems.cache` | [InterSystems Caché](https://www.intersystems.com/products/cache/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `iotdb` | [Apache IoTDB](https://iotdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `kdb+` | [KDB+](https://kx.com/products/kdb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `kurrentdb` | [KurrentDB](https://www.kurrent.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `lmdb` | [Lightning Memory-Mapped Database](https://www.symas.com/mdb) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mariadb` | [MariaDB](https://mariadb.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `memcached` | [Memcached](https://memcached.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `microsoft.sql_server` | [Microsoft SQL Server](https://www.microsoft.com/sql-server) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -245,6 +245,7 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -254,6 +255,7 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `derby` | [Apache Derby](https://db.apache.org/derby/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `documentdb` | [DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `elasticsearch` | [Elasticsearch](https://www.elastic.co/elasticsearch) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `firebirdsql` | [Firebird](https://www.firebirdsql.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp.spanner` | [Google Cloud Spanner](https://cloud.google.com/spanner) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -278,11 +280,13 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -245,7 +245,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `aerospike` | [Aerospike](https://aerospike.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -256,8 +255,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `derby` | [Apache Derby](https://db.apache.org/derby/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `documentdb` | [DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `druid` | [Apache Druid](https://druid.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `elasticsearch` | [Elasticsearch](https://www.elastic.co/elasticsearch) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `firebirdsql` | [Firebird](https://www.firebirdsql.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp.spanner` | [Google Cloud Spanner](https://cloud.google.com/spanner) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -270,12 +267,8 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | `ibm.informix` | [IBM Informix](https://www.ibm.com/products/informix) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.netezza` | [IBM Netezza](https://www.ibm.com/products/netezza) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `influxdb` | [InfluxDB](https://www.influxdata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `inmemory` | In-memory | ![Development](https://img.shields.io/badge/-development-blue) |
 | `instantdb` | [Instant](https://www.instantdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `intersystems.cache` | [InterSystems Caché](https://www.intersystems.com/products/cache/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `iotdb` | [Apache IoTDB](https://iotdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `kdb+` | [KDB+](https://kx.com/products/kdb/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `kurrentdb` | [KurrentDB](https://www.kurrent.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `lmdb` | [Lightning Memory-Mapped Database](https://www.symas.com/mdb) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mariadb` | [MariaDB](https://mariadb.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `memcached` | [Memcached](https://memcached.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -284,19 +277,16 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | `mysql` | [MySQL](https://www.mysql.com/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `neo4j` | [Neo4j](https://neo4j.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `opensearch` | [OpenSearch](https://opensearch.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `opentsdb` | [OpenTSDB](https://opentsdb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `rethinkdb+` | [RethinkDB+](https://rethinkdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `tarantool+` | [Tarantool](https://www.tarantool.io/en/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/registry/attributes/db.md
+++ b/docs/registry/attributes/db.md
@@ -122,6 +122,7 @@ stored procedure name then that stored procedure name SHOULD be used.
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -131,6 +132,7 @@ stored procedure name then that stored procedure name SHOULD be used.
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `derby` | [Apache Derby](https://db.apache.org/derby/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `documentdb` | [DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `elasticsearch` | [Elasticsearch](https://www.elastic.co/elasticsearch) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `firebirdsql` | [Firebird](https://www.firebirdsql.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp.spanner` | [Google Cloud Spanner](https://cloud.google.com/spanner) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -155,11 +157,13 @@ stored procedure name then that stored procedure name SHOULD be used.
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/registry/attributes/db.md
+++ b/docs/registry/attributes/db.md
@@ -122,7 +122,6 @@ stored procedure name then that stored procedure name SHOULD be used.
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -157,13 +156,11 @@ stored procedure name then that stored procedure name SHOULD be used.
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/registry/attributes/db.md
+++ b/docs/registry/attributes/db.md
@@ -122,7 +122,6 @@ stored procedure name then that stored procedure name SHOULD be used.
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `aerospike` | [Aerospike](https://aerospike.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -133,8 +132,6 @@ stored procedure name then that stored procedure name SHOULD be used.
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `derby` | [Apache Derby](https://db.apache.org/derby/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `documentdb` | [DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `druid` | [Apache Druid](https://druid.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `elasticsearch` | [Elasticsearch](https://www.elastic.co/elasticsearch) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `firebirdsql` | [Firebird](https://www.firebirdsql.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp.spanner` | [Google Cloud Spanner](https://cloud.google.com/spanner) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -147,12 +144,8 @@ stored procedure name then that stored procedure name SHOULD be used.
 | `ibm.informix` | [IBM Informix](https://www.ibm.com/products/informix) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.netezza` | [IBM Netezza](https://www.ibm.com/products/netezza) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `influxdb` | [InfluxDB](https://www.influxdata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `inmemory` | In-memory | ![Development](https://img.shields.io/badge/-development-blue) |
 | `instantdb` | [Instant](https://www.instantdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `intersystems.cache` | [InterSystems Caché](https://www.intersystems.com/products/cache/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `iotdb` | [Apache IoTDB](https://iotdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `kdb+` | [KDB+](https://kx.com/products/kdb/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `kurrentdb` | [KurrentDB](https://www.kurrent.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `lmdb` | [Lightning Memory-Mapped Database](https://www.symas.com/mdb) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mariadb` | [MariaDB](https://mariadb.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `memcached` | [Memcached](https://memcached.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -161,19 +154,16 @@ stored procedure name then that stored procedure name SHOULD be used.
 | `mysql` | [MySQL](https://www.mysql.com/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `neo4j` | [Neo4j](https://neo4j.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `opensearch` | [OpenSearch](https://opensearch.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `opentsdb` | [OpenTSDB](https://opentsdb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `rethinkdb+` | [RethinkDB+](https://rethinkdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `tarantool+` | [Tarantool](https://www.tarantool.io/en/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/registry/attributes/db.md
+++ b/docs/registry/attributes/db.md
@@ -122,17 +122,20 @@ stored procedure name then that stored procedure name SHOULD be used.
 | Value  | Description | Stability |
 |---|---|---|
 | `actian.ingres` | [Actian Ingres](https://www.actian.com/databases/ingres/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `aerospike` | [Aerospike](https://aerospike.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `arangodb` | [ArangoDB](https://arangodb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.dynamodb` | [Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws.redshift` | [Amazon Redshift](https://aws.amazon.com/redshift/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cassandra` | [Apache Cassandra](https://cassandra.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `clickhouse` | [ClickHouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `clickhouse` | [Clickhouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cockroachdb` | [CockroachDB](https://www.cockroachlabs.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `derby` | [Apache Derby](https://db.apache.org/derby/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `documentdb` | [DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `druid` | [Apache Druid](https://druid.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `elasticsearch` | [Elasticsearch](https://www.elastic.co/elasticsearch) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `firebirdsql` | [Firebird](https://www.firebirdsql.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp.spanner` | [Google Cloud Spanner](https://cloud.google.com/spanner) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -147,6 +150,9 @@ stored procedure name then that stored procedure name SHOULD be used.
 | `influxdb` | [InfluxDB](https://www.influxdata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `instantdb` | [Instant](https://www.instantdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `intersystems.cache` | [InterSystems Caché](https://www.intersystems.com/products/cache/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `iotdb` | [Apache IoTDB](https://iotdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `kdb+` | [KDB+](https://kx.com/products/kdb/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `kurrentdb` | [KurrentDB](https://www.kurrent.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mariadb` | [MariaDB](https://mariadb.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `memcached` | [Memcached](https://memcached.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `microsoft.sql_server` | [Microsoft SQL Server](https://www.microsoft.com/sql-server) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
@@ -154,16 +160,19 @@ stored procedure name then that stored procedure name SHOULD be used.
 | `mysql` | [MySQL](https://www.mysql.com/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `neo4j` | [Neo4j](https://neo4j.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `opensearch` | [OpenSearch](https://opensearch.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `opentsdb` | [OpenTSDB](https://opentsdb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `oracle.db` | [Oracle Database](https://www.oracle.com/database/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `other_sql` | Some other SQL database. Fallback only. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `postgresql` | [PostgreSQL](https://www.postgresql.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `ravendb` | [RavenDB](https://ravendb.net/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `redis` | [Redis](https://redis.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `rethinkdb+` | [RethinkDB+](https://rethinkdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.hana` | [SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sap.maxdb` | [SAP MaxDB](https://maxdb.sap.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `softwareag.adabas` | [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `sqlite` | [SQLite](https://www.sqlite.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `surrealdb` | [SurrealDB](https://surrealdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `tarantool+` | [Tarantool](https://www.tarantool.io/en/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `teradata` | [Teradata](https://www.teradata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `trino` | [Trino](https://trino.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/registry/attributes/db.md
+++ b/docs/registry/attributes/db.md
@@ -147,11 +147,13 @@ stored procedure name then that stored procedure name SHOULD be used.
 | `ibm.informix` | [IBM Informix](https://www.ibm.com/products/informix) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.netezza` | [IBM Netezza](https://www.ibm.com/products/netezza) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `influxdb` | [InfluxDB](https://www.influxdata.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `inmemory` | In-memory | ![Development](https://img.shields.io/badge/-development-blue) |
 | `instantdb` | [Instant](https://www.instantdb.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `intersystems.cache` | [InterSystems Caché](https://www.intersystems.com/products/cache/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `iotdb` | [Apache IoTDB](https://iotdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `kdb+` | [KDB+](https://kx.com/products/kdb/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `kurrentdb` | [KurrentDB](https://www.kurrent.io/) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `lmdb` | [Lightning Memory-Mapped Database](https://www.symas.com/mdb) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mariadb` | [MariaDB](https://mariadb.org/) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `memcached` | [Memcached](https://memcached.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `microsoft.sql_server` | [Microsoft SQL Server](https://www.microsoft.com/sql-server) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |

--- a/docs/registry/attributes/db.md
+++ b/docs/registry/attributes/db.md
@@ -129,7 +129,6 @@ stored procedure name then that stored procedure name SHOULD be used.
 | `azure.cosmosdb` | [Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cassandra` | [Apache Cassandra](https://cassandra.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `clickhouse` | [ClickHouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `clickhouse` | [Clickhouse](https://clickhouse.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cockroachdb` | [CockroachDB](https://www.cockroachlabs.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchbase` | [Couchbase](https://www.couchbase.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `couchdb` | [Apache CouchDB](https://couchdb.apache.org/) | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/model/database/registry.yaml
+++ b/model/database/registry.yaml
@@ -392,6 +392,14 @@ groups:
               value: "tarantool+"
               brief: "[Tarantool](https://www.tarantool.io/en/)"
               stability: development
+            - id: inmemory
+              value: "inmemory"
+              brief: "In-memory"
+              stability: development
+            - id: lmdb
+              value: "lmdb"
+              brief: "[Lightning Memory-Mapped Database](https://www.symas.com/mdb)"
+              stability: development
         stability: stable
       - id: db.client.connection.state
         stability: development

--- a/model/database/registry.yaml
+++ b/model/database/registry.yaml
@@ -360,6 +360,42 @@ groups:
               value: "surrealdb"
               brief: "[SurrealDB](https://surrealdb.com/)"
               stability: development
+            - id: aerospike
+              value: "aerospike"
+              brief: "[Aerospike](https://aerospike.com/)"
+              stability: development
+            - id: clickhouse
+              value: "clickhouse"
+              brief: "[Clickhouse](https://clickhouse.com/)"
+              stability: development
+            - id: druid
+              value: "druid"
+              brief: "[Apache Druid](https://druid.apache.org/)"
+              stability: development
+            - id: kurrentdb
+              value: "kurrentdb"
+              brief: "[KurrentDB](https://www.kurrent.io/)"
+              stability: development
+            - id: iotdb
+              value: "iotdb"
+              brief: "[Apache IoTDB](https://iotdb.apache.org/)"
+              stability: development
+            - id: kdb
+              value: "kdb+"
+              brief: "[KDB+](https://kx.com/products/kdb/)"
+              stability: development
+            - id: opentsdb
+              value: "opentsdb"
+              brief: "[OpenTSDB](https://opentsdb.net/)"
+              stability: development
+            - id: rethinkdb
+              value: "rethinkdb+"
+              brief: "[RethinkDB+](https://rethinkdb.com/)"
+              stability: development
+            - id: tarantool
+              value: "tarantool+"
+              brief: "[Tarantool](https://www.tarantool.io/en/)"
+              stability: development
         stability: stable
       - id: db.client.connection.state
         stability: development

--- a/model/database/registry.yaml
+++ b/model/database/registry.yaml
@@ -344,6 +344,22 @@ groups:
               value: "trino"
               brief: "[Trino](https://trino.io/)"
               stability: development
+            - id: arangodb
+              value: "arangodb"
+              brief: "[ArangoDB](https://arangodb.com/)"
+              stability: development
+            - id: documentdb
+              value: "documentdb"
+              brief: "[DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/)"
+              stability: development
+            - id: ravendb
+              value: "ravendb"
+              brief: "[RavenDB](https://ravendb.net/)"
+              stability: development
+            - id: surrealdb
+              value: "surrealdb"
+              brief: "[SurrealDB](https://surrealdb.com/)"
+              stability: development
         stability: stable
       - id: db.client.connection.state
         stability: development

--- a/model/database/registry.yaml
+++ b/model/database/registry.yaml
@@ -364,10 +364,6 @@ groups:
               value: "aerospike"
               brief: "[Aerospike](https://aerospike.com/)"
               stability: development
-            - id: clickhouse
-              value: "clickhouse"
-              brief: "[Clickhouse](https://clickhouse.com/)"
-              stability: development
             - id: druid
               value: "druid"
               brief: "[Apache Druid](https://druid.apache.org/)"

--- a/model/database/registry.yaml
+++ b/model/database/registry.yaml
@@ -348,10 +348,6 @@ groups:
               value: "arangodb"
               brief: "[ArangoDB](https://arangodb.com/)"
               stability: development
-            - id: documentdb
-              value: "documentdb"
-              brief: "[DocumentDB](https://opensource.microsoft.com/blog/2025/01/23/documentdb-open-source-announcement/)"
-              stability: development
             - id: ravendb
               value: "ravendb"
               brief: "[RavenDB](https://ravendb.net/)"
@@ -359,42 +355,6 @@ groups:
             - id: surrealdb
               value: "surrealdb"
               brief: "[SurrealDB](https://surrealdb.com/)"
-              stability: development
-            - id: aerospike
-              value: "aerospike"
-              brief: "[Aerospike](https://aerospike.com/)"
-              stability: development
-            - id: druid
-              value: "druid"
-              brief: "[Apache Druid](https://druid.apache.org/)"
-              stability: development
-            - id: kurrentdb
-              value: "kurrentdb"
-              brief: "[KurrentDB](https://www.kurrent.io/)"
-              stability: development
-            - id: iotdb
-              value: "iotdb"
-              brief: "[Apache IoTDB](https://iotdb.apache.org/)"
-              stability: development
-            - id: kdb
-              value: "kdb+"
-              brief: "[KDB+](https://kx.com/products/kdb/)"
-              stability: development
-            - id: opentsdb
-              value: "opentsdb"
-              brief: "[OpenTSDB](https://opentsdb.net/)"
-              stability: development
-            - id: rethinkdb
-              value: "rethinkdb+"
-              brief: "[RethinkDB+](https://rethinkdb.com/)"
-              stability: development
-            - id: tarantool
-              value: "tarantool+"
-              brief: "[Tarantool](https://www.tarantool.io/en/)"
-              stability: development
-            - id: inmemory
-              value: "inmemory"
-              brief: "In-memory"
               stability: development
             - id: lmdb
               value: "lmdb"

--- a/model/database/registry.yaml
+++ b/model/database/registry.yaml
@@ -344,18 +344,6 @@ groups:
               value: "trino"
               brief: "[Trino](https://trino.io/)"
               stability: development
-            - id: arangodb
-              value: "arangodb"
-              brief: "[ArangoDB](https://arangodb.com/)"
-              stability: development
-            - id: ravendb
-              value: "ravendb"
-              brief: "[RavenDB](https://ravendb.net/)"
-              stability: development
-            - id: surrealdb
-              value: "surrealdb"
-              brief: "[SurrealDB](https://surrealdb.com/)"
-              stability: development
             - id: lmdb
               value: "lmdb"
               brief: "[Lightning Memory-Mapped Database](https://www.symas.com/mdb)"


### PR DESCRIPTION
Progresses #1107

## Changes

Adds in lmdb as used by ruby.

## Usage example

https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/lmdb with the span defined in: https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/lmdb/lib/opentelemetry/instrumentation/lmdb/patches/database.rb

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
