### PR TITLE
Add the 'deprecated:' attribute to the recently deprecated 'z_os' enum value

### DIFF
--- a/.chloggen/trentm-z_os-enum-value-deprecated-attr.yaml
+++ b/.chloggen/trentm-z_os-enum-value-deprecated-attr.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: os
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds the 'deprecated:' tag/attribute to the `z_os` enum value of `os.type`. This value was recently deprecated in v1.35.0.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2479]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/os.md
+++ b/docs/registry/attributes/os.md
@@ -31,5 +31,4 @@ The operating system (OS) on which the process represented by this resource is r
 | `openbsd` | OpenBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `solaris` | SunOS, Oracle Solaris | ![Development](https://img.shields.io/badge/-development-blue) |
 | `windows` | Microsoft Windows | ![Development](https://img.shields.io/badge/-development-blue) |
-| `z_os` | Deprecated. Use `zos` instead. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `zos` | IBM z/OS | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/registry/entities/os.md
+++ b/docs/registry/entities/os.md
@@ -50,7 +50,6 @@
 | `openbsd` | OpenBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `solaris` | SunOS, Oracle Solaris | ![Development](https://img.shields.io/badge/-development-blue) |
 | `windows` | Microsoft Windows | ![Development](https://img.shields.io/badge/-development-blue) |
-| `z_os` | Deprecated. Use `zos` instead. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `zos` | IBM z/OS | ![Development](https://img.shields.io/badge/-development-blue) |
 
 

--- a/docs/resource/os.md
+++ b/docs/resource/os.md
@@ -48,7 +48,6 @@ In case of virtualized environments, this is the operating system as it is obser
 | `openbsd` | OpenBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `solaris` | SunOS, Oracle Solaris | ![Development](https://img.shields.io/badge/-development-blue) |
 | `windows` | Microsoft Windows | ![Development](https://img.shields.io/badge/-development-blue) |
-| `z_os` | Deprecated. Use `zos` instead. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `zos` | IBM z/OS | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->

--- a/docs/resource/zos.md
+++ b/docs/resource/zos.md
@@ -97,7 +97,6 @@ The following table describes how to populate the operating system attributes on
 | `openbsd` | OpenBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `solaris` | SunOS, Oracle Solaris | ![Development](https://img.shields.io/badge/-development-blue) |
 | `windows` | Microsoft Windows | ![Development](https://img.shields.io/badge/-development-blue) |
-| `z_os` | Deprecated. Use `zos` instead. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `zos` | IBM z/OS | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->

--- a/model/os/registry.yaml
+++ b/model/os/registry.yaml
@@ -54,6 +54,7 @@ groups:
             - id: z_os
               value: 'z_os'
               brief: "Deprecated. Use `zos` instead."
+              deprecated: "Replaced by `zos`."
               stability: development
             - id: zos
               value: 'zos'


### PR DESCRIPTION
This should help with code gen that can use the 'deprecated:' attribute.
'z_os' was recently deprecated in #1687.

Refs: #1687


## Questions

- I'm not confident this is the correct thing. From following examples of other enum values that were deprecated, this *looks* like the correct thing to do.
- Is a changelog entry required for this? There was a changelog entry for v1.35.0 that included mention of the value being deprecated.