### PR TITLE
[chore] Fix link breaking 'make markdown-link-check'

### DIFF
--- a/docs/general/metrics.md
+++ b/docs/general/metrics.md
@@ -95,7 +95,7 @@ using the OpenMetrics exposition format, use the
 **Status**: [Stable][DocumentStatus]
 
 Units should follow the
-[Unified Code for Units of Measure](https://unitsofmeasure.org/ucum.html).
+[Unified Code for Units of Measure](https://ucum.org/ucum).
 
 - Instruments for **utilization** metrics (that measure the fraction out of a
 total) are dimensionless and SHOULD use the default unit `1` (the unity).


### PR DESCRIPTION
https://unitsofmeasure.org/ucum.html has moved to https://ucum.org/ucum
The former site no longer responds. The latest from the waybackmachine
shows that it matches the new ucum.org content:
https://web.archive.org/web/20250609201256/https://unitsofmeasure.org/ucum
