### PR TITLE
[chore] Explicitly set the SQS link title #2351

### DIFF
--- a/docs/messaging/sns.md
+++ b/docs/messaging/sns.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: SNS
+linkTitle: AWS SNS
 --->
 
 # Semantic conventions for AWS SNS

--- a/docs/messaging/sqs.md
+++ b/docs/messaging/sqs.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: AWS SQS
+--->
+
 # Semantic conventions for AWS SQS
 
 **Status**: [Development][DocumentStatus]


### PR DESCRIPTION
Fixes #2351

## Changes

Explicitly set the SQS doc link title to AWS SQS and while at it set the SNS link title to AWS SNS to match

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
