### PR TITLE
Fixing Syntax Issues in Cloud SemConv

### DIFF
--- a/model/cloud/registry.yaml
+++ b/model/cloud/registry.yaml
@@ -179,7 +179,9 @@ groups:
               value: 'azure_vm'
               brief: Azure Virtual Machines
               stability: development
-              deprecated: "Replaced by `azure.vm`"
+              deprecated: 
+                reason: renamed
+                renamed_to: "`azure.vm`"
               annotations:
                 code_generation:
                   exclude: true
@@ -187,7 +189,9 @@ groups:
               value: 'azure_container_apps'
               brief: Azure Container Apps
               stability: development
-              deprecated: "Replaced by `azure.container_apps`"
+              deprecated: 
+                reason: renamed
+                renamed_to: "`azure.container_apps`"
               annotations:
                 code_generation:
                   exclude: true
@@ -195,7 +199,9 @@ groups:
               value: 'azure_container_instances'
               brief: Azure Container Instances
               stability: development
-              deprecated: "Replaced by `azure.container_instances`"
+              deprecated: 
+                reason: renamed
+                renamed_to: "`azure.container_instances`"
               annotations:
                 code_generation:
                   exclude: true
@@ -203,7 +209,9 @@ groups:
               value: 'azure_aks'
               brief: Azure Kubernetes Service
               stability: development
-              deprecated: "Replaced by `azure.aks`"
+              deprecated: 
+                reason: renamed
+                renamed_to: "`azure.aks`"
               annotations:
                 code_generation:
                   exclude: true
@@ -211,7 +219,9 @@ groups:
               value: 'azure_functions'
               brief: Azure Functions
               stability: development
-              deprecated: "Replaced by `azure.functions`"
+              deprecated: 
+                reason: renamed
+                renamed_to: "`azure.functions`"
               annotations:
                 code_generation:
                   exclude: true
@@ -219,7 +229,9 @@ groups:
               value: 'azure_app_service'
               brief: Azure App Service
               stability: development
-              deprecated: "Replaced by `azure.app_service`"
+              deprecated: 
+                reason: renamed
+                renamed_to: "`azure.app_service`"
               annotations:
                 code_generation:
                   exclude: true
@@ -227,7 +239,9 @@ groups:
               value: 'azure_openshift'
               brief: Azure Red Hat OpenShift
               stability: development
-              deprecated: "Replaced by `azure.openshift`"
+              deprecated: 
+                reason: renamed
+                renamed_to: "`azure.openshift`"
               annotations:
                 code_generation:
                   exclude: true

--- a/model/cloud/registry.yaml
+++ b/model/cloud/registry.yaml
@@ -181,7 +181,7 @@ groups:
               stability: development
               deprecated: 
                 reason: renamed
-                renamed_to: "`azure.vm`"
+                renamed_to: "azure.vm"
               annotations:
                 code_generation:
                   exclude: true
@@ -191,7 +191,7 @@ groups:
               stability: development
               deprecated: 
                 reason: renamed
-                renamed_to: "`azure.container_apps`"
+                renamed_to: "azure.container_apps"
               annotations:
                 code_generation:
                   exclude: true
@@ -201,7 +201,7 @@ groups:
               stability: development
               deprecated: 
                 reason: renamed
-                renamed_to: "`azure.container_instances`"
+                renamed_to: "azure.container_instances"
               annotations:
                 code_generation:
                   exclude: true
@@ -211,7 +211,7 @@ groups:
               stability: development
               deprecated: 
                 reason: renamed
-                renamed_to: "`azure.aks`"
+                renamed_to: "azure.aks"
               annotations:
                 code_generation:
                   exclude: true
@@ -221,7 +221,7 @@ groups:
               stability: development
               deprecated: 
                 reason: renamed
-                renamed_to: "`azure.functions`"
+                renamed_to: "azure.functions"
               annotations:
                 code_generation:
                   exclude: true
@@ -231,7 +231,7 @@ groups:
               stability: development
               deprecated: 
                 reason: renamed
-                renamed_to: "`azure.app_service`"
+                renamed_to: "azure.app_service"
               annotations:
                 code_generation:
                   exclude: true
@@ -241,7 +241,7 @@ groups:
               stability: development
               deprecated: 
                 reason: renamed
-                renamed_to: "`azure.openshift`"
+                renamed_to: "azure.openshift"
               annotations:
                 code_generation:
                   exclude: true

--- a/model/database/deprecated/registry-deprecated.yaml
+++ b/model/database/deprecated/registry-deprecated.yaml
@@ -384,7 +384,9 @@ groups:
               stability: development
             - id: cache
               value: "cache"
