### PR TITLE
[chore] Fix 'make check' on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ misspell-correction:	$(MISSPELL)
 	$(MISSPELL) -w $(ALL_DOCS)
 
 .PHONY: normalized-link-check
-# NOTE: Seach "model/*/**" rather than "model" to skip `model/README.md`, which
+# NOTE: Search "model/*/**" rather than "model" to skip `model/README.md`, which
 # contains valid occurrences of `../docs/`.
 normalized-link-check:
 	@if grep -R '\.\./docs/' docs model/*/**; then \

--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,10 @@ misspell-correction:	$(MISSPELL)
 	$(MISSPELL) -w $(ALL_DOCS)
 
 .PHONY: normalized-link-check
-# NOTE: we check `model/[a-z]*` to avoid `model/README.md`, which contains
-# valid occurrences of `../docs/`.
+# NOTE: Seach "model/*/**" rather than "model" to skip `model/README.md`, which
+# contains valid occurrences of `../docs/`.
 normalized-link-check:
-	@if grep -R '\.\./docs/' docs model/[a-z]*; then \
+	@if grep -R '\.\./docs/' docs model/*/**; then \
 		echo "\nERROR: Found occurrences of '../docs/'; see above."; \
 		echo "       Remove the '../docs/' from doc page links referencing doc pages."; \
 		exit 1; \


### PR DESCRIPTION
This fixes the breakage of `make normalized-link-check` on macOS by
carefully finding an invocation of `grep ...` that searches docs/ and
model/ but skips "model/README.md" and works with `sh` and `grep` on
macOS and linux.

Fixes: https://github.com/open-telemetry/semantic-conventions/issues/2480
