### PR TITLE
Adds explicit id for faas entities #2393

### DIFF
--- a/.chloggen/add_id_to_faas.yaml
+++ b/.chloggen/add_id_to_faas.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: faas
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds in an id to faas so that it could be used for non cloud as well as entities.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2393]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/faas/faas-spans.md
+++ b/docs/faas/faas-spans.md
@@ -48,8 +48,9 @@ If Spans following this convention are produced, a Resource of type `faas` MUST 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`cloud.resource_id`](/docs/registry/attributes/cloud.md) | string | Cloud provider-specific native identifier of the monitored cloud resource (e.g. an [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) on AWS, a [fully qualified resource ID](https://learn.microsoft.com/rest/api/resources/resources/get-by-id) on Azure, a [full resource name](https://google.aip.dev/122#full-resource-names) on GCP) [1] | `arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function`; `//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID`; `/subscriptions/<SUBSCRIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`faas.id`](/docs/registry/attributes/faas.md) | string | The id of the single function that this runtime instance executes. [2] | `arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function`; `//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID`; `/subscriptions/<SUBSCRIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`faas.invocation_id`](/docs/registry/attributes/faas.md) | string | The invocation ID of the current function invocation. | `af9d5aa4-a685-4c5f-a22b-444f80b3cc28` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`faas.trigger`](/docs/registry/attributes/faas.md) | string | Type of the trigger which caused this function invocation. [2] | `datasource`; `http`; `pubsub` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`faas.trigger`](/docs/registry/attributes/faas.md) | string | Type of the trigger which caused this function invocation. [3] | `datasource`; `http`; `pubsub` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 **[1] `cloud.resource_id`:** On some cloud providers, it may not be possible to determine the full ID at startup,
 so it may be necessary to set `cloud.resource_id` as a span attribute instead.
@@ -69,7 +70,9 @@ The following well-known definitions MUST be used if you set this attribute and 
   This means that a span attribute MUST be used, as an Azure function app can host multiple functions that would usually share
   a TracerProvider.
 
-**[2] `faas.trigger`:** For the server/consumer span on the incoming side,
+**[2] `faas.id`:** This id in the case of cloud based faas systems will be the same value as `cloud.resource_id` however in the case of local systems this should be another local identifier.
+
+**[3] `faas.trigger`:** For the server/consumer span on the incoming side,
 `faas.trigger` MUST be set.
 
 Clients invoking FaaS instances usually cannot set `faas.trigger`,
@@ -270,8 +273,11 @@ This span represents server side if the FaaS invocations triggered in response r
 |---|---|---|---|---|---|
 | [`faas.document.collection`](/docs/registry/attributes/faas.md) | string | The name of the source on which the triggering operation was performed. For example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name. | `myBucketName`; `myDbName` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`faas.document.operation`](/docs/registry/attributes/faas.md) | string | Describes the type of the operation that was performed on the data. | `insert`; `edit`; `delete` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`faas.id`](/docs/registry/attributes/faas.md) | string | The id of the single function that this runtime instance executes. [1] | `arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function`; `//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID`; `/subscriptions/<SUBSCRIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`faas.document.name`](/docs/registry/attributes/faas.md) | string | The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name. | `myFile.txt`; `myTableName` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`faas.document.time`](/docs/registry/attributes/faas.md) | string | A string containing the time when the data was accessed in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime). | `2020-01-23T13:47:06Z` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+
+**[1] `faas.id`:** This id in the case of cloud based faas systems will be the same value as `cloud.resource_id` however in the case of local systems this should be another local identifier.
 
 ---
 

--- a/docs/registry/attributes/faas.md
+++ b/docs/registry/attributes/faas.md
@@ -15,28 +15,31 @@ FaaS attributes
 | <a id="faas-document-name" href="#faas-document-name">`faas.document.name`</a> | string | The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name. | `myFile.txt`; `myTableName` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="faas-document-operation" href="#faas-document-operation">`faas.document.operation`</a> | string | Describes the type of the operation that was performed on the data. | `insert`; `edit`; `delete` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="faas-document-time" href="#faas-document-time">`faas.document.time`</a> | string | A string containing the time when the data was accessed in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime). | `2020-01-23T13:47:06Z` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="faas-instance" href="#faas-instance">`faas.instance`</a> | string | The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version. [1] | `2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="faas-id" href="#faas-id">`faas.id`</a> | string | The id of the single function that this runtime instance executes. [1] | `arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function`; `//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID`; `/subscriptions/<SUBSCRIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="faas-instance" href="#faas-instance">`faas.instance`</a> | string | The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version. [2] | `2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="faas-invocation-id" href="#faas-invocation-id">`faas.invocation_id`</a> | string | The invocation ID of the current function invocation. | `af9d5aa4-a685-4c5f-a22b-444f80b3cc28` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="faas-invoked-name" href="#faas-invoked-name">`faas.invoked_name`</a> | string | The name of the invoked function. [2] | `my-function` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="faas-invoked-provider" href="#faas-invoked-provider">`faas.invoked_provider`</a> | string | The cloud provider of the invoked function. [3] | `alibaba_cloud`; `aws`; `azure` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="faas-invoked-region" href="#faas-invoked-region">`faas.invoked_region`</a> | string | The cloud region of the invoked function. [4] | `eu-central-1` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="faas-max-memory" href="#faas-max-memory">`faas.max_memory`</a> | int | The amount of memory available to the serverless function converted to Bytes. [5] | `134217728` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="faas-name" href="#faas-name">`faas.name`</a> | string | The name of the single function that this runtime instance executes. [6] | `my-function`; `myazurefunctionapp/some-function-name` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="faas-invoked-name" href="#faas-invoked-name">`faas.invoked_name`</a> | string | The name of the invoked function. [3] | `my-function` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="faas-invoked-provider" href="#faas-invoked-provider">`faas.invoked_provider`</a> | string | The cloud provider of the invoked function. [4] | `alibaba_cloud`; `aws`; `azure` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="faas-invoked-region" href="#faas-invoked-region">`faas.invoked_region`</a> | string | The cloud region of the invoked function. [5] | `eu-central-1` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="faas-max-memory" href="#faas-max-memory">`faas.max_memory`</a> | int | The amount of memory available to the serverless function converted to Bytes. [6] | `134217728` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="faas-name" href="#faas-name">`faas.name`</a> | string | The name of the single function that this runtime instance executes. [7] | `my-function`; `myazurefunctionapp/some-function-name` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="faas-time" href="#faas-time">`faas.time`</a> | string | A string containing the function invocation time in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime). | `2020-01-23T13:47:06Z` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="faas-trigger" href="#faas-trigger">`faas.trigger`</a> | string | Type of the trigger which caused this function invocation. | `datasource`; `http`; `pubsub` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="faas-version" href="#faas-version">`faas.version`</a> | string | The immutable version of the function being executed. [7] | `26`; `pinkfroid-00002` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="faas-version" href="#faas-version">`faas.version`</a> | string | The immutable version of the function being executed. [8] | `26`; `pinkfroid-00002` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[1] `faas.instance`:** - **AWS Lambda:** Use the (full) log stream name.
