### PR TITLE
Add more service info #2391

### DIFF
--- a/.chloggen/extend_services.yaml
+++ b/.chloggen/extend_services.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: service
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow services to report their status and what roles they perform
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2391]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/service.md
+++ b/docs/registry/attributes/service.md
@@ -13,7 +13,7 @@ A service instance.
 | <a id="service-name" href="#service-name">`service.name`</a> | string | Logical name of the service. [2] | `shoppingcart` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | <a id="service-namespace" href="#service-namespace">`service.namespace`</a> | string | A namespace for `service.name`. [3] | `Shop` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="service-roles" href="#service-roles">`service.roles`</a> | string[] | Roles of a service node. [4] | `["ui", "background_tasks"]`; `["background_tasks"]` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="service-state" href="#service-state">`service.state`</a> | string | Current state of the service. [5] | `starting`; `running`; `stopping`; `stopped` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="service-state" href="#service-state">`service.state`</a> | string | Current state of the service. [5] | `stopped`; `start_pending`; `stop_pending` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="service-version" href="#service-version">`service.version`</a> | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 **[1] `service.instance.id`:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words
@@ -49,10 +49,24 @@ port.
 
 **[4] `service.roles`:** This allows for distinction between different running roles of the same service.
 
-In the case of Kibana, the service.node.role could be ui or background_tasks or both.
+In the case of Kibana, the service.roles could be ui or background_tasks or both.
 
-In the case of Elasticsearch, the service.node.role could be master or data or both.
+In the case of Elasticsearch, the service.roles could be master or data or both.
 
 Other services could use this to distinguish between a web and worker role running as part of the service.
 
 **[5] `service.state`:** This state could be reported a collector which monitors the services
