### PR TITLE
Add missing brief on `ios.state` attribute and add policies to require briefs

### DIFF
--- a/docs/registry/attributes/android.md
+++ b/docs/registry/attributes/android.md
@@ -33,7 +33,7 @@ This document defines attributes that represents an occurrence of a lifecycle tr
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
-| <a id="android-state" href="#android-state">`android.state`</a> | string | Deprecated. Use `android.app.state` body field instead. | `created`; `background`; `foreground` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Use `android.app.state` body field instead. |
+| <a id="android-state" href="#android-state">`android.state`</a> | string | Deprecated. Use `android.app.state` attribute instead. | `created`; `background`; `foreground` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Use `android.app.state` attribute instead. |
 
 ---
 

--- a/docs/registry/attributes/ios.md
+++ b/docs/registry/attributes/ios.md
@@ -34,7 +34,7 @@ The iOS platform on which the iOS application is running.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
-| <a id="ios-state" href="#ios-state">`ios.state`</a> | string |  [2] | `active`; `inactive`; `background` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by the `ios.app.state` event body field. |
+| <a id="ios-state" href="#ios-state">`ios.state`</a> | string | Deprecated. Use the `ios.app.state` attribute. [2] | `active`; `inactive`; `background` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by the `ios.app.state` attribute. |
 
 **[2] `ios.state`:** The iOS lifecycle states are defined in the [UIApplicationDelegate documentation](https://developer.apple.com/documentation/uikit/uiapplicationdelegate), and from which the `OS terminology` column values are derived.
 

--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -352,7 +352,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.memory.utilization` | Gauge | `1` |  | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.memory.utilization` | Gauge | `1` | TODO. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -427,7 +427,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.paging.utilization` | Gauge | `1` |  | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.paging.utilization` | Gauge | `1` | TODO. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -461,7 +461,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.paging.faults` | Counter | `{fault}` |  | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.paging.faults` | Counter | `{fault}` | TODO. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -494,7 +494,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.paging.operations` | Counter | `{operation}` |  | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.paging.operations` | Counter | `{operation}` | TODO. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -541,7 +541,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.disk.io` | Counter | `By` |  | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.disk.io` | Counter | `By` | TODO. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -575,7 +575,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.disk.operations` | Counter | `{operation}` |  | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.disk.operations` | Counter | `{operation}` | TODO. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -679,7 +679,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.disk.merged` | Counter | `{operation}` |  | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.disk.merged` | Counter | `{operation}` | TODO. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -795,7 +795,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.filesystem.utilization` | Gauge | `1` |  | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.filesystem.utilization` | Gauge | `1` | TODO. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -930,7 +930,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.network.packets` | Counter | `{packet}` |  | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.network.packets` | Counter | `{packet}` | TODO. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -1004,7 +1004,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.network.io` | Counter | `By` |  | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.network.io` | Counter | `By` | TODO. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -1038,7 +1038,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.network.connection.count` | UpDownCounter | `{connection}` |  | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.network.connection.count` | UpDownCounter | `{connection}` | TODO. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|

--- a/model/android/deprecated/registry-deprecated.yaml
+++ b/model/android/deprecated/registry-deprecated.yaml
@@ -7,10 +7,10 @@ groups:
     attributes:
       - id: android.state
         stability: development
-        brief: Deprecated. Use `android.app.state` body field instead.
+        brief: Deprecated. Use `android.app.state` attribute instead.
         deprecated:
           reason: uncategorized
-          note: Use `android.app.state` body field instead.
+          note: Use `android.app.state` attribute instead.
         type:
           members:
             - id: created

--- a/model/ios/deprecated/registry-deprecated.yaml
+++ b/model/ios/deprecated/registry-deprecated.yaml
@@ -7,10 +7,12 @@ groups:
     attributes:
       - id: ios.state
         stability: development
+        brief: >
+          Deprecated. Use the `ios.app.state` attribute.
         deprecated:
           reason: uncategorized
           note:
-            Replaced by the `ios.app.state` event body field.
+            Replaced by the `ios.app.state` attribute.
         note: >
           The iOS lifecycle states are defined in the [UIApplicationDelegate documentation](https://developer.apple.com/documentation/uikit/uiapplicationdelegate),
           and from which the `OS terminology` column values are derived.

--- a/model/system/metrics.yaml
+++ b/model/system/metrics.yaml
@@ -149,7 +149,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: ""
+    brief: TODO.
     instrument: gauge
     unit: "1"
     attributes:
@@ -183,7 +183,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: ""
+    brief: TODO.
     instrument: gauge
     unit: "1"
     attributes:
@@ -201,7 +201,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: ""
+    brief: TODO.
     instrument: counter
     unit: "{fault}"
     attributes:
@@ -216,7 +216,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: int
-    brief: ""
+    brief: TODO.
     instrument: counter
     unit: "{operation}"
     attributes:
@@ -233,7 +233,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: ""
+    brief: TODO.
     instrument: counter
     unit: "By"
     attributes:
@@ -249,7 +249,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: ""
+    brief: TODO.
     instrument: counter
     unit: "{operation}"
     attributes:
@@ -308,7 +308,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: ""
+    brief: TODO.
     instrument: counter
     unit: "{operation}"
     attributes:
@@ -364,7 +364,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: ""
+    brief: TODO.
     instrument: gauge
     unit: "1"
     attributes:
@@ -428,7 +428,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: ""
+    brief: TODO.
     instrument: counter
     unit: "{packet}"
     attributes:
@@ -466,7 +466,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: ""
+    brief: TODO.
     instrument: counter
     unit: "By"
     attributes:
@@ -482,7 +482,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: ""
+    brief: TODO.
     instrument: updowncounter
     unit: "{connection}"
     attributes:

--- a/policies_test/metric_brief_format_test.rego
+++ b/policies_test/metric_brief_format_test.rego
@@ -26,25 +26,6 @@ test_metric_brief_without_period if {
     ]}
 }
 
