### PR TITLE
Add stability requirements for entities to have attribute roles.

### DIFF
--- a/model/service/entities.yaml
+++ b/model/service/entities.yaml
@@ -8,6 +8,10 @@ groups:
     attributes:
       - ref: service.name
         requirement_level: required
+        role: identifying
       - ref: service.version
+        role: descriptive
       - ref: service.namespace
+        role: identifying
       - ref: service.instance.id
+        role: identifying

--- a/model/telemetry/entities.yaml
+++ b/model/telemetry/entities.yaml
@@ -8,10 +8,13 @@ groups:
     attributes:
       - ref: telemetry.sdk.name
         requirement_level: required
+        role: identifying
       - ref: telemetry.sdk.language
         requirement_level: required
+        role: identifying
       - ref: telemetry.sdk.version
         requirement_level: required
+        role: descriptive
   - id: entity.telemetry.distro
     name: 'telemetry.distro'
     type: entity

--- a/policies/entity_stability.rego
+++ b/policies/entity_stability.rego
@@ -1,0 +1,48 @@
+package after_resolution
+import rego.v1
+
+# checks for stable entity groups that have no identifying attributes
+deny contains entity_stability_violation(description, group.id, "") if {
+    group := input.groups[_]
+    # ignore attribute_groups
+    group.type == "entity"
+    group.stability == "stable"
+
+    exceptions = {}
+    not exceptions[group.id]
+
+    ids := [attr |
+        some attr in group.attributes
+        attr.role == "identifying"
+    ]
+    count(ids) < 1
+
+    description := sprintf("Stable entity '%s' has no identifying attributes", [group.name])
+}
+
+
+# checks for stable entity groups that have attributes with no role
+deny contains entity_stability_violation(description, group.id, attr.name) if {
+    group := input.groups[_]
+    # ignore attribute_groups
+    group.type == "entity"
+    group.stability == "stable"
+
+    exceptions = {}
+    not exceptions[group.id]
+
+    attr := group.attributes[_]
+    not attr.role
+
+    description := sprintf("Stable entity '%s' has attribute without role: '%s'", [group.name, attr.name])
+}
+
+entity_stability_violation(description, group, attr) = violation if {
+    violation := {
+        "id": description,
+        "type": "semconv_attribute",
+        "category": "group_stability_violation",
+        "attr": attr,
+        "group": group,
+    }
+}

--- a/policies_test/entity_stability_test.rego
+++ b/policies_test/entity_stability_test.rego
@@ -1,0 +1,48 @@
+package after_resolution
+import future.keywords
+
+test_fails_on_stable_entity_with_attributes_having_no_role if {
+    count(deny) >= 1 with input as {"groups": [{
+        "id": "entity.foo",
+        "type": "entity",
+        "name": "foo",
+        "stability": "stable",
+        "attributes": [{
+            "name": "test.experimental",
+            "stability": "stable",
+        }, {
+            "name": "test.id",
+            "stability": "stable",
+            "role": "identifying",
+        }]}]}
+}
+
+test_fails_on_stable_entity_with_attributes_having_no_id if {
+    count(deny) >= 1 with input as {"groups": [{
+        "id": "entity.foo",
+        "type": "entity",
+        "name": "foo",
+        "stability": "stable",
+        "attributes": [{
+            "name": "test.experimental",
+            "stability": "stable",
+            "role": "descriptive",
+        }]}]}
+}
+
+test_passes_on_stable_entity_with_id if {
+    count(deny) == 0 with input as {"groups": [{
+        "id": "entity.foo",
+        "type": "entity",
+        "name": "foo",
+        "stability": "stable",
+        "attributes": [{
+            "name": "test.experimental",
+            "stability": "stable",
+            "role": "descriptive",
+        },{
+            "name": "test.id",
+            "stability": "stable",
+            "role": "identifying",
+        }]}]}
+}


### PR DESCRIPTION
splits from #2278

## Changes

- Add more urgently needed controls to ensure stable entities have `identifying` and `descriptive` attributes modeled before stabilizing.
- Retrocatively declares identifying and descriptive attributes for stable entities.