+
+---
+
+`service.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `pause_pending` | Pause Pending | ![Development](https://img.shields.io/badge/-development-blue) |
+| `paused` | Paused | ![Development](https://img.shields.io/badge/-development-blue) |
+| `resume_pending` | Resume Pending | ![Development](https://img.shields.io/badge/-development-blue) |
+| `running` | Running | ![Development](https://img.shields.io/badge/-development-blue) |
+| `start_pending` | Start Pending | ![Development](https://img.shields.io/badge/-development-blue) |
+| `stop_pending` | Stop Pending | ![Development](https://img.shields.io/badge/-development-blue) |
+| `stopped` | Stopped | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/registry/attributes/service.md
+++ b/docs/registry/attributes/service.md
@@ -12,6 +12,8 @@ A service instance.
 | <a id="service-instance-id" href="#service-instance-id">`service.instance.id`</a> | string | The string ID of the service instance. [1] | `627cc493-f310-47de-96bd-71410b7dec09` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="service-name" href="#service-name">`service.name`</a> | string | Logical name of the service. [2] | `shoppingcart` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | <a id="service-namespace" href="#service-namespace">`service.namespace`</a> | string | A namespace for `service.name`. [3] | `Shop` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="service-roles" href="#service-roles">`service.roles`</a> | string[] | Roles of a service node. [4] | `["ui", "background_tasks"]`; `["background_tasks"]` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="service-state" href="#service-state">`service.state`</a> | string | Current state of the service. [5] | `starting`; `running`; `stopping`; `stopped` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="service-version" href="#service-version">`service.version`</a> | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 **[1] `service.instance.id`:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words
@@ -44,3 +46,13 @@ port.
 **[2] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
 
 **[3] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+
+**[4] `service.roles`:** This allows for distinction between different running roles of the same service.
+
+In the case of Kibana, the service.node.role could be ui or background_tasks or both.
+
+In the case of Elasticsearch, the service.node.role could be master or data or both.
+
+Other services could use this to distinguish between a web and worker role running as part of the service.
+
+**[5] `service.state`:** This state could be reported a collector which monitors the services

--- a/docs/registry/entities/README.md
+++ b/docs/registry/entities/README.md
@@ -248,10 +248,6 @@ Currently, the following namespaces exist:
   <td><a href="service.md#service">service</a></td>
   <td><img src="https://img.shields.io/badge/-stable-lightgreen" alt="Stable"/></td>
 </tr><tr>
-  <td></td>
-  <td><a href="service.md#service-instance">service.instance</a></td>
-  <td><img src="https://img.shields.io/badge/-development-blue" alt="Development"/></td>
-</tr><tr>
 <td>Telemetry</td><td></td><td></td>
 </tr><tr>
   <td></td>

--- a/docs/registry/entities/README.md
+++ b/docs/registry/entities/README.md
@@ -248,6 +248,10 @@ Currently, the following namespaces exist:
   <td><a href="service.md#service">service</a></td>
   <td><img src="https://img.shields.io/badge/-stable-lightgreen" alt="Stable"/></td>
 </tr><tr>
+  <td></td>
+  <td><a href="service.md#service-instance">service.instance</a></td>
+  <td><img src="https://img.shields.io/badge/-development-blue" alt="Development"/></td>
+</tr><tr>
 <td>Telemetry</td><td></td><td></td>
 </tr><tr>
   <td></td>

--- a/docs/registry/entities/service.md
+++ b/docs/registry/entities/service.md
@@ -11,52 +11,19 @@
 
 **type:** `service`
 
-**Description:** A service which can generate telemetry.
-
-**Identifying Attributes:**
-
-| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
-|---|---|---|---|---|---|
-| [`service.name`](/docs/registry/attributes/service.md) | string | Logical name of the service. [1] | `shoppingcart` | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| [`service.namespace`](/docs/registry/attributes/service.md) | string | A namespace for `service.name`. [2] | `Shop` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`service.version`](/docs/registry/attributes/service.md) | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-
-**[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
-
-**[2] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
-
-**Descriptive Attributes:**
-
-| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
-|---|---|---|---|---|---|
-| [`service.roles`](/docs/registry/attributes/service.md) | string[] | Roles of a service node. [3] | `["ui", "background_tasks"]`; `["background_tasks"]` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`service.state`](/docs/registry/attributes/service.md) | string | Current state of the service. [4] | `starting`; `running`; `stopping`; `stopped` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-
-**[3] `service.roles`:** This allows for distinction between different running roles of the same service.
-
-In the case of Kibana, the service.node.role could be ui or background_tasks or both.
-
-In the case of Elasticsearch, the service.node.role could be master or data or both.
-
-Other services could use this to distinguish between a web and worker role running as part of the service.
-
-**[4] `service.state`:** This state could be reported a collector which monitors the services
-
-## Service Instance
-
-**Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `service.instance`
-
 **Description:** A service instance.
 
 **Identifying Attributes:**
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`service.instance.id`](/docs/registry/attributes/service.md) | string | The string ID of the service instance. [5] | `627cc493-f310-47de-96bd-71410b7dec09` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.name`](/docs/registry/attributes/service.md) | string | Logical name of the service. [1] | `shoppingcart` | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`service.instance.id`](/docs/registry/attributes/service.md) | string | The string ID of the service instance. [2] | `627cc493-f310-47de-96bd-71410b7dec09` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.namespace`](/docs/registry/attributes/service.md) | string | A namespace for `service.name`. [3] | `Shop` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[5] `service.instance.id`:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words
+**[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+
+**[2] `service.instance.id`:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words
 `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to
 distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled
 service).
@@ -83,17 +50,39 @@ However, Collectors can set the `service.instance.id` if they can unambiguously 
 for that telemetry. This is typically the case for scraping receivers, as they know the target address and
 port.
 
+**[3] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+
 **Descriptive Attributes:**
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`service.name`](/docs/registry/attributes/service.md) | string | Logical name of the service. [6] | `shoppingcart` | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| [`service.namespace`](/docs/registry/attributes/service.md) | string | A namespace for `service.name`. [7] | `Shop` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.roles`](/docs/registry/attributes/service.md) | string[] | Roles of a service node. [4] | `["ui", "background_tasks"]`; `["background_tasks"]` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.state`](/docs/registry/attributes/service.md) | string | Current state of the service. [5] | `stopped`; `start_pending`; `stop_pending` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`service.version`](/docs/registry/attributes/service.md) | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
-**[6] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+**[4] `service.roles`:** This allows for distinction between different running roles of the same service.
 
