### PR TITLE
Additional info about the telemetry #2345

### DIFF
--- a/.chloggen/TEMPLATE copy.yaml
+++ b/.chloggen/TEMPLATE copy.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: telemetry
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Telemetry can now from the source be associated with the namespace of where it is to end up as well as the organisation which it is of interest to.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2345]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/telemetry.md
+++ b/docs/registry/attributes/telemetry.md
@@ -9,16 +9,23 @@ This document defines attributes for telemetry SDK.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
-| <a id="telemetry-distro-name" href="#telemetry-distro-name">`telemetry.distro.name`</a> | string | The name of the auto instrumentation agent or distribution, if used. [1] | `parts-unlimited-java` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="telemetry-destination-namespace" href="#telemetry-destination-namespace">`telemetry.destination.namespace`</a> | string | The namespace which the telemetry should be put into. [1] | `public-website` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="telemetry-distro-name" href="#telemetry-distro-name">`telemetry.distro.name`</a> | string | The name of the auto instrumentation agent or distribution, if used. [2] | `parts-unlimited-java` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="telemetry-distro-version" href="#telemetry-distro-version">`telemetry.distro.version`</a> | string | The version string of the auto instrumentation agent or distribution, if used. | `1.2.3` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="telemetry-organisation-id" href="#telemetry-organisation-id">`telemetry.organisation.id`</a> | string | Unique identifier for the organization. | `19e97b12-0fa0-45de-9c59-23ff59d572b9` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="telemetry-organisation-name" href="#telemetry-organisation-name">`telemetry.organisation.name`</a> | string | Name for the Organization or team. | `productX_support` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="telemetry-organisation-role" href="#telemetry-organisation-role">`telemetry.organisation.role`</a> | string | Role of the organisation. | `support`; `hosting` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="telemetry-sdk-language" href="#telemetry-sdk-language">`telemetry.sdk.language`</a> | string | The language of the telemetry SDK. | `cpp`; `dotnet`; `erlang` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| <a id="telemetry-sdk-name" href="#telemetry-sdk-name">`telemetry.sdk.name`</a> | string | The name of the telemetry SDK as defined above. [2] | `opentelemetry` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| <a id="telemetry-sdk-name" href="#telemetry-sdk-name">`telemetry.sdk.name`</a> | string | The name of the telemetry SDK as defined above. [3] | `opentelemetry` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | <a id="telemetry-sdk-version" href="#telemetry-sdk-version">`telemetry.sdk.version`</a> | string | The version string of the telemetry SDK. | `1.2.3` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
-**[1] `telemetry.distro.name`:** Official auto instrumentation agents and distributions SHOULD set the `telemetry.distro.name` attribute to
+**[1] `telemetry.destination.namespace`:** For Elastic this would be the space.
+For GCP this would be the telemetry project.
+
+**[2] `telemetry.distro.name`:** Official auto instrumentation agents and distributions SHOULD set the `telemetry.distro.name` attribute to
 a string starting with `opentelemetry-`, e.g. `opentelemetry-java-instrumentation`.
 
-**[2] `telemetry.sdk.name`:** The OpenTelemetry SDK MUST set the `telemetry.sdk.name` attribute to `opentelemetry`.
+**[3] `telemetry.sdk.name`:** The OpenTelemetry SDK MUST set the `telemetry.sdk.name` attribute to `opentelemetry`.
 If another SDK, like a fork or a vendor-provided implementation, is used, this SDK MUST set the
 `telemetry.sdk.name` attribute to the fully-qualified class or module name of this SDK's main entry point
 or another suitable identifier depending on the language.

--- a/model/telemetry/entities.yaml
+++ b/model/telemetry/entities.yaml
@@ -23,3 +23,16 @@ groups:
         requirement_level: recommended
       - ref: telemetry.distro.version
         requirement_level: recommended
+  - id: entity.telemetry.organisation
+    name: 'telemetry.organisation'
+    type: entity
+    stability: development
+    brief: >
+      The organisation which this telemetry is intended to be used by.
+    attributes:
+      - ref: telemetry.organisation.id
+        requirement_level: recommended
+      - ref: telemetry.organisation.name
+        requirement_level: recommended
+      - ref: telemetry.organisation.role
+        requirement_level: opt_in

--- a/model/telemetry/registry.yaml
+++ b/model/telemetry/registry.yaml
@@ -81,3 +81,30 @@ groups:
         brief: >
           The version string of the auto instrumentation agent or distribution, if used.
         examples: ["1.2.3"]
+      - id: telemetry.destination.namespace
+        type: string
+        stability: development
+        brief: >
+          The namespace which the telemetry should be put into.
+        note: |
+          For Elastic this would be the space.
+          For GCP this would be the telemetry project.
+        examples: ["public-website"]
+      - id: telemetry.organisation.id
+        type: string
+        stability: development
+        brief: >
+          Unique identifier for the organization.
+        examples: ["19e97b12-0fa0-45de-9c59-23ff59d572b9"]
+      - id: telemetry.organisation.name
+        type: string
+        stability: development
+        brief: >
+          Name for the Organization or team.
+        examples: ["productX_support"]
+      - id: telemetry.organisation.role
+        type: string
+        stability: development
+        brief: >
+          Role of the organisation.
+        examples: ["support", "hosting"]


### PR DESCRIPTION
Fixes #2345 

## Changes

Adds the ability to specify the organisation which the telemetry is for and the destination of the telemetry,

The organisation telemetry is to bring across a similar functionality in ecs.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