-test_metric_without_brief if {
-    # Should pass: metric without brief is ignored (handled by other policies)
-    count(before_resolution.deny) == 0 with input as {"groups": [
-        {"id": "metric.test", "type": "metric", "stability": "development"}
-    ]}
-}
-
-test_metric_with_empty_brief if {
-    # Should pass: metric with empty brief is allowed
-    count(before_resolution.deny) == 0 with input as {"groups": [
-        {"id": "metric.test", "type": "metric", "brief": "", "stability": "development"}
-    ]}
-
-    # Should pass: metric with whitespace-only brief is treated as empty and allowed
-    count(before_resolution.deny) == 0 with input as {"groups": [
-        {"id": "metric.test2", "type": "metric", "brief": "   ", "stability": "development"}
-    ]}
-}
-
 test_non_metric_groups_ignored if {
     # Should pass: non-metric groups are ignored
     count(before_resolution.deny) == 0 with input as {"groups": [

--- a/policies_test/registry_test.rego
+++ b/policies_test/registry_test.rego
@@ -11,57 +11,57 @@ test_registry_attribute_groups if {
 
 test_attribute_ids if {
 	# This requires a prefix for use with opa, but weaver will fill in.
-	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "not_registry", "prefix": "", "attributes": [{"id": "foo.bar", "stability": "rc"}]}]}
+	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "not_registry", "prefix": "", "attributes": [{"id": "foo.bar", "stability": "rc", "brief": "brief"}]}]}
 	count(before_resolution.deny) == 0 with input as {"groups": [
-		{"id": "registry.test", "prefix": "", "attributes": [{"id": "foo.bar", "stability": "rc"}]},
-		{"id": "not_registry", "prefix": "", "attributes": [{"ref": "foo.bar", "stability": "rc"}]},
+		{"id": "registry.test", "prefix": "", "attributes": [{"id": "foo.bar", "stability": "rc", "brief": "brief"}]},
+		{"id": "not_registry", "prefix": "", "attributes": [{"ref": "foo.bar", "stability": "rc", "brief": "brief"}]},
 	]}
 }
 
 test_attribute_without_stability if {
-	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.text", "attributes": [{"id": "foo.bar"}]}]}
+	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.text", "attributes": [{"id": "foo.bar", "brief": "brief"}]}]}
 	count(before_resolution.deny) == 0 with input as {"groups": [
-		{"id": "registry.test", "attributes": [{"id": "foo.bar", "stability": "alpha"}]},
+		{"id": "registry.test", "attributes": [{"id": "foo.bar", "stability": "alpha", "brief": "brief"}]},
 	]}
 }
 
 test_span_without_stability if {
 	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "span.group", "type": "span"}]}
 	count(before_resolution.deny) == 0 with input as {"groups": [
-		{"id": "span.group", "type": "span", "stability": "alpha"}]
+		{"id": "span.group", "type": "span", "stability": "alpha", "brief": "brief"},]
     }
 }
 
 test_event_without_stability if {
 	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "event.foo", "type": "event", "name": "foo"}]}
 	count(before_resolution.deny) == 0 with input as {"groups": [
-		{"id": "event.foo", "name": "foo", "type": "event", "stability": "alpha"}]
+		{"id": "event.foo", "name": "foo", "type": "event", "stability": "alpha", "brief": "brief"}]
     }
 }
 
 test_metric_without_stability if {
 	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "metric.foo", "type": "metric", "name": "foo"}]}
 	count(before_resolution.deny) == 0 with input as {"groups": [
-		{"id": "metric.foo", "name": "foo", "type": "metric", "stability": "development"}]
+		{"id": "metric.foo", "name": "foo", "type": "metric", "stability": "development", "brief": "brief."}]
     }
 }
 
 test_resource_without_stability if {
 	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "resource.foo", "type": "resource", "name": "foo"}]}
 	count(before_resolution.deny) == 0 with input as {"groups": [
-		{"id": "resource.foo", "name": "foo", "type": "resource", "stability": "stable"}]
+		{"id": "resource.foo", "name": "foo", "type": "resource", "stability": "stable", "brief": "brief"}]
     }
 }
 
 test_attribute_refs if {
-	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.foo", "attributes": [{"ref": "foo"}]}]}
-	count(before_resolution.deny) == 0 with input as {"groups": [{"id": "not_registry", "attributes": [{"ref": "foo"}]}]}
+	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.foo", "attributes": [{"ref": "brief"}]}]}
+	count(before_resolution.deny) == 0 with input as {"groups": [{"id": "not_registry", "attributes": [{"ref": "brief"}]}]}
 }
 
 test_attribute_requirement_levels if {
-	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.foo", "attributes": [{"id": "foo", "requirement_level": "required", "stability": "rc"}]}]}
-	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.foo", "attributes": [{"id": "foo", "requirement_level": {"recommended": "if available"}, "stability": "rc"}]}]}
-	count(before_resolution.deny) == 0 with input as {"groups": [{"id": "not_registry", "attributes": [{"ref": "foo", "requirement_level": "required"}]}]}
+	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.foo", "attributes": [{"id": "foo", "requirement_level": "required", "stability": "rc", "brief": "brief", "brief": "brief"}]}]}
+	count(before_resolution.deny) > 0 with input as {"groups": [{"id": "registry.foo", "attributes": [{"id": "foo", "requirement_level": {"recommended": "if available"}, "stability": "rc", "brief": "brief"}]}]}
+	count(before_resolution.deny) == 0 with input as {"groups": [{"id": "not_registry", "attributes": [{"ref": "foo", "requirement_level": "required", "brief": "brief"}]}]}
 }
 
 test_fails_on_member_id_collision if {
@@ -69,7 +69,7 @@ test_fails_on_member_id_collision if {
         {"id": "registry.test", "prefix": "", "attributes": [{"id": "foo.bar.baz", "type": {"members": [
             {"id": "member", "value": "value1", "brief": "brief", "stability": "stable"},
             {"id": "member", "value": "value2", "brief": "brief", "stability": "stable"},
-        ]}, "stability": "stable"}]},
+        ]}, "stability": "stable", "brief": "brief"}]},
     ]}
     count(before_resolution.deny) == 2 with input as collision
 }