-**[7] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+In the case of Kibana, the service.roles could be ui or background_tasks or both.
+
+In the case of Elasticsearch, the service.roles could be master or data or both.
+
+Other services could use this to distinguish between a web and worker role running as part of the service.
+
+**[5] `service.state`:** This state could be reported a collector which monitors the services
+
+---
+
+`service.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `pause_pending` | Pause Pending | ![Development](https://img.shields.io/badge/-development-blue) |
+| `paused` | Paused | ![Development](https://img.shields.io/badge/-development-blue) |
+| `resume_pending` | Resume Pending | ![Development](https://img.shields.io/badge/-development-blue) |
+| `running` | Running | ![Development](https://img.shields.io/badge/-development-blue) |
+| `start_pending` | Start Pending | ![Development](https://img.shields.io/badge/-development-blue) |
+| `stop_pending` | Stop Pending | ![Development](https://img.shields.io/badge/-development-blue) |
+| `stopped` | Stopped | ![Development](https://img.shields.io/badge/-development-blue) |
 
 
 <!-- markdownlint-restore -->

--- a/docs/registry/entities/service.md
+++ b/docs/registry/entities/service.md
@@ -11,19 +11,52 @@
 
 **type:** `service`
 
-**Description:** A service instance.
+**Description:** A service which can generate telemetry.
 
 **Identifying Attributes:**
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`service.name`](/docs/registry/attributes/service.md) | string | Logical name of the service. [1] | `shoppingcart` | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| [`service.instance.id`](/docs/registry/attributes/service.md) | string | The string ID of the service instance. [2] | `627cc493-f310-47de-96bd-71410b7dec09` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`service.namespace`](/docs/registry/attributes/service.md) | string | A namespace for `service.name`. [3] | `Shop` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.namespace`](/docs/registry/attributes/service.md) | string | A namespace for `service.name`. [2] | `Shop` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.version`](/docs/registry/attributes/service.md) | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 **[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
 
-**[2] `service.instance.id`:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words
+**[2] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+
+**Descriptive Attributes:**
+
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
+|---|---|---|---|---|---|
+| [`service.roles`](/docs/registry/attributes/service.md) | string[] | Roles of a service node. [3] | `["ui", "background_tasks"]`; `["background_tasks"]` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.state`](/docs/registry/attributes/service.md) | string | Current state of the service. [4] | `starting`; `running`; `stopping`; `stopped` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+
+**[3] `service.roles`:** This allows for distinction between different running roles of the same service.
+
+In the case of Kibana, the service.node.role could be ui or background_tasks or both.
+
+In the case of Elasticsearch, the service.node.role could be master or data or both.
+
+Other services could use this to distinguish between a web and worker role running as part of the service.
+
+**[4] `service.state`:** This state could be reported a collector which monitors the services
+
+## Service Instance
+
+**Status:** ![Development](https://img.shields.io/badge/-development-blue)
+
+**type:** `service.instance`
+
+**Description:** A service instance.
+
+**Identifying Attributes:**
+
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
+|---|---|---|---|---|---|
+| [`service.instance.id`](/docs/registry/attributes/service.md) | string | The string ID of the service instance. [5] | `627cc493-f310-47de-96bd-71410b7dec09` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+
+**[5] `service.instance.id`:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words
 `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to
 distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled
 service).
@@ -50,13 +83,17 @@ However, Collectors can set the `service.instance.id` if they can unambiguously 
 for that telemetry. This is typically the case for scraping receivers, as they know the target address and
 port.
 
-**[3] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
-
 **Descriptive Attributes:**
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
+| [`service.name`](/docs/registry/attributes/service.md) | string | Logical name of the service. [6] | `shoppingcart` | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`service.namespace`](/docs/registry/attributes/service.md) | string | A namespace for `service.name`. [7] | `Shop` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`service.version`](/docs/registry/attributes/service.md) | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+
+**[6] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+
+**[7] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
 
 
 <!-- markdownlint-restore -->

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -79,45 +79,29 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 
 **type:** `service`
 
-**Description:** A service instance.
+**Description:** A service which can generate telemetry.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`service.name`](/docs/registry/attributes/service.md) | string | Logical name of the service. [1] | `shoppingcart` | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| [`service.instance.id`](/docs/registry/attributes/service.md) | string | The string ID of the service instance. [2] | `627cc493-f310-47de-96bd-71410b7dec09` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`service.namespace`](/docs/registry/attributes/service.md) | string | A namespace for `service.name`. [3] | `Shop` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.namespace`](/docs/registry/attributes/service.md) | string | A namespace for `service.name`. [2] | `Shop` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.roles`](/docs/registry/attributes/service.md) | string[] | Roles of a service node. [3] | `["ui", "background_tasks"]`; `["background_tasks"]` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.state`](/docs/registry/attributes/service.md) | string | Current state of the service. [4] | `starting`; `running`; `stopping`; `stopped` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`service.version`](/docs/registry/attributes/service.md) | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 **[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
 
-**[2] `service.instance.id`:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words
-`service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to
-distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled
-service).
+**[2] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
 
-Implementations, such as SDKs, are recommended to generate a random Version 1 or Version 4 [RFC
-4122](https://www.ietf.org/rfc/rfc4122.txt) UUID, but are free to use an inherent unique ID as the source of
-this value if stability is desirable. In that case, the ID SHOULD be used as source of a UUID Version 5 and
-SHOULD use the following UUID as the namespace: `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
+**[3] `service.roles`:** This allows for distinction between different running roles of the same service.
 
-UUIDs are typically recommended, as only an opaque value for the purposes of identifying a service instance is
-needed. Similar to what can be seen in the man page for the
-[`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/latest/machine-id.html) file, the underlying
-data, such as pod name and namespace should be treated as confidential, being the user's choice to expose it
-or not via another resource attribute.
+In the case of Kibana, the service.node.role could be ui or background_tasks or both.
 
-For applications running behind an application server (like unicorn), we do not recommend using one identifier
-for all processes participating in the application. Instead, it's recommended each division (e.g. a worker
-thread in unicorn) to have its own instance.id.
+In the case of Elasticsearch, the service.node.role could be master or data or both.
 
-It's not recommended for a Collector to set `service.instance.id` if it can't unambiguously determine the
-service instance that is generating that telemetry. For instance, creating an UUID based on `pod.name` will
-likely be wrong, as the Collector might not know from which container within that pod the telemetry originated.
-However, Collectors can set the `service.instance.id` if they can unambiguously determine the service instance
-for that telemetry. This is typically the case for scraping receivers, as they know the target address and
-port.
+Other services could use this to distinguish between a web and worker role running as part of the service.
 
-**[3] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+**[4] `service.state`:** This state could be reported a collector which monitors the services
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -79,29 +79,71 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 
 **type:** `service`
 
-**Description:** A service which can generate telemetry.
+**Description:** A service instance.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`service.name`](/docs/registry/attributes/service.md) | string | Logical name of the service. [1] | `shoppingcart` | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| [`service.namespace`](/docs/registry/attributes/service.md) | string | A namespace for `service.name`. [2] | `Shop` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`service.roles`](/docs/registry/attributes/service.md) | string[] | Roles of a service node. [3] | `["ui", "background_tasks"]`; `["background_tasks"]` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`service.state`](/docs/registry/attributes/service.md) | string | Current state of the service. [4] | `starting`; `running`; `stopping`; `stopped` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.instance.id`](/docs/registry/attributes/service.md) | string | The string ID of the service instance. [2] | `627cc493-f310-47de-96bd-71410b7dec09` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.namespace`](/docs/registry/attributes/service.md) | string | A namespace for `service.name`. [3] | `Shop` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.roles`](/docs/registry/attributes/service.md) | string[] | Roles of a service node. [4] | `["ui", "background_tasks"]`; `["background_tasks"]` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.state`](/docs/registry/attributes/service.md) | string | Current state of the service. [5] | `stopped`; `start_pending`; `stop_pending` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`service.version`](/docs/registry/attributes/service.md) | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 **[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
 
-**[2] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+**[2] `service.instance.id`:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words
+`service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to
+distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled
+service).
 
