### PR TITLE
CPU Arch now lives under host.cpu #2374

### DIFF
--- a/.chloggen/move_host_arch.yaml
+++ b/.chloggen/move_host_arch.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: host
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The CPU architecture now resides under the CPU to support the cpu entity
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2374]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/cpu.md
+++ b/docs/registry/attributes/cpu.md
@@ -5,7 +5,8 @@
 
 ## CPU Attributes
 
-Attributes specific to a cpu instance.
+CPU fields can carry data about a specific cpu instance.
+Note: These CPU attributes are typically used to capture system metrics about a CPU. The CPU attributes under host are for describing the cpu in the host.
 
 **Attributes:**
 

--- a/docs/registry/attributes/host.md
+++ b/docs/registry/attributes/host.md
@@ -3,6 +3,9 @@
 
 # Host
 
+- [Host Attributes](#host-attributes)
+- [Deprecated Host Attributes](#deprecated-host-attributes)
+
 ## Host Attributes
 
 A host is defined as a computing instance. For example, physical servers, virtual machines, switches or disk array.
@@ -11,7 +14,7 @@ A host is defined as a computing instance. For example, physical servers, virtua
 
 | Key | Stability | Value Type | Description | Example Values |
 |---|---|---|---|---|
-| <a id="host-arch" href="#host-arch">`host.arch`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The CPU architecture the host system is running on. | `amd64`; `arm32`; `arm64` |
+| <a id="host-cpu-arch" href="#host-cpu-arch">`host.cpu.arch`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The CPU architecture the host system is running on. | `amd64`; `arm32`; `arm64` |
 | <a id="host-cpu-cache-l2-size" href="#host-cpu-cache-l2-size">`host.cpu.cache.l2.size`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The amount of level 2 memory cache available to the processor (in Bytes). | `12288000` |
 | <a id="host-cpu-family" href="#host-cpu-family">`host.cpu.family`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Family or generation of the CPU. | `6`; `PA-RISC 1.1e` |
 | <a id="host-cpu-model-id" href="#host-cpu-model-id">`host.cpu.model.id`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Model identifier. It provides more granular information about the CPU, distinguishing it from other CPUs within the same family. | `6`; `9000/778/B180L` |
@@ -32,6 +35,31 @@ A host is defined as a computing instance. For example, physical servers, virtua
 **[2] `host.ip`:** IPv4 Addresses MUST be specified in dotted-quad notation. IPv6 addresses MUST be specified in the [RFC 5952](https://www.rfc-editor.org/rfc/rfc5952.html) format.
 
 **[3] `host.mac`:** MAC Addresses MUST be represented in [IEEE RA hexadecimal form](https://standards.ieee.org/wp-content/uploads/import/documents/tutorials/eui.pdf): as hyphen-separated octets in uppercase hexadecimal form from most to least significant.
+
+---
+
+`host.cpu.arch` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `amd64` | AMD64 | ![Development](https://img.shields.io/badge/-development-blue) |
+| `arm32` | ARM32 | ![Development](https://img.shields.io/badge/-development-blue) |
+| `arm64` | ARM64 | ![Development](https://img.shields.io/badge/-development-blue) |
+| `ia64` | Itanium | ![Development](https://img.shields.io/badge/-development-blue) |
+| `ppc32` | 32-bit PowerPC | ![Development](https://img.shields.io/badge/-development-blue) |
+| `ppc64` | 64-bit PowerPC | ![Development](https://img.shields.io/badge/-development-blue) |
+| `s390x` | IBM z/Architecture | ![Development](https://img.shields.io/badge/-development-blue) |
+| `x86` | 32-bit x86 | ![Development](https://img.shields.io/badge/-development-blue) |
+
+## Deprecated Host Attributes
+
+A host is defined as a computing instance. For example, physical servers, virtual machines, switches or disk array.
+
+**Attributes:**
+
+| Key | Stability | Value Type | Description | Example Values |
+|---|---|---|---|---|
+| <a id="host-arch" href="#host-arch">`host.arch`</a> | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `host.cpu.arch`. | string | The CPU architecture the host system is running on. | `amd64`; `arm32`; `arm64` |
 
 ---
 

--- a/docs/registry/entities/README.md
+++ b/docs/registry/entities/README.md
@@ -62,6 +62,7 @@ Currently, the following namespaces exist:
 | Host | | |
 | | [host](host.md#host) | ![Development](https://img.shields.io/badge/-development-blue) |
 | | [host.cpu](host.md#host-cpu) | ![Development](https://img.shields.io/badge/-development-blue) |
+| | [host.image](host.md#host-image) | ![Development](https://img.shields.io/badge/-development-blue) |
 | K8s | | |
 | | [k8s.cluster](k8s.md#k8s-cluster) | ![Development](https://img.shields.io/badge/-development-blue) |
 | | [k8s.container](k8s.md#k8s-container) | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/registry/entities/host.md
+++ b/docs/registry/entities/host.md
@@ -18,17 +18,18 @@
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`host.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system. [1] | `fdbf79e8af94cb7f9e8df36789187052` |
-| Other | [`host.image.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | VM image ID or host OS image ID. For Cloud, this value is from the provider. | `ami-07b06b442921831e5` |
-| Other | [`host.image.name`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Name of the VM image or OS install the host was instantiated from. | `infra-ami-eks-worker-node-7d4ec78312`; `CentOS-8-x86_64-1905` |
-| Other | [`host.image.version`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The version string of the VM image or host OS as defined in [Version Attributes](/docs/resource/README.md#version-attributes). | `0.1` |
+| Description | [`host.type`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Type of host. For Cloud, this must be the machine type. | `n1-standard-1` |
+| Description | [`host.ip`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string[] | Available IP addresses of the host, excluding loopback interfaces. [1] | `["192.168.1.140", "fe80::abc2:4a28:737a:609e"]` |
+| Description | [`host.mac`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string[] | Available MAC addresses of the host, excluding loopback interfaces. [2] | `["AC-DE-48-23-45-67", "AC-DE-48-23-45-67-01-9F"]` |
+| Other | [`host.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system. [3] | `fdbf79e8af94cb7f9e8df36789187052` |
 | Other | [`host.name`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user. | `opentelemetry-test` |
-| Other | [`host.type`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Type of host. For Cloud, this must be the machine type. | `n1-standard-1` |
-| Other | [`host.ip`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string[] | Available IP addresses of the host, excluding loopback interfaces. [2] | `["192.168.1.140", "fe80::abc2:4a28:737a:609e"]` |
-| Other | [`host.mac`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string[] | Available MAC addresses of the host, excluding loopback interfaces. [3] | `["AC-DE-48-23-45-67", "AC-DE-48-23-45-67-01-9F"]` |
 
 
-**[1] `host.id`:** Collecting `host.id` from non-containerized systems
+**[1] `host.ip`:** IPv4 Addresses MUST be specified in dotted-quad notation. IPv6 addresses MUST be specified in the [RFC 5952](https://www.rfc-editor.org/rfc/rfc5952.html) format.
+
+**[2] `host.mac`:** MAC Addresses MUST be represented in [IEEE RA hexadecimal form](https://standards.ieee.org/wp-content/uploads/import/documents/tutorials/eui.pdf): as hyphen-separated octets in uppercase hexadecimal form from most to least significant.
+
+**[3] `host.id`:** Collecting `host.id` from non-containerized systems
 
 **Non-privileged Machine ID Lookup**
 
@@ -54,10 +55,6 @@ detector implementations MUST not collect `host.id` from privileged sources. If
 privileged lookup of `host.id` is required, the value should be injected via the
 `OTEL_RESOURCE_ATTRIBUTES` environment variable.
 
-**[2] `host.ip`:** IPv4 Addresses MUST be specified in dotted-quad notation. IPv6 addresses MUST be specified in the [RFC 5952](https://www.rfc-editor.org/rfc/rfc5952.html) format.
-
-**[3] `host.mac`:** MAC Addresses MUST be represented in [IEEE RA hexadecimal form](https://standards.ieee.org/wp-content/uploads/import/documents/tutorials/eui.pdf): as hyphen-separated octets in uppercase hexadecimal form from most to least significant.
-
 ## Host CPU
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
@@ -82,5 +79,19 @@ privileged lookup of `host.id` is required, the value should be injected via the
 
 
 **[4] `host.cpu.vendor.id`:** [CPUID](https://wiki.osdev.org/CPUID) command returns the vendor ID string in EBX, EDX and ECX registers. Writing these to memory in this order results in a 12-character string.
+
+## Host Image
+
+**Status:** ![Development](https://img.shields.io/badge/-development-blue)
+
+**type:** `host.image`
+
+**Description:** The image that was used to be originally setup up a host.
+
+| Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
+|---|---|---|---|---|---|---|
+| Identity | [`host.image.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | VM image ID or host OS image ID. For Cloud, this value is from the provider. | `ami-07b06b442921831e5` |
+| Identity | [`host.image.version`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The version string of the VM image or host OS as defined in [Version Attributes](/docs/resource/README.md#version-attributes). | `0.1` |
+| Description | [`host.image.name`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Name of the VM image or OS install the host was instantiated from. | `infra-ami-eks-worker-node-7d4ec78312`; `CentOS-8-x86_64-1905` |
 
 <!-- markdownlint-restore -->

--- a/docs/registry/entities/host.md
+++ b/docs/registry/entities/host.md
@@ -18,7 +18,6 @@
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`host.arch`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The CPU architecture the host system is running on. | `amd64`; `arm32`; `arm64` |
 | Other | [`host.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system. [1] | `fdbf79e8af94cb7f9e8df36789187052` |
 | Other | [`host.image.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | VM image ID or host OS image ID. For Cloud, this value is from the provider. | `ami-07b06b442921831e5` |
 | Other | [`host.image.name`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Name of the VM image or OS install the host was instantiated from. | `infra-ami-eks-worker-node-7d4ec78312`; `CentOS-8-x86_64-1905` |
@@ -72,6 +71,8 @@ privileged lookup of `host.id` is required, the value should be injected via the
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
+| Other | [`host.cpu.arch`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The CPU architecture the host system is running on. | `amd64`; `arm32`; `arm64` |
+| Other | [`host.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system. | `fdbf79e8af94cb7f9e8df36789187052` |
 | Other | [`host.cpu.cache.l2.size`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | int | The amount of level 2 memory cache available to the processor (in Bytes). | `12288000` |
 | Other | [`host.cpu.family`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | Family or generation of the CPU. | `6`; `PA-RISC 1.1e` |
 | Other | [`host.cpu.model.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | Model identifier. It provides more granular information about the CPU, distinguishing it from other CPUs within the same family. | `6`; `9000/778/B180L` |

--- a/docs/resource/host.md
+++ b/docs/resource/host.md
@@ -21,7 +21,6 @@ To report host metrics, the `system.*` namespace SHOULD be used.
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`host.arch`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The CPU architecture the host system is running on. | `amd64`; `arm32`; `arm64` |
 | Other | [`host.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system. [1] | `fdbf79e8af94cb7f9e8df36789187052` |
 | Other | [`host.image.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | VM image ID or host OS image ID. For Cloud, this value is from the provider. | `ami-07b06b442921831e5` |
 | Other | [`host.image.name`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Name of the VM image or OS install the host was instantiated from. | `infra-ami-eks-worker-node-7d4ec78312`; `CentOS-8-x86_64-1905` |
@@ -86,6 +85,8 @@ privileged lookup of `host.id` is required, the value should be injected via the
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
+| Other | [`host.cpu.arch`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The CPU architecture the host system is running on. | `amd64`; `arm32`; `arm64` |
+| Other | [`host.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system. | `fdbf79e8af94cb7f9e8df36789187052` |
 | Other | [`host.cpu.cache.l2.size`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | int | The amount of level 2 memory cache available to the processor (in Bytes). | `12288000` |
 | Other | [`host.cpu.family`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | Family or generation of the CPU. | `6`; `PA-RISC 1.1e` |
 | Other | [`host.cpu.model.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | Model identifier. It provides more granular information about the CPU, distinguishing it from other CPUs within the same family. | `6`; `9000/778/B180L` |

--- a/docs/resource/host.md
+++ b/docs/resource/host.md
@@ -21,17 +21,18 @@ To report host metrics, the `system.*` namespace SHOULD be used.
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`host.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system. [1] | `fdbf79e8af94cb7f9e8df36789187052` |
-| Other | [`host.image.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | VM image ID or host OS image ID. For Cloud, this value is from the provider. | `ami-07b06b442921831e5` |
-| Other | [`host.image.name`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Name of the VM image or OS install the host was instantiated from. | `infra-ami-eks-worker-node-7d4ec78312`; `CentOS-8-x86_64-1905` |
-| Other | [`host.image.version`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The version string of the VM image or host OS as defined in [Version Attributes](/docs/resource/README.md#version-attributes). | `0.1` |
+| Description | [`host.type`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Type of host. For Cloud, this must be the machine type. | `n1-standard-1` |
+| Description | [`host.ip`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string[] | Available IP addresses of the host, excluding loopback interfaces. [1] | `["192.168.1.140", "fe80::abc2:4a28:737a:609e"]` |
+| Description | [`host.mac`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string[] | Available MAC addresses of the host, excluding loopback interfaces. [2] | `["AC-DE-48-23-45-67", "AC-DE-48-23-45-67-01-9F"]` |
+| Other | [`host.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system. [3] | `fdbf79e8af94cb7f9e8df36789187052` |
 | Other | [`host.name`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user. | `opentelemetry-test` |
-| Other | [`host.type`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Type of host. For Cloud, this must be the machine type. | `n1-standard-1` |
-| Other | [`host.ip`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string[] | Available IP addresses of the host, excluding loopback interfaces. [2] | `["192.168.1.140", "fe80::abc2:4a28:737a:609e"]` |
-| Other | [`host.mac`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string[] | Available MAC addresses of the host, excluding loopback interfaces. [3] | `["AC-DE-48-23-45-67", "AC-DE-48-23-45-67-01-9F"]` |
 
 
-**[1] `host.id`:** Collecting `host.id` from non-containerized systems
+**[1] `host.ip`:** IPv4 Addresses MUST be specified in dotted-quad notation. IPv6 addresses MUST be specified in the [RFC 5952](https://www.rfc-editor.org/rfc/rfc5952.html) format.
+
+**[2] `host.mac`:** MAC Addresses MUST be represented in [IEEE RA hexadecimal form](https://standards.ieee.org/wp-content/uploads/import/documents/tutorials/eui.pdf): as hyphen-separated octets in uppercase hexadecimal form from most to least significant.
+
+**[3] `host.id`:** Collecting `host.id` from non-containerized systems
 
 **Non-privileged Machine ID Lookup**
 
@@ -56,10 +57,6 @@ systems can use the output of `dmidecode -t system`, `dmidecode -t baseboard`,
 detector implementations MUST not collect `host.id` from privileged sources. If
 privileged lookup of `host.id` is required, the value should be injected via the
 `OTEL_RESOURCE_ATTRIBUTES` environment variable.
-
-**[2] `host.ip`:** IPv4 Addresses MUST be specified in dotted-quad notation. IPv6 addresses MUST be specified in the [RFC 5952](https://www.rfc-editor.org/rfc/rfc5952.html) format.
-
-**[3] `host.mac`:** MAC Addresses MUST be represented in [IEEE RA hexadecimal form](https://standards.ieee.org/wp-content/uploads/import/documents/tutorials/eui.pdf): as hyphen-separated octets in uppercase hexadecimal form from most to least significant.
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
 <!-- END AUTOGENERATED TEXT -->

--- a/docs/resource/zos.md
+++ b/docs/resource/zos.md
@@ -46,13 +46,13 @@ The following table describes how to populate attributes on the `host` entity on
 
 | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|
-| [`host.arch`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The CPU architecture the host system is running on. | `s390x` |
+| [`host.cpu.arch`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The CPU architecture the host system is running on. | `s390x` |
 | [`host.name`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | Name of the host. On z/OS, SHOULD be the full qualified hostname used to register the z/OS system in DNS. | `SYS1.DOMAIN.COM` |
 | [`host.id`](/docs/registry/attributes/host.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | Unique host ID. On z/OS, SHOULD be the concatenation of sysplex name and SMFID, separated by a dash | `SYSPLEX1-SYS1` |
 
 ---
 
-`host.arch` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`host.cpu.arch` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/model/cpu/registry.yaml
+++ b/model/cpu/registry.yaml
@@ -1,7 +1,10 @@
 groups:
   - id: registry.cpu
     type: attribute_group
-    brief: Attributes specific to a cpu instance.
+    brief: >
+      CPU fields can carry data about a specific cpu instance.
+
+      Note: These CPU attributes are typically used to capture system metrics about a CPU. The CPU attributes under host are for describing the cpu in the host.
     display_name: CPU Attributes
     attributes:
       - id: cpu.mode

--- a/model/host/deprecated/registry-deprecated.yaml
+++ b/model/host/deprecated/registry-deprecated.yaml
@@ -1,0 +1,48 @@
+groups:
+  - id: registry.host.deprecated
+    type: attribute_group
+    display_name: Deprecated Host Attributes
+    brief: >
+      A host is defined as a computing instance. For example, physical servers, virtual machines, switches or disk array.
+    attributes:
+      - id: host.arch
+        deprecated:
+          reason: renamed
+          renamed_to: host.cpu.arch
+        type:
+          members:
+            - id: amd64
+              value: 'amd64'
+              brief: "AMD64"
+              stability: development
+            - id: arm32
+              value: 'arm32'
+              brief: "ARM32"
+              stability: development
+            - id: arm64
+              value: 'arm64'
+              brief: "ARM64"
+              stability: development
+            - id: ia64
+              value: 'ia64'
+              brief: "Itanium"
+              stability: development
+            - id: ppc32
+              value: 'ppc32'
+              brief: "32-bit PowerPC"
+              stability: development
+            - id: ppc64
+              value: 'ppc64'
+              brief: "64-bit PowerPC"
+              stability: development
+            - id: s390x
+              value: 's390x'
+              brief: "IBM z/Architecture"
+              stability: development
+            - id: x86
+              value: 'x86'
+              brief: "32-bit x86"
+              stability: development
+        stability: development
+        brief: >
+            The CPU architecture the host system is running on.

--- a/model/host/entities.yaml
+++ b/model/host/entities.yaml
@@ -35,7 +35,6 @@ groups:
           `OTEL_RESOURCE_ATTRIBUTES` environment variable.
       - ref: host.name
       - ref: host.type
-      - ref: host.arch
       - ref: host.image.name
       - ref: host.image.id
       - ref: host.image.version
@@ -51,6 +50,8 @@ groups:
     brief: >
       A host's CPU information
     attributes:
+      - ref: host.id
+      - ref: host.cpu.arch
       - ref: host.cpu.vendor.id
         requirement_level: opt_in
       - ref: host.cpu.family

--- a/model/host/entities.yaml
+++ b/model/host/entities.yaml
@@ -35,14 +35,26 @@ groups:
           `OTEL_RESOURCE_ATTRIBUTES` environment variable.
       - ref: host.name
       - ref: host.type
-      - ref: host.image.name
-      - ref: host.image.id
-      - ref: host.image.version
+        role: descriptive
       - ref: host.ip
+        role: descriptive
         requirement_level: opt_in
       - ref: host.mac
+        role: descriptive
         requirement_level: opt_in
-
+  - id: entity.host.image
+    type: entity
+    stability: development
+    name: host.image
+    brief: >
+        The image that was used to be originally setup up a host.
+    attributes:
+      - ref: host.image.name
+        role: descriptive
+      - ref: host.image.id
+        role: identifying
+      - ref: host.image.version
+        role: identifying
   - id: entity.host.cpu
     type: entity
     stability: development

--- a/model/host/registry.yaml
+++ b/model/host/registry.yaml
@@ -27,7 +27,7 @@ groups:
         brief: >
           Type of host. For Cloud, this must be the machine type.
         examples: ['n1-standard-1']
-      - id: host.arch
+      - id: host.cpu.arch
         type:
           members:
             - id: amd64

--- a/model/zos/common.yaml
+++ b/model/zos/common.yaml
@@ -76,7 +76,7 @@ groups:
       - ref: host.name
         brief: 'Name of the host. On z/OS, SHOULD be the full qualified hostname used to register the z/OS system in DNS.'
         examples: 'SYS1.DOMAIN.COM'
-      - ref: host.arch
+      - ref: host.cpu.arch
         examples: 's390x'
       - ref: host.id
         brief: 'Unique host ID. On z/OS, SHOULD be the concatenation of sysplex name and SMFID, separated by a dash'


### PR DESCRIPTION
Fixes #2374

## Changes

This moves the CPU arch to now be under the host.cpu namespace rather than directly under the host namespace

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
