### PR TITLE
[chore] Remove duplicate `check` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,6 @@ WEAVER_CONTAINER=$(WEAVER_CONTAINER_REPOSITORY)/$(VERSIONED_WEAVER_CONTAINER_NO_
 OPA_CONTAINER=$(OPA_CONTAINER_REPOSITORY)/$(VERSIONED_OPA_CONTAINER_NO_REPO)
 LYCHEE_CONTAINER=$(LYCHEE_CONTAINER_REPOSITORY)/$(VERSIONED_LYCHEE_CONTAINER_NO_REPO)
 
-CHECK_TARGETS=install-tools markdownlint misspell table-check \
-			schema-check check-file-and-folder-names-in-docs
-
 # Determine if "docker" is actually podman
 DOCKER_VERSION_OUTPUT := $(shell docker --version 2>&1)
 DOCKER_IS_PODMAN := $(shell echo $(DOCKER_VERSION_OUTPUT) | grep -c podman)
@@ -88,10 +85,7 @@ endif
 
 # TODO: add `yamllint` step to `all` after making sure it works on Mac.
 .PHONY: all
-all: $(CHECK_TARGETS) markdown-link-check
-
-.PHONY: check
-check: $(CHECK_TARGETS)
+all: install-tools markdownlint misspell table-check schema-check check-file-and-folder-names-in-docs markdown-link-check
 
 .PHONY: check-file-and-folder-names-in-docs
 check-file-and-folder-names-in-docs:


### PR DESCRIPTION


Fixes #2481


## Changes

This PR removes a `check` target that I added without realizing that there already was a target called `check`. The original intention was to add a target that could be run locally without `markdown-link-check` as that used to take a considerably long time. Since that is a fair bit quicker now, there isn't much reason for it anymore. This PR essentially undoes what I did when I added the check.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [N/A] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [N/A] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