-**[3] `service.roles`:** This allows for distinction between different running roles of the same service.
+Implementations, such as SDKs, are recommended to generate a random Version 1 or Version 4 [RFC
+4122](https://www.ietf.org/rfc/rfc4122.txt) UUID, but are free to use an inherent unique ID as the source of
+this value if stability is desirable. In that case, the ID SHOULD be used as source of a UUID Version 5 and
+SHOULD use the following UUID as the namespace: `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
 
-In the case of Kibana, the service.node.role could be ui or background_tasks or both.
+UUIDs are typically recommended, as only an opaque value for the purposes of identifying a service instance is
+needed. Similar to what can be seen in the man page for the
+[`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/latest/machine-id.html) file, the underlying
+data, such as pod name and namespace should be treated as confidential, being the user's choice to expose it
+or not via another resource attribute.
 
-In the case of Elasticsearch, the service.node.role could be master or data or both.
+For applications running behind an application server (like unicorn), we do not recommend using one identifier
+for all processes participating in the application. Instead, it's recommended each division (e.g. a worker
+thread in unicorn) to have its own instance.id.
+
+It's not recommended for a Collector to set `service.instance.id` if it can't unambiguously determine the
+service instance that is generating that telemetry. For instance, creating an UUID based on `pod.name` will
+likely be wrong, as the Collector might not know from which container within that pod the telemetry originated.
+However, Collectors can set the `service.instance.id` if they can unambiguously determine the service instance
+for that telemetry. This is typically the case for scraping receivers, as they know the target address and
+port.
+
+**[3] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+
+**[4] `service.roles`:** This allows for distinction between different running roles of the same service.
+
+In the case of Kibana, the service.roles could be ui or background_tasks or both.
+
+In the case of Elasticsearch, the service.roles could be master or data or both.
 
 Other services could use this to distinguish between a web and worker role running as part of the service.
 