@@ -79,7 +79,7 @@ test_fails_on_member_const_name_collision if {
         {"id": "registry.test", "prefix": "", "attributes": [{"id": "foo.bar.baz", "type": {"members": [
             {"id": "member_id", "value": "member_id", "brief": "brief", "stability": "stable"},
             {"id": "member.id", "value": "member.id", "brief": "brief", "stability": "stable"},
-        ]}, "stability": "stable"}]},
+        ]}, "stability": "stable", "brief": "brief"}]},
     ]}
     count(before_resolution.deny) == 2 with input as collision
 }
@@ -89,7 +89,7 @@ test_fails_on_member_value_collision if {
         {"id": "registry.test", "prefix": "", "attributes": [{"id": "foo.bar.baz", "type": {"members": [
             {"id": "member1", "value": "member", "brief": "brief", "stability": "stable"},
             {"id": "member2", "value": "member", "brief": "brief", "stability": "stable"},
-        ]}, "stability": "stable"}]},
+        ]}, "stability": "stable", "brief": "brief"}]},
     ]}
     count(before_resolution.deny) == 2 with input as collision
 }
@@ -99,7 +99,7 @@ test_passes_on_member_value_collision_with_deprecated if {
         {"id": "registry.test", "prefix": "", "attributes": [{"id": "foo.bar.baz", "type": {"members": [
             {"id": "member1", "value": "member", "brief": "brief", "stability": "stable", "deprecated": "renamed to member2"},
             {"id": "member2", "value": "member", "brief": "brief", "stability": "stable"},
-        ]}, "stability": "stable"}]},
+        ]}, "stability": "stable", "brief": "brief"}]},
     ]}
     count(before_resolution.deny) == 0 with input as collision
 }

