### PR TITLE
Add copilot instructions for auto-review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,23 +1,33 @@
-# Copilot instructions for OpenTelemetry Semantic Conventions
+# Copilot Instructions for OpenTelemetry Semantic Conventions
 
 ## Overview
-These instructions guide AI assistants in reviewing OpenTelemetry Semantic Conventions
-pull requests to ensure consistency, quality, and adherence to established standards.
+These instructions guide AI assistants in reviewing pull requests for the
+OpenTelemetry Semantic Conventions repository. Follow these guidelines to
+ensure consistency, quality, and adherence to established standards.
 
-**CRITICAL REVIEW CRITERIA**: New areas require special scrutiny and must meet these requirements:
+This repository contains semantic conventions supported by the OpenTelemetry ecosystem.
 
-### Prerequisites for new areas
+**CRITICAL REVIEW CRITERIA**: New areas require special scrutiny and must meet
+these requirements:
+
+#### Prerequisites for New Convention Areas
 - **Domain Expertise**: Must have a group of people familiar with the domain
-- **Active Involvement**: Contributors must be involved with instrumentation efforts in that area
-- **Long-term Commitment**: Must have committed maintainers as points of contact for pull requests, issues, questions, and ongoing maintenance
+- **Active Involvement**: Contributors must be involved with instrumentation
+  efforts in that area
+- **Long-term Commitment**: Must have committed maintainers to be point of contact for:
+  pull requests, issues, question, ongoing maintenance
+
+#### Process for New Areas
 1. **Project Management**: Follow [OpenTelemetry project management](https://github.com/open-telemetry/community/blob/main/project-management.md) guidelines
 2. **Codeowners**: New areas MUST have assigned codeowners
 
-## General review principles
-- **YAML Models**: All attributes, metrics, and conventions are formally defined in YAML files under `model/` directory
+## General Review Principles
+- **YAML Models**: All attributes, metrics, and conventions are formally defined
+  in YAML files under `model/` directory
   - Validate against [schema](https://github.com/open-telemetry/weaver/blob/main/schemas/semconv.schema.json)
-  - Verify clear `brief` and `note` sections with realistic examples
-  - Confirm proper RFC 2119 keywords (MUST, SHOULD, MAY, etc.)
+  - Verify all new conventions are documented with clear `brief` and `note` sections
+  - Validate that examples are realistic and helpful
+  - Confirm proper use of RFC 2119 keywords (MUST, SHOULD, MAY, etc.)
 
 - **Scope**: ensure contributions belong here:
   - **SHOULD be included:**
@@ -29,62 +39,88 @@ pull requests to ensure consistency, quality, and adherence to established stand
     - Instrumentations following external schemas not fully compatible with OpenTelemetry
     - Domain-specific conventions better maintained in their own repositories
 
-### Naming conventions
-- Use lowercase with dot-separated namespaces (e.g., `service.name`)
-- Multi-word components use snake_case (e.g., `http.response.status_code`)
-- Only widely recognized abbreviations (HTTP, CPU, AWS, etc.)
-- Proper namespace hierarchy
+### Naming Conventions
 
-## Attribute review guidelines
+- **Attributes/Metrics/Events**: Use lowercase with dot-separated namespaces
+  (e.g., `service.name`)
+- **Multi-word components**: Use snake_case (e.g., `http.response.status_code`)
+- **Abbreviations**: Only use widely recognized abbreviations (HTTP, CPU, AWS, etc.)
+- **Namespacing**: Ensure proper namespace hierarchy and avoid name collisions
+- **No reuse**: Different entities cannot share the same name within their category
 
-### Requirements
-- Clear benefit to end users with usage in spans, metrics, events, or entities
-- Follow stability progression (development → stable)
-- Reuse existing attributes when possible, check existing namespaces first
+## Attribute Guidelines
+
+### New Attribute Requirements
+
+- Must have clear benefit to end users
+- Should be used by spans/metrics/events/entities
+- Must follow stability progression (development → stable)
+- Should reuse existing attributes when possible
+- Check against existing namespaces before creating new ones
+
+### Attribute Definition Standards
+
 - Use appropriate type (string, int, double, boolean, array, enum)
-- Define enums for closed sets, avoid unbounded values (>1KB strings, >1000 elements)
+- Define enums for short, closed sets of values
+- Use template type only for dynamic names (last segment only)
+- Avoid unbounded values (>1KB strings, >1000 element arrays)
+- Avoid high-cardinality attributes in metrics
 - Mark PII/sensitive data with warnings
 
-### Types and usage
-- **Timestamps**: ISO 8601 string format
-- **Arrays**: Homogeneous; separate attributes for different concepts
-- **Complex values**: Flatten when possible
-- **Template attributes**: Dynamic names (last segment only)
+### Attribute Types and Usage
 
-## Event conventions
-- MUST have unique, low-cardinality event name
-- SHOULD have attributes for context, SHOULD NOT use body
+- **Timestamps**: Use string in ISO 8601 format
+- **Arrays**: Must be homogeneous; use separate attributes for different concepts
+- **Complex values**: Flatten into multiple attributes when possible
+- **Template attributes**: For user-defined key-value pairs (e.g., HTTP headers)
 
-## Error handling conventions
+## Event Guidelines
+
+- SHOULD have attributes for additional context
+- SHOULD NOT use body
+
+## Entity Requirements
+
+- Use `type: entity` with proper `name` field for entity groups
+- Distinguish between `identifying` and `descriptive` attribute roles
+- Identifying attributes must be minimally sufficient for unique identification and 
+  must not change during entity lifespan
+- Use proper namespacing based on discovery mechanism (e.g., `k8s.*` for Kubernetes)
+- Use `entity_associations` field to link signals with appropriate entities
+
+## Error Handling Conventions
+
+### Error Recording Standards
 - **Spans**: Set status to Error, populate `error.type`, set description when helpful
 - **Metrics**: Include `error.type` attribute for filtering and analysis
+- **Exceptions**: Record as span events or log records using SDK APIs
 - **Consistency**: Same `error.type` across spans and metrics for same operation
 
-## Common issues to flag
+## Common Issues to Flag
 
-- Creating attributes without referencing them in spans, metrics, events, or entities
+- Creating attributes without referenicng them in spans/metrics/events/entities
 - Creating new attributes without clear use case or instrumentation that will use them
 - Creating overly generic attributes without established standards
 - Duplicating existing functionality
 - Missing or inadequate documentation
+- Missing, incorrect YAML syntax or schema violations
 - Inconsistent naming patterns
+- Missing required fields or metadata
 - Performance or security concerns not addressed
 
-## Review response guidelines
-
-### Constructive feedback
+## Review Response Guidelines
 
 - Explain rationale behind suggestions
 - Reference relevant documentation sections
 - Provide specific examples of improvements
 - Suggest alternatives when rejecting proposals
 
-## Resources and references
+## Resources and References
 
-- [Contributing to OpenTelemetry Semantic Conventions](../CONTRIBUTING.md)
-- [How to define conventions](../docs/general/how-to-define-semantic-conventions.md)
-- [YAML model documentation](../model/README.md)
-- [Naming guidelines](../docs/general/naming.md)
-- [Attribute requirement levels](../docs/general/attribute-requirement-level.md)
-- [Error recording](../docs/general/recording-errors.md)
-- [Event conventions](../docs/general/events.md)
+- [How to Define Conventions](../docs/general/how-to-define-semantic-conventions.md)
+- [YAML Model Documentation](../model/README.md)
+- [Naming Guidelines](../docs/general/naming.md)
+- [Attribute Requirement Levels](../docs/general/attribute-requirement-level.md)
+- [Error Recording](../docs/general/recording-errors.md)
+- [Event Conventions](../docs/general/events.md)
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,95 @@
+# Copilot Instructions for OpenTelemetry Semantic Conventions
+
+## Overview
+These instructions guide AI assistants in reviewing OpenTelemetry Semantic Conventions pull requests to ensure consistency, quality, and adherence to established standards.
+
+**CRITICAL REVIEW CRITERIA**: New areas require special scrutiny and must meet these requirements:
+
+#### Prerequisites for New Convention Areas
+- **Domain Expertise**: Must have a group of people familiar with the domain
+- **Active Involvement**: Contributors must be involved with instrumentation efforts in that area
+- **Long-term Commitment**: Must have committed maintainers as points of contact for pull requests, issues, questions, and ongoing maintenance
+
+#### Process for New Areas
+1. **Project Management**: Follow [OpenTelemetry project management](https://github.com/open-telemetry/community/blob/main/project-management.md) guidelines
+2. **Codeowners**: New areas MUST have assigned codeowners
+
+## General Review Principles
+- **YAML Models**: All attributes, metrics, and conventions are formally defined in YAML files under `model/` directory
+  - Validate against [schema](https://github.com/open-telemetry/weaver/blob/main/schemas/semconv.schema.json)
+  - Verify clear `brief` and `note` sections with realistic examples
+  - Confirm proper RFC 2119 keywords (MUST, SHOULD, MAY, etc.)
+
+- **Scope**: ensure contributions belong here:
+  - **SHOULD be included:**
+    - Instrumentations hosted in OpenTelemetry
+    - Common attributes and conventions used across multiple instrumentations
+    - Conventions that benefit from centralized policy enforcement
+
+  - **SHOULD NOT be included:**
+    - Instrumentations following external schemas not fully compatible with OpenTelemetry
+    - Domain-specific conventions better maintained in their own repositories
+
+### Naming Conventions
+- Use lowercase with dot-separated namespaces (e.g., `service.name`)
+- Multi-word components use snake_case (e.g., `http.response.status_code`)
+- Only widely recognized abbreviations (HTTP, CPU, AWS, etc.)
+- Proper namespace hierarchy, avoid name collisions
+- No name reuse within categories
+
+## Attribute Review Guidelines
+
+### Requirements
+- Clear benefit to end users with usage in spans, metrics, events, or entities
+- Follow stability progression (development → stable)
+- Reuse existing attributes when possible, check existing namespaces first
+- Use appropriate type (string, int, double, boolean, array, enum)
+- Define enums for closed sets, avoid unbounded values (>1KB strings, >1000 elements)
+- Mark PII/sensitive data with warnings
+
+### Types and Usage
+- **Timestamps**: ISO 8601 string format
+- **Arrays**: Homogeneous; separate attributes for different concepts
+- **Complex values**: Flatten when possible
+- **Template attributes**: Dynamic names (last segment only)
+
+## Event Conventions
+- MUST have unique, low-cardinality event name
+- SHOULD have attributes for context, SHOULD NOT use body
+
+## Error Handling Conventions
+- **Spans**: Set status to Error, populate `error.type`, set description when helpful
+- **Metrics**: Include `error.type` attribute for filtering and analysis
+- **Exceptions**: Record as span events or log records using SDK APIs
+- **Consistency**: Same `error.type` across spans and metrics for same operation
+
+## Common Issues to Flag
+
+- Creating attributes without referencing them in spans, metrics, events, or entities
+- Creating new attributes without clear use case or instrumentation that will use them
+- Creating overly generic attributes without established standards
+- Duplicating existing functionality
+- Missing or inadequate documentation
+- Missing, incorrect YAML syntax or schema violations
+- Inconsistent naming patterns
+- Missing required fields or metadata
+- Performance or security concerns not addressed
+
+## Review Response Guidelines
+
+### Constructive Feedback
+
+- Explain rationale behind suggestions
+- Reference relevant documentation sections
+- Provide specific examples of improvements
+- Suggest alternatives when rejecting proposals
+
+## Resources and References
+
+- [How to Define Conventions](../docs/general/how-to-define-semantic-conventions.md)
+- [YAML Model Documentation](../model/README.md)
+- [Naming Guidelines](../docs/general/naming.md)
+- [Attribute Requirement Levels](../docs/general/attribute-requirement-level.md)
+- [Error Recording](../docs/general/recording-errors.md)
+- [Event Conventions](../docs/general/events.md)
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Copilot Instructions for OpenTelemetry Semantic Conventions
+# Copilot instructions for OpenTelemetry Semantic Conventions
 
 ## Overview
 These instructions guide AI assistants in reviewing OpenTelemetry Semantic Conventions
@@ -6,16 +6,14 @@ pull requests to ensure consistency, quality, and adherence to established stand
 
 **CRITICAL REVIEW CRITERIA**: New areas require special scrutiny and must meet these requirements:
 
-#### Prerequisites for New Convention Areas
+### Prerequisites for new areas
 - **Domain Expertise**: Must have a group of people familiar with the domain
 - **Active Involvement**: Contributors must be involved with instrumentation efforts in that area
 - **Long-term Commitment**: Must have committed maintainers as points of contact for pull requests, issues, questions, and ongoing maintenance
-
-#### Process for New Areas
 1. **Project Management**: Follow [OpenTelemetry project management](https://github.com/open-telemetry/community/blob/main/project-management.md) guidelines
 2. **Codeowners**: New areas MUST have assigned codeowners
 
-## General Review Principles
+## General review principles
 - **YAML Models**: All attributes, metrics, and conventions are formally defined in YAML files under `model/` directory
   - Validate against [schema](https://github.com/open-telemetry/weaver/blob/main/schemas/semconv.schema.json)
   - Verify clear `brief` and `note` sections with realistic examples
@@ -31,13 +29,13 @@ pull requests to ensure consistency, quality, and adherence to established stand
     - Instrumentations following external schemas not fully compatible with OpenTelemetry
     - Domain-specific conventions better maintained in their own repositories
 
-### Naming Conventions
+### Naming conventions
 - Use lowercase with dot-separated namespaces (e.g., `service.name`)
 - Multi-word components use snake_case (e.g., `http.response.status_code`)
 - Only widely recognized abbreviations (HTTP, CPU, AWS, etc.)
 - Proper namespace hierarchy
 
-## Attribute Review Guidelines
+## Attribute review guidelines
 
 ### Requirements
 - Clear benefit to end users with usage in spans, metrics, events, or entities
@@ -47,22 +45,22 @@ pull requests to ensure consistency, quality, and adherence to established stand
 - Define enums for closed sets, avoid unbounded values (>1KB strings, >1000 elements)
 - Mark PII/sensitive data with warnings
 
-### Types and Usage
+### Types and usage
 - **Timestamps**: ISO 8601 string format
 - **Arrays**: Homogeneous; separate attributes for different concepts
 - **Complex values**: Flatten when possible
 - **Template attributes**: Dynamic names (last segment only)
 
-## Event Conventions
+## Event conventions
 - MUST have unique, low-cardinality event name
 - SHOULD have attributes for context, SHOULD NOT use body
 
-## Error Handling Conventions
+## Error handling conventions
 - **Spans**: Set status to Error, populate `error.type`, set description when helpful
 - **Metrics**: Include `error.type` attribute for filtering and analysis
 - **Consistency**: Same `error.type` across spans and metrics for same operation
 
-## Common Issues to Flag
+## Common issues to flag
 
 - Creating attributes without referencing them in spans, metrics, events, or entities
 - Creating new attributes without clear use case or instrumentation that will use them
@@ -72,22 +70,21 @@ pull requests to ensure consistency, quality, and adherence to established stand
 - Inconsistent naming patterns
 - Performance or security concerns not addressed
 
-## Review Response Guidelines
+## Review response guidelines
 
-### Constructive Feedback
+### Constructive feedback
 
 - Explain rationale behind suggestions
 - Reference relevant documentation sections
 - Provide specific examples of improvements
 - Suggest alternatives when rejecting proposals
 
-## Resources and References
+## Resources and references
 
 - [Contributing to OpenTelemetry Semantic Conventions](../CONTRIBUTING.md)
-- [How to Define Conventions](../docs/general/how-to-define-semantic-conventions.md)
-- [YAML Model Documentation](../model/README.md)
-- [Naming Guidelines](../docs/general/naming.md)
-- [Attribute Requirement Levels](../docs/general/attribute-requirement-level.md)
-- [Error Recording](../docs/general/recording-errors.md)
-- [Event Conventions](../docs/general/events.md)
-
+- [How to define conventions](../docs/general/how-to-define-semantic-conventions.md)
+- [YAML model documentation](../model/README.md)
+- [Naming guidelines](../docs/general/naming.md)
+- [Attribute requirement levels](../docs/general/attribute-requirement-level.md)
+- [Error recording](../docs/general/recording-errors.md)
+- [Event conventions](../docs/general/events.md)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,8 @@
 # Copilot Instructions for OpenTelemetry Semantic Conventions
 
 ## Overview
-These instructions guide AI assistants in reviewing OpenTelemetry Semantic Conventions pull requests to ensure consistency, quality, and adherence to established standards.
+These instructions guide AI assistants in reviewing OpenTelemetry Semantic Conventions
+pull requests to ensure consistency, quality, and adherence to established standards.
 
 **CRITICAL REVIEW CRITERIA**: New areas require special scrutiny and must meet these requirements:
 
@@ -34,8 +35,7 @@ These instructions guide AI assistants in reviewing OpenTelemetry Semantic Conve
 - Use lowercase with dot-separated namespaces (e.g., `service.name`)
 - Multi-word components use snake_case (e.g., `http.response.status_code`)
 - Only widely recognized abbreviations (HTTP, CPU, AWS, etc.)
-- Proper namespace hierarchy, avoid name collisions
-- No name reuse within categories
+- Proper namespace hierarchy
 
 ## Attribute Review Guidelines
 
@@ -60,7 +60,6 @@ These instructions guide AI assistants in reviewing OpenTelemetry Semantic Conve
 ## Error Handling Conventions
 - **Spans**: Set status to Error, populate `error.type`, set description when helpful
 - **Metrics**: Include `error.type` attribute for filtering and analysis
-- **Exceptions**: Record as span events or log records using SDK APIs
 - **Consistency**: Same `error.type` across spans and metrics for same operation
 
 ## Common Issues to Flag
@@ -70,9 +69,7 @@ These instructions guide AI assistants in reviewing OpenTelemetry Semantic Conve
 - Creating overly generic attributes without established standards
 - Duplicating existing functionality
 - Missing or inadequate documentation
-- Missing, incorrect YAML syntax or schema violations
 - Inconsistent naming patterns
-- Missing required fields or metadata
 - Performance or security concerns not addressed
 
 ## Review Response Guidelines

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -83,6 +83,7 @@ pull requests to ensure consistency, quality, and adherence to established stand
 
 ## Resources and References
 
+- [Contributing to OpenTelemetry Semantic Conventions](../CONTRIBUTING.md)
 - [How to Define Conventions](../docs/general/how-to-define-semantic-conventions.md)
 - [YAML Model Documentation](../model/README.md)
 - [Naming Guidelines](../docs/general/naming.md)


### PR DESCRIPTION
Adds [instructions](https://docs.github.com/en/copilot/how-tos/custom-instructions/adding-repository-custom-instructions-for-github-copilot) for review/coding agent based on [contributing.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) and [general guidance](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/general).

Tried on a few PRs, it seems to produce some reasonable advice, but definitely can be tuned further.