+**[1] `faas.id`:** This id in the case of cloud based faas systems will be the same value as `cloud.resource_id` however in the case of local systems this should be another local identifier.
 
-**[2] `faas.invoked_name`:** SHOULD be equal to the `faas.name` resource attribute of the invoked function.
+**[2] `faas.instance`:** - **AWS Lambda:** Use the (full) log stream name.
 
-**[3] `faas.invoked_provider`:** SHOULD be equal to the `cloud.provider` resource attribute of the invoked function.
+**[3] `faas.invoked_name`:** SHOULD be equal to the `faas.name` resource attribute of the invoked function.
 
-**[4] `faas.invoked_region`:** SHOULD be equal to the `cloud.region` resource attribute of the invoked function.
+**[4] `faas.invoked_provider`:** SHOULD be equal to the `cloud.provider` resource attribute of the invoked function.
 
-**[5] `faas.max_memory`:** It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information (which must be multiplied by 1,048,576).
+**[5] `faas.invoked_region`:** SHOULD be equal to the `cloud.region` resource attribute of the invoked function.
 
-**[6] `faas.name`:** This is the name of the function as configured/deployed on the FaaS
+**[6] `faas.max_memory`:** It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information (which must be multiplied by 1,048,576).
+
+**[7] `faas.name`:** This is the name of the function as configured/deployed on the FaaS
 platform and is usually different from the name of the callback
 function (which may be stored in the
 [`code.namespace`/`code.function.name`](/docs/general/attributes.md#source-code-attributes)
@@ -53,7 +56,7 @@ definition of function name MUST be used for this attribute
   app can host multiple functions that would usually share
   a TracerProvider (see also the `cloud.resource_id` attribute).
 
-**[7] `faas.version`:** Depending on the cloud provider and platform, use:
+**[8] `faas.version`:** Depending on the cloud provider and platform, use:
 
 - **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
   (an integer represented as a decimal string).

--- a/docs/resource/faas.md
+++ b/docs/resource/faas.md
@@ -27,13 +27,16 @@ See also:
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`faas.name`](/docs/registry/attributes/faas.md) | string | The name of the single function that this runtime instance executes. [1] | `my-function`; `myazurefunctionapp/some-function-name` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`cloud.resource_id`](/docs/registry/attributes/cloud.md) | string | Cloud provider-specific native identifier of the monitored cloud resource (e.g. an [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) on AWS, a [fully qualified resource ID](https://learn.microsoft.com/rest/api/resources/resources/get-by-id) on Azure, a [full resource name](https://google.aip.dev/122#full-resource-names) on GCP) [2] | `arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function`; `//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID`; `/subscriptions/<SUBSCRIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`faas.instance`](/docs/registry/attributes/faas.md) | string | The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version. [3] | `2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`faas.max_memory`](/docs/registry/attributes/faas.md) | int | The amount of memory available to the serverless function converted to Bytes. [4] | `134217728` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`faas.version`](/docs/registry/attributes/faas.md) | string | The immutable version of the function being executed. [5] | `26`; `pinkfroid-00002` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`faas.id`](/docs/registry/attributes/faas.md) | string | The id of the single function that this runtime instance executes. [1] | `arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function`; `//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID`; `/subscriptions/<SUBSCRIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`faas.name`](/docs/registry/attributes/faas.md) | string | The name of the single function that this runtime instance executes. [2] | `my-function`; `myazurefunctionapp/some-function-name` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`cloud.resource_id`](/docs/registry/attributes/cloud.md) | string | Cloud provider-specific native identifier of the monitored cloud resource (e.g. an [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) on AWS, a [fully qualified resource ID](https://learn.microsoft.com/rest/api/resources/resources/get-by-id) on Azure, a [full resource name](https://google.aip.dev/122#full-resource-names) on GCP) [3] | `arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function`; `//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID`; `/subscriptions/<SUBSCRIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`faas.instance`](/docs/registry/attributes/faas.md) | string | The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version. [4] | `2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`faas.max_memory`](/docs/registry/attributes/faas.md) | int | The amount of memory available to the serverless function converted to Bytes. [5] | `134217728` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`faas.version`](/docs/registry/attributes/faas.md) | string | The immutable version of the function being executed. [6] | `26`; `pinkfroid-00002` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[1] `faas.name`:** This is the name of the function as configured/deployed on the FaaS
+**[1] `faas.id`:** This id in the case of cloud based faas systems will be the same value as `cloud.resource_id` however in the case of local systems this should be another local identifier.
+
+**[2] `faas.name`:** This is the name of the function as configured/deployed on the FaaS
 platform and is usually different from the name of the callback
 function (which may be stored in the
 [`code.namespace`/`code.function.name`](/docs/general/attributes.md#source-code-attributes)
@@ -50,7 +53,7 @@ definition of function name MUST be used for this attribute
   app can host multiple functions that would usually share
   a TracerProvider (see also the `cloud.resource_id` attribute).
 
-**[2] `cloud.resource_id`:** On some cloud providers, it may not be possible to determine the full ID at startup,
+**[3] `cloud.resource_id`:** On some cloud providers, it may not be possible to determine the full ID at startup,
 so it may be necessary to set `cloud.resource_id` as a span attribute instead.
 
 The exact value to use for `cloud.resource_id` depends on the cloud provider.
@@ -68,11 +71,11 @@ The following well-known definitions MUST be used if you set this attribute and 
   This means that a span attribute MUST be used, as an Azure function app can host multiple functions that would usually share
   a TracerProvider.
 
-**[3] `faas.instance`:** - **AWS Lambda:** Use the (full) log stream name.
+**[4] `faas.instance`:** - **AWS Lambda:** Use the (full) log stream name.
 
-**[4] `faas.max_memory`:** It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information (which must be multiplied by 1,048,576).
+**[5] `faas.max_memory`:** It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information (which must be multiplied by 1,048,576).
 
-**[5] `faas.version`:** Depending on the cloud provider and platform, use:
+**[6] `faas.version`:** Depending on the cloud provider and platform, use:
 
 - **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
   (an integer represented as a decimal string).

--- a/model/faas/entities.yaml
+++ b/model/faas/entities.yaml
@@ -6,6 +6,8 @@ groups:
     brief: >
       A serverless instance.
     attributes:
+      - ref: faas.id
+        requirement_level: required
       - ref: faas.name
         requirement_level: required
       - ref: faas.version

--- a/model/faas/registry.yaml
+++ b/model/faas/registry.yaml
@@ -4,6 +4,17 @@ groups:
     type: attribute_group
     display_name: Function as a Service Attributes
     attributes:
+      - id: faas.id
+        type: string
+        stability: development
+        brief: >
+          The id of the single function that this runtime instance executes.
+        note: |
+          This id in the case of cloud based faas systems will be the same value as `cloud.resource_id` however in the case of local systems this should be another local identifier.
+        examples:
+          - 'arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function'
+          - '//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID'
+          - '/subscriptions/<SUBSCRIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>'
       - id: faas.name
         type: string
         stability: development

--- a/model/faas/spans.yaml
+++ b/model/faas/spans.yaml
@@ -13,6 +13,7 @@ groups:
 
       If Spans following this convention are produced, a Resource of type `faas` MUST exist following the [Resource semantic convention](/docs/resource/faas.md).
     attributes:
+      - ref: faas.id
       - ref: faas.trigger
         note: |
           For the server/consumer span on the incoming side,
@@ -35,6 +36,8 @@ groups:
       This span represents server side if the FaaS invocations triggered in response
       response to some data source operation such as a database or filesystem read/write.
     attributes:
+      - ref: faas.id
+        requirement_level: required
       - ref: faas.document.collection
         requirement_level: required
       - ref: faas.document.operation


### PR DESCRIPTION
Fixes #2393 

## Changes

Adds in an explicit id for the faas entity to enable decoupling of the cloud resource.id

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