--- a/policies_test/yaml_schema_test.rego
+++ b/policies_test/yaml_schema_test.rego
@@ -19,6 +19,7 @@ test_fails_on_invalid_attribute_member_id if {
                             "id": name,
                             "value": "test",
                             "stability": "stable",
+                            "brief": "brief"
                         }]
                     }}]}]}
     }
@@ -38,7 +39,7 @@ test_fails_on_invalid_metric_id if {
         "metric.foo.bar.deprecated",
     ]
     every id in invalid_ids {
-        count(deny) >= 1 with input as {"groups": [{"id": id, "type": "metric", "metric_name": "foo.bar"}]}
+        count(deny) >= 1 with input as {"groups": [{"id": id, "type": "metric", "metric_name": "foo.bar", "brief": "brief"}]}
     }
 }
 
@@ -56,7 +57,7 @@ test_fails_on_invalid_event_id if {
         "evnt.foo.bar.deprecated",
     ]
     every id in invalid_ids {
-        count(deny) >= 1 with input as {"groups": [{"id": id, "type": "event", "name": "foo.bar"}]}
+        count(deny) >= 1 with input as {"groups": [{"id": id, "type": "event", "name": "foo.bar", "brief": "brief"}]}
     }
 }
 
@@ -65,6 +66,7 @@ test_fails_on_referenced_event_name_on_event if {
                 "type": "event",
                 "name": "foo",
                 "stability": "rc",
+                "brief": "brief",
                 "attributes": [{"ref": "event.name"}]}]
     count(deny) == 1 with input as {"groups": event}
 }
@@ -93,9 +95,11 @@ test_passes_on_valid_attribute_member_id if {
                         "members": [{
                             "id": name,
                             "value": "test",
-                            "stability": "stable",
+                            "stability": "stable"
                         }]
-                    }}]}]}
+                    },
+                    "brief": "brief"
+                }]}]}
     }
 }
 
