### PR TITLE
[chore] Fix identifying attribute rendering #2458

### DIFF
--- a/templates/registry/markdown/entity_namespace.md.j2
+++ b/templates/registry/markdown/entity_namespace.md.j2
@@ -20,7 +20,7 @@
 
 **Description:** {{ e.brief | trim }}
 
-{%- if desc_attrs | length > 0 %}
+{%- if id_attrs | length > 0 %}
 
 **Identifying Attributes:**
 


### PR DESCRIPTION
Fixes #2458 

## Changes

Corrects the logic in the template

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