-              deprecated: "Replaced by `intersystems_cache`."
+              deprecated: 
+                reason: renamed
+                renamed_to: "intersystems_cache"
               brief: "Deprecated, use `intersystems_cache` instead."
               stability: development
             - id: intersystems_cache
@@ -401,7 +403,9 @@ groups:
               stability: development
             - id: cloudscape
               value: "cloudscape"
-              deprecated: "Replaced by `other_sql`."
+              deprecated:
+                reason: renamed
+                renamed_to: "other_sql"
               brief: "Deprecated, use `other_sql` instead."
               stability: development
             - id: cockroachdb
@@ -410,7 +414,8 @@ groups:
               stability: development
             - id: coldfusion
               value: "coldfusion"
-              deprecated: "Removed."
+              deprecated:
+                reason: obsoleted
               brief: "Deprecated, no replacement at this time."
               stability: development
             - id: cosmosdb
@@ -455,7 +460,9 @@ groups:
               stability: development
             - id: firstsql
               value: "firstsql"
-              deprecated: "Replaced by `other_sql`."
+              deprecated:
+                reason: renamed
+                renamed_to: "other_sql"
               brief: "Deprecated, use `other_sql` instead."
               stability: development
             - id: geode
@@ -524,7 +531,9 @@ groups:
               stability: development
             - id: mssqlcompact
               value: "mssqlcompact"
-              deprecated: "Removed, use `other_sql` instead."
+              deprecated:
+                reason: renamed
+                renamed_to: "other_sql"
               brief: "Deprecated, Microsoft SQL Server Compact is discontinued."
               stability: development
             - id: mysql

--- a/model/gen-ai/deprecated/registry-deprecated.yaml
+++ b/model/gen-ai/deprecated/registry-deprecated.yaml
@@ -70,12 +70,16 @@ groups:
               stability: development
               value: "vertex_ai"
               brief: 'Vertex AI'
-              deprecated: "Use 'gcp.vertex_ai' instead."
+              deprecated:
+                reason: renamed
+                renamed_to: "gcp.vertex_ai"
             - id: gemini
               stability: development
               value: "gemini"
               brief: 'Gemini'
-              deprecated: "Use 'gcp.gemini' instead."
+              deprecated:
+                reason: renamed
+                renamed_to: "gcp.gemini"
             - id: anthropic
               stability: development
               value: "anthropic"
@@ -116,7 +120,9 @@ groups:
               stability: development
               value: "xai"
               brief: 'xAI'
-              deprecated: "Use 'x_ai' instead."
+              deprecated:
+                reason: renamed
+                renamed_to: "x_ai"
             - id: deepseek
               stability: development
               value: "deepseek"

--- a/model/gen-ai/registry.yaml
+++ b/model/gen-ai/registry.yaml
@@ -197,7 +197,9 @@ groups:
             - id: completion
               stability: development
               value: "output"
-              deprecated: "Replaced by `output`."
+              deprecated:
+                reason: renamed
+                renamed_to: "output"
               brief: 'Output tokens (completion, response, etc.)'
             - id: output
               stability: development

--- a/model/messaging/registry.yaml
+++ b/model/messaging/registry.yaml
@@ -134,12 +134,16 @@ groups:
             - id: deliver
               value: "deliver"
               brief: "Deprecated. Use `process` instead."
-              deprecated: "Replaced by `process`."
+              deprecated:
+                reason: renamed
+                renamed_to: "process"
               stability: development
             - id: publish
               value: "publish"
               brief: "Deprecated. Use `send` instead."
-              deprecated: "Replaced by `send`."
+              deprecated:
+                reason: renamed
+                renamed_to: "send"
               stability: development
 
         stability: development

--- a/model/os/registry.yaml
+++ b/model/os/registry.yaml
@@ -54,7 +54,9 @@ groups:
             - id: z_os
               value: 'z_os'
               brief: "Deprecated. Use `zos` instead."
-              deprecated: "Replaced by `zos`."
+              deprecated:
+                reason: renamed
+                renamed_to: "zos"
               stability: development
             - id: zos
               value: 'zos'

--- a/model/vcs/registry.yaml
+++ b/model/vcs/registry.yaml
@@ -264,7 +264,9 @@ groups:
             - id: gittea
               value: gittea
               brief: "Deprecated, use `gitea` instead."
-              deprecated: "Replaced by `gitea`."
+              deprecated:
+                reason: renamed
+                renamed_to: "gitea"
               stability: development
             - id: gitea
               value: gitea


### PR DESCRIPTION
Fixes the wrong syntax of deprecations.

Fixes #

The `cloud` SemConv uses a wrong / outdated format for deprecation notes.
This breaks weaver's `registry search` command.

## Changes

The PR adjusts the syntax to what the authors likely wanted to express but using the latest SemConv schema.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`