@@ -110,7 +114,7 @@ test_fails_on_invalid_span_id if {
         "span.foo.bar.client.deprecated",
     ]
     every id in invalid_ids {
-        count(deny) >= 1 with input as {"groups": [{"id": id, "type": "span", "span_kind": "client"}]}
+        count(deny) >= 1 with input as {"groups": [{"id": id, "type": "span", "span_kind": "client", "brief": "brief"}]}
     }
 }
 
@@ -121,27 +125,56 @@ test_fails_on_invalid_resource_id if {
         "resource.foo.bar.deprecated",
     ]
     every id in invalid_ids {
-        count(deny) >= 1 with input as {"groups": [{"id": id, "type": "resource", "name": "foo.bar"}]}
+        count(deny) >= 1 with input as {"groups": [{"id": id, "type": "resource", "name": "foo.bar", "brief": "brief"}]}
     }
 }
 
+test_fails_on_attribute_without_brief if {
+    briefs := [
+        null,
+        ""
+    ]
+
+    every brief in briefs {
+        count(deny) >= 1 with input as {"groups": [{"id": "yaml_schema.test", "attributes": [{"id": "foo.bar", "stability": "rc", "brief": brief}]}]}
+    }
+
+    count(deny) >= 1 with input as {"groups": [{"id": "yaml_schema.test", "attributes": [{"id": "foo.bar", "stability": "rc"}]}]}
+    count(deny) == 0 with input as {"groups": [{"id": "yaml_schema.test", "attributes": [{"id": "foo.bar", "stability": "rc", "brief": "brief:"}]}]}
+}
+
+test_fails_on_group_without_brief if {
+    briefs := [
+        null,
+        ""
+    ]
+
+    every brief in briefs {
+        count(deny) >= 1 with input as {"groups": [{"id": "event.foo.bar", "brief": brief, "type": "event", "stability": "rc", "name": "foo.bar"}]}
+    }
+
+    count(deny) >= 1 with input as {"groups": [{"id": "event.foo.bar", "type": "event", "name": "foo.bar", "stability": "rc"}]}
+    count(deny) == 0 with input as {"groups": [{"id": "event.foo.bar", "type": "event", "name": "foo.bar", "stability": "rc", "brief": "brief"}]}
+}
+
+
 create_attribute_group(attr) = json if {
-    json := [{"id": "yaml_schema.test", "attributes": [{"id": attr, "stability": "rc"}]}]
+    json := [{"id": "yaml_schema.test", "attributes": [{"id": attr, "stability": "rc", "brief": "brief"}]}]
 }
 
 create_metric(name) = json if {
     id := sprintf("metric.%s", [name])
-    json := [{"id": id, "type": "metric", "metric_name": name, "stability": "rc"}]
+    json := [{"id": id, "type": "metric", "metric_name": name, "stability": "rc", "brief": "brief."}]
 }
 
 create_event(name) = json if {
     id := sprintf("event.%s", [name])
-    json := [{"id": id, "type": "event", "name": name, "stability": "rc"}]
+    json := [{"id": id, "type": "event", "name": name, "stability": "rc", "brief": "brief"}]
 }
 
 create_resource(name) = json if {
     id := sprintf("resource.%s", [name])
-    json := [{"id": id, "type": "resource", "name": name, "stability": "rc"}]
+    json := [{"id": id, "type": "resource", "name": name, "stability": "rc", "brief": "brief"}]
 }
 
 invalid_names := [


### PR DESCRIPTION
We've accidentally removed brief on `ios.state` which leads to codegen issues like https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2896.

I believe we should guarantee brief on attributes to be either set explicitly or auto-generated in some edge cases (#1419) so that codegen should not need to fallback. 

So adding a policy to require briefs on attributes and groups.
We have  A LOT of enum members without briefs, so not adding a check at least for the time being.