### PR TITLE
Add more thread details #2409

### DIFF
--- a/.chloggen/TEMPLATE copy.yaml
+++ b/.chloggen/TEMPLATE copy.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: thread
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add more properties for a thead
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2409]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/thread.md
+++ b/docs/registry/attributes/thread.md
@@ -9,5 +9,8 @@ These attributes may be used for any operation to store information about a thre
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
+| <a id="thread-background" href="#thread-background">`thread.background`</a> | boolean | The thread is a background thread. | `true`; `false` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="thread-id" href="#thread-id">`thread.id`</a> | int | Current "managed" thread ID (as opposed to OS thread ID). | `42` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="thread-name" href="#thread-name">`thread.name`</a> | string | Current thread name. | `main` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="thread-pooled" href="#thread-pooled">`thread.pooled`</a> | boolean | The thread belongs to the managed thread pool. | `true`; `false` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="thread-priority" href="#thread-priority">`thread.priority`</a> | string | The scheduling priority of a thread. | `Lowest`; `BelowNormal`; `Normal`; `AboveNormal`; `Highest` | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/model/thread/registry.yaml
+++ b/model/thread/registry.yaml
@@ -17,3 +17,21 @@ groups:
         brief: >
           Current thread name.
         examples: main
+      - id: thread.background
+        type: boolean
+        stability: development
+        brief: >
+          The thread is a background thread.
+        examples: [true, false]
+      - id: thread.pooled
+        type: boolean
+        stability: development
+        brief: >
+          The thread belongs to the managed thread pool.
+        examples: [true, false]
+      - id: thread.priority
+        type: string
+        stability: development
+        brief: >
+          The scheduling priority of a thread.
+        examples: [ "Lowest", "BelowNormal", "Normal", "AboveNormal", "Highest" ]


### PR DESCRIPTION
Fixes #2409

## Changes

Introduces more details about the thread being described.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