-**[4] `service.state`:** This state could be reported a collector which monitors the services
+**[5] `service.state`:** This state could be reported a collector which monitors the services
+
+---
+
+`service.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `pause_pending` | Pause Pending | ![Development](https://img.shields.io/badge/-development-blue) |
+| `paused` | Paused | ![Development](https://img.shields.io/badge/-development-blue) |
+| `resume_pending` | Resume Pending | ![Development](https://img.shields.io/badge/-development-blue) |
+| `running` | Running | ![Development](https://img.shields.io/badge/-development-blue) |
+| `start_pending` | Start Pending | ![Development](https://img.shields.io/badge/-development-blue) |
+| `stop_pending` | Stop Pending | ![Development](https://img.shields.io/badge/-development-blue) |
+| `stopped` | Stopped | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/model/service/entities.yaml
+++ b/model/service/entities.yaml
@@ -1,17 +1,35 @@
 groups:
+  - id: entity.service.intance
+    type: entity
+    name: service.instance
+    brief: >
+      A service instance.
+    stability: development
+    attributes:
+      - ref: service.name
+        requirement_level: required
+        role: descriptive
+      - ref: service.version
+        role: descriptive
+      - ref: service.namespace
+        role: descriptive
+      - ref: service.instance.id
+        role: identifying
   - id: entity.service
     type: entity
     name: service
     brief: >
-      A service instance.
+      A service which can generate telemetry.
     stability: stable
     attributes:
       - ref: service.name
         requirement_level: required
         role: identifying
       - ref: service.version
-        role: descriptive
+        role: identifying
       - ref: service.namespace
         role: identifying
-      - ref: service.instance.id
-        role: identifying
+      - ref: service.roles
+        role: descriptive
+      - ref: service.state
+        role: descriptive

--- a/model/service/entities.yaml
+++ b/model/service/entities.yaml
@@ -1,33 +1,19 @@
 groups:
-  - id: entity.service.intance
-    type: entity
-    name: service.instance
-    brief: >
-      A service instance.
-    stability: development
-    attributes:
-      - ref: service.name
-        requirement_level: required
-        role: descriptive
-      - ref: service.version
-        role: descriptive
-      - ref: service.namespace
-        role: descriptive
-      - ref: service.instance.id
-        role: identifying
   - id: entity.service
     type: entity
     name: service
     brief: >
-      A service which can generate telemetry.
+      A service instance.
     stability: stable
     attributes:
       - ref: service.name
         requirement_level: required
         role: identifying
       - ref: service.version
-        role: identifying
+        role: descriptive
       - ref: service.namespace
+        role: identifying
+      - ref: service.instance.id
         role: identifying
       - ref: service.roles
         role: descriptive

--- a/model/service/registry.yaml
+++ b/model/service/registry.yaml
@@ -69,3 +69,27 @@ groups:
           for that telemetry. This is typically the case for scraping receivers, as they know the target address and
           port.
         examples: ["627cc493-f310-47de-96bd-71410b7dec09"]
+      - id: service.roles
+        type: string[]
+        stability: development
+        brief: >
+          Roles of a service node.
+        note: |
+          This allows for distinction between different running roles of the same service.
+
+          In the case of Kibana, the service.node.role could be ui or background_tasks or both.
+
+          In the case of Elasticsearch, the service.node.role could be master or data or both.
+
+          Other services could use this to distinguish between a web and worker role running as part of the service.
+        examples:
+          - ["ui", "background_tasks"]
+          - ["background_tasks"]
+      - id: service.state
+        type: string
+        brief: >
+          Current state of the service.
+        note: >
+          This state could be reported a collector which monitors the services
+        examples: ["starting", "running", "stopping", "stopped"]
+        stability: development

--- a/model/service/registry.yaml
+++ b/model/service/registry.yaml
@@ -77,19 +77,47 @@ groups:
         note: |
           This allows for distinction between different running roles of the same service.
 
-          In the case of Kibana, the service.node.role could be ui or background_tasks or both.
+          In the case of Kibana, the service.roles could be ui or background_tasks or both.
 
-          In the case of Elasticsearch, the service.node.role could be master or data or both.
+          In the case of Elasticsearch, the service.roles could be master or data or both.
 
           Other services could use this to distinguish between a web and worker role running as part of the service.
         examples:
           - ["ui", "background_tasks"]
           - ["background_tasks"]
       - id: service.state
-        type: string
+        type:
+          members:
+            - id: stopped
+              value: "stopped"
+              brief: Stopped
+              stability: development
+            - id: start_pending
+              value: "start_pending"
+              brief: Start Pending
+              stability: development
+            - id: stop_pending
+              value: "stop_pending"
+              brief: Stop Pending
+              stability: development
+            - id: running
+              value: "running"
+              brief: Running
+              stability: development
+            - id: paused
+              value: "paused"
+              brief: Paused
+              stability: development
+            - id: pause_pending
+              value: "pause_pending"
+              brief: Pause Pending
+              stability: development
+            - id: resume_pending
+              value: "resume_pending"
+              brief: Resume Pending
+              stability: development
         brief: >
           Current state of the service.
         note: >
           This state could be reported a collector which monitors the services
-        examples: ["starting", "running", "stopping", "stopped"]
         stability: development


### PR DESCRIPTION
Fixes #2391

## Changes

Introduces the roles array to services so that data can be filtered based upon the role the service is providing. At the same time the service can now have a state.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Usages
State is a migration of https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/windowsservicereceiver/documentation.md and roles is coming across from ECS.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
