### PR TITLE
Enforce consistency of metric briefs

### DIFF
--- a/docs/cicd/cicd-metrics.md
+++ b/docs/cicd/cicd-metrics.md
@@ -317,7 +317,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `vcs.change.count` | UpDownCounter | `{change}` | The number of changes (pull requests/merge requests/changelists) in a repository, categorized by their state (e.g. open or merged) | ![Development](https://img.shields.io/badge/-development-blue) | [`vcs.repo`](/docs/registry/entities/vcs.md#vcs-repo) |
+| `vcs.change.count` | UpDownCounter | `{change}` | The number of changes (pull requests/merge requests/changelists) in a repository, categorized by their state (e.g. open or merged). | ![Development](https://img.shields.io/badge/-development-blue) | [`vcs.repo`](/docs/registry/entities/vcs.md#vcs-repo) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -786,7 +786,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `vcs.ref.revisions_delta` | Gauge | `{revision}` | The number of revisions (commits) a ref (branch) is ahead/behind the branch from the `vcs.ref.base.name` attribute [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`vcs.repo`](/docs/registry/entities/vcs.md#vcs-repo) |
+| `vcs.ref.revisions_delta` | Gauge | `{revision}` | The number of revisions (commits) a ref (branch) is ahead/behind the branch from the `vcs.ref.base.name` attribute. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`vcs.repo`](/docs/registry/entities/vcs.md#vcs-repo) |
 
 **[1]:** This metric should be reported for each `vcs.revision_delta.direction` value. For example if branch `a` is 3 commits behind and 2 commits ahead of `trunk`,
 instrumentation SHOULD report two measurements: 3 and 2 (both positive numbers) and `vcs.ref.base.name` is set to `trunk`.
@@ -881,7 +881,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `vcs.ref.time` | Gauge | `s` | Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` attribute will always be `branch` | ![Development](https://img.shields.io/badge/-development-blue) | [`vcs.repo`](/docs/registry/entities/vcs.md#vcs-repo) |
+| `vcs.ref.time` | Gauge | `s` | Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` attribute will always be `branch`. | ![Development](https://img.shields.io/badge/-development-blue) | [`vcs.repo`](/docs/registry/entities/vcs.md#vcs-repo) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -943,7 +943,7 @@ This metric is [opt-in][MetricOptIn].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `vcs.contributor.count` | Gauge | `{contributor}` | The number of unique contributors to a repository | ![Development](https://img.shields.io/badge/-development-blue) | [`vcs.repo`](/docs/registry/entities/vcs.md#vcs-repo) |
+| `vcs.contributor.count` | Gauge | `{contributor}` | The number of unique contributors to a repository. | ![Development](https://img.shields.io/badge/-development-blue) | [`vcs.repo`](/docs/registry/entities/vcs.md#vcs-repo) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|

--- a/docs/database/cosmosdb.md
+++ b/docs/database/cosmosdb.md
@@ -352,7 +352,7 @@ Explaining bucket configuration:
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `azure.cosmosdb.client.operation.request_charge` | Histogram | `{request_unit}` | [Request units](https://learn.microsoft.com/azure/cosmos-db/request-units) consumed by the operation | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `azure.cosmosdb.client.operation.request_charge` | Histogram | `{request_unit}` | [Request units](https://learn.microsoft.com/azure/cosmos-db/request-units) consumed by the operation. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -441,7 +441,7 @@ It captures the number of active instances at any given time. Best practices dic
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `azure.cosmosdb.client.active_instance.count` | UpDownCounter | `{instance}` | Number of active client instances | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `azure.cosmosdb.client.active_instance.count` | UpDownCounter | `{instance}` | Number of active client instances. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|

--- a/docs/database/database-metrics.md
+++ b/docs/database/database-metrics.md
@@ -429,7 +429,7 @@ This metric is [required][MetricRequired].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `db.client.connection.count` | UpDownCounter | `{connection}` | The number of connections that are currently in state described by the `state` attribute | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `db.client.connection.count` | UpDownCounter | `{connection}` | The number of connections that are currently in state described by the `state` attribute. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -463,7 +463,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `db.client.connection.idle.max` | UpDownCounter | `{connection}` | The maximum number of idle open connections allowed | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `db.client.connection.idle.max` | UpDownCounter | `{connection}` | The maximum number of idle open connections allowed. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -487,7 +487,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `db.client.connection.idle.min` | UpDownCounter | `{connection}` | The minimum number of idle open connections allowed | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `db.client.connection.idle.min` | UpDownCounter | `{connection}` | The minimum number of idle open connections allowed. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -511,7 +511,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `db.client.connection.max` | UpDownCounter | `{connection}` | The maximum number of open connections allowed | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `db.client.connection.max` | UpDownCounter | `{connection}` | The maximum number of open connections allowed. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -535,7 +535,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `db.client.connection.pending_requests` | UpDownCounter | `{request}` | The number of current pending requests for an open connection | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `db.client.connection.pending_requests` | UpDownCounter | `{request}` | The number of current pending requests for an open connection. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -559,7 +559,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `db.client.connection.timeouts` | Counter | `{timeout}` | The number of connection timeouts that have occurred trying to obtain a connection from the pool | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `db.client.connection.timeouts` | Counter | `{timeout}` | The number of connection timeouts that have occurred trying to obtain a connection from the pool. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -583,7 +583,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `db.client.connection.create_time` | Histogram | `s` | The time it took to create a new connection | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `db.client.connection.create_time` | Histogram | `s` | The time it took to create a new connection. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -607,7 +607,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `db.client.connection.wait_time` | Histogram | `s` | The time it took to obtain an open connection from the pool | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `db.client.connection.wait_time` | Histogram | `s` | The time it took to obtain an open connection from the pool. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -631,7 +631,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `db.client.connection.use_time` | Histogram | `s` | The time between borrowing a connection and returning it to the pool | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `db.client.connection.use_time` | Histogram | `s` | The time between borrowing a connection and returning it to the pool. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|

--- a/docs/faas/faas-metrics.md
+++ b/docs/faas/faas-metrics.md
@@ -56,7 +56,7 @@ of `[ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `faas.invoke_duration` | Histogram | `s` | Measures the duration of the function's logic execution | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `faas.invoke_duration` | Histogram | `s` | Measures the duration of the function's logic execution. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -96,7 +96,7 @@ of `[ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `faas.init_duration` | Histogram | `s` | Measures the duration of the function's initialization, such as a cold start | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `faas.init_duration` | Histogram | `s` | Measures the duration of the function's initialization, such as a cold start. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -132,7 +132,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `faas.coldstarts` | Counter | `{coldstart}` | Number of invocation cold starts | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `faas.coldstarts` | Counter | `{coldstart}` | Number of invocation cold starts. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -168,7 +168,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `faas.errors` | Counter | `{error}` | Number of invocation errors | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `faas.errors` | Counter | `{error}` | Number of invocation errors. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -204,7 +204,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `faas.invocations` | Counter | `{invocation}` | Number of successful invocations | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `faas.invocations` | Counter | `{invocation}` | Number of successful invocations. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -240,7 +240,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `faas.timeouts` | Counter | `{timeout}` | Number of invocation timeouts | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `faas.timeouts` | Counter | `{timeout}` | Number of invocation timeouts. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -276,7 +276,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `faas.mem_usage` | Histogram | `By` | Distribution of max memory usage per invocation | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `faas.mem_usage` | Histogram | `By` | Distribution of max memory usage per invocation. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -316,7 +316,7 @@ of `[ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `faas.cpu_usage` | Histogram | `s` | Distribution of CPU usage per invocation | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `faas.cpu_usage` | Histogram | `s` | Distribution of CPU usage per invocation. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -352,7 +352,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `faas.net_io` | Histogram | `By` | Distribution of net I/O usage per invocation | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `faas.net_io` | Histogram | `By` | Distribution of net I/O usage per invocation. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|

--- a/docs/gen-ai/gen-ai-metrics.md
+++ b/docs/gen-ai/gen-ai-metrics.md
@@ -76,7 +76,7 @@ This metric SHOULD be specified with [ExplicitBucketBoundaries] of [1, 4, 16, 64
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `gen_ai.client.token.usage` | Histogram | `{token}` | Measures number of input and output tokens used | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `gen_ai.client.token.usage` | Histogram | `{token}` | Number of input and output tokens used. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -184,7 +184,7 @@ This metric SHOULD be specified with [ExplicitBucketBoundaries] of [0.01, 0.02, 
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `gen_ai.client.operation.duration` | Histogram | `s` | GenAI operation duration | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `gen_ai.client.operation.duration` | Histogram | `s` | GenAI operation duration. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -302,7 +302,7 @@ This metric SHOULD be specified with [ExplicitBucketBoundaries] of
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `gen_ai.server.request.duration` | Histogram | `s` | Generative AI server request duration such as time-to-last byte or last output token | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `gen_ai.server.request.duration` | Histogram | `s` | Generative AI server request duration such as time-to-last byte or last output token. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -420,7 +420,7 @@ This metric SHOULD be specified with [ExplicitBucketBoundaries] of
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `gen_ai.server.time_per_output_token` | Histogram | `s` | Time per output token generated after the first token for successful responses | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `gen_ai.server.time_per_output_token` | Histogram | `s` | Time per output token generated after the first token for successful responses. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -524,7 +524,7 @@ This metric SHOULD be specified with [ExplicitBucketBoundaries] of
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `gen_ai.server.time_to_first_token` | Histogram | `s` | Time to generate first token for successful responses | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `gen_ai.server.time_to_first_token` | Histogram | `s` | Time to generate first token for successful responses. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|

--- a/docs/hardware/common.md
+++ b/docs/hardware/common.md
@@ -81,7 +81,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `hw.energy` | Counter | `J` | Energy consumed by the component | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `hw.energy` | Counter | `J` | Energy consumed by the component. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -131,7 +131,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `hw.errors` | Counter | `{error}` | Number of errors encountered by the component | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `hw.errors` | Counter | `{error}` | Number of errors encountered by the component. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -192,7 +192,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `hw.power` | Gauge | `W` | Instantaneous power consumed by the component [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `hw.power` | Gauge | `W` | Instantaneous power consumed by the component. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** It is recommended to report `hw.energy` instead of `hw.power` when possible.
 
@@ -244,7 +244,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `hw.status` | UpDownCounter | `1` | Operational status: `1` (true) or `0` (false) for each of the possible states [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `hw.status` | UpDownCounter | `1` | Operational status: `1` (true) or `0` (false) for each of the possible states. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** `hw.status` is currently specified as an *UpDownCounter* but would ideally be represented using a [*StateSet* as defined in OpenMetrics](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#stateset). This semantic convention will be updated once *StateSet* is specified in OpenTelemetry. This planned change is not expected to have any consequence on the way users query their timeseries backend to retrieve the values of `hw.status` over time.
 

--- a/docs/hardware/host.md
+++ b/docs/hardware/host.md
@@ -34,7 +34,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `hw.host.ambient_temperature` | Gauge | `Cel` | Ambient (external) temperature of the physical host | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `hw.host.ambient_temperature` | Gauge | `Cel` | Ambient (external) temperature of the physical host. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -60,7 +60,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `hw.host.energy` | Counter | `J` | Total energy consumed by the entire physical host, in joules [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `hw.host.energy` | Counter | `J` | Total energy consumed by the entire physical host, in joules. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** The overall energy usage of a host MUST be reported using the specific `hw.host.energy` and `hw.host.power` metrics **only**, instead of the generic `hw.energy` and `hw.power` described in the previous section, to prevent summing up overlapping values.
 
@@ -88,7 +88,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `hw.host.heating_margin` | Gauge | `Cel` | By how many degrees Celsius the temperature of the physical host can be increased, before reaching a warning threshold on one of the internal sensors | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `hw.host.heating_margin` | Gauge | `Cel` | By how many degrees Celsius the temperature of the physical host can be increased, before reaching a warning threshold on one of the internal sensors. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -114,7 +114,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `hw.host.power` | Gauge | `W` | Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred) [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `hw.host.power` | Gauge | `W` | Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred). [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** The overall energy usage of a host MUST be reported using the specific `hw.host.energy` and `hw.host.power` metrics **only**, instead of the generic `hw.energy` and `hw.power` described in the previous section, to prevent summing up overlapping values.
 

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -51,7 +51,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.span.live` | UpDownCounter | `{span}` | The number of created spans with `recording=true` for which the end operation has not been called yet | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.span.live` | UpDownCounter | `{span}` | The number of created spans with `recording=true` for which the end operation has not been called yet. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -85,7 +85,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.span.started` | Counter | `{span}` | The number of created spans [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.span.started` | Counter | `{span}` | The number of created spans. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** Implementations MUST record this metric for all spans, even for non-recording ones.
 
@@ -132,7 +132,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.processor.span.queue.size` | UpDownCounter | `{span}` | The number of spans in the queue of a given instance of an SDK span processor [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.processor.span.queue.size` | UpDownCounter | `{span}` | The number of spans in the queue of a given instance of an SDK span processor. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** Only applies to span processors which use a queue, e.g. the SDK Batching Span Processor.
 
@@ -199,7 +199,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.processor.span.queue.capacity` | UpDownCounter | `{span}` | The maximum number of spans the queue of a given instance of an SDK span processor can hold [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.processor.span.queue.capacity` | UpDownCounter | `{span}` | The maximum number of spans the queue of a given instance of an SDK span processor can hold. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** Only applies to span processors which use a queue, e.g. the SDK Batching Span Processor.
 
@@ -266,7 +266,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.processor.span.processed` | Counter | `{span}` | The number of spans for which the processing has finished, either successful or failed [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.processor.span.processed` | Counter | `{span}` | The number of spans for which the processing has finished, either successful or failed. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
 For the SDK Simple and Batching Span Processor a span is considered to be processed already when it has been submitted to the exporter, not when the corresponding export call has finished.
@@ -363,7 +363,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.exporter.span.inflight` | UpDownCounter | `{span}` | The number of spans which were passed to the exporter, but that have not been exported yet (neither successful, nor failed) [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.exporter.span.inflight` | UpDownCounter | `{span}` | The number of spans which were passed to the exporter, but that have not been exported yet (neither successful, nor failed). [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** For successful exports, `error.type` MUST NOT be set. For failed exports, `error.type` MUST contain the failure cause.
 
@@ -436,7 +436,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.exporter.span.exported` | Counter | `{span}` | The number of spans for which the export has finished, either successful or failed [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.exporter.span.exported` | Counter | `{span}` | The number of spans for which the export has finished, either successful or failed. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** For successful exports, `error.type` MUST NOT be set. For failed exports, `error.type` MUST contain the failure cause.
 For exporters with partial success semantics (e.g. OTLP with `rejected_spans`), rejected spans MUST count as failed and only non-rejected spans count as success.
@@ -542,7 +542,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.log.created` | Counter | `{log_record}` | The number of logs submitted to enabled SDK Loggers | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.log.created` | Counter | `{log_record}` | The number of logs submitted to enabled SDK Loggers. | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -562,7 +562,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.processor.log.queue.size` | UpDownCounter | `{log_record}` | The number of log records in the queue of a given instance of an SDK log processor [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.processor.log.queue.size` | UpDownCounter | `{log_record}` | The number of log records in the queue of a given instance of an SDK log processor. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** Only applies to log record processors which use a queue, e.g. the SDK Batching Log Record Processor.
 
@@ -629,7 +629,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.processor.log.queue.capacity` | UpDownCounter | `{log_record}` | The maximum number of log records the queue of a given instance of an SDK Log Record processor can hold [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.processor.log.queue.capacity` | UpDownCounter | `{log_record}` | The maximum number of log records the queue of a given instance of an SDK Log Record processor can hold. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** Only applies to Log Record processors which use a queue, e.g. the SDK Batching Log Record Processor.
 
@@ -696,7 +696,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.processor.log.processed` | Counter | `{log_record}` | The number of log records for which the processing has finished, either successful or failed [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.processor.log.processed` | Counter | `{log_record}` | The number of log records for which the processing has finished, either successful or failed. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
 For the SDK Simple and Batching Log Record Processor a log record is considered to be processed already when it has been submitted to the exporter,
@@ -794,7 +794,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.exporter.log.inflight` | UpDownCounter | `{log_record}` | The number of log records which were passed to the exporter, but that have not been exported yet (neither successful, nor failed) [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.exporter.log.inflight` | UpDownCounter | `{log_record}` | The number of log records which were passed to the exporter, but that have not been exported yet (neither successful, nor failed). [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** For successful exports, `error.type` MUST NOT be set. For failed exports, `error.type` MUST contain the failure cause.
 
@@ -867,7 +867,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.exporter.log.exported` | Counter | `{log_record}` | The number of log records for which the export has finished, either successful or failed [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.exporter.log.exported` | Counter | `{log_record}` | The number of log records for which the export has finished, either successful or failed. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** For successful exports, `error.type` MUST NOT be set. For failed exports, `error.type` MUST contain the failure cause.
 For exporters with partial success semantics (e.g. OTLP with `rejected_log_records`), rejected log records MUST count as failed and only non-rejected log records count as success.
@@ -973,7 +973,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.exporter.metric_data_point.inflight` | UpDownCounter | `{data_point}` | The number of metric data points which were passed to the exporter, but that have not been exported yet (neither successful, nor failed) [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.exporter.metric_data_point.inflight` | UpDownCounter | `{data_point}` | The number of metric data points which were passed to the exporter, but that have not been exported yet (neither successful, nor failed). [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** For successful exports, `error.type` MUST NOT be set. For failed exports, `error.type` MUST contain the failure cause.
 
@@ -1046,7 +1046,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.exporter.metric_data_point.exported` | Counter | `{data_point}` | The number of metric data points for which the export has finished, either successful or failed [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `otel.sdk.exporter.metric_data_point.exported` | Counter | `{data_point}` | The number of metric data points for which the export has finished, either successful or failed. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** For successful exports, `error.type` MUST NOT be set. For failed exports, `error.type` MUST contain the failure cause.
 For exporters with partial success semantics (e.g. OTLP with `rejected_data_points`), rejected data points MUST count as failed and only non-rejected data points count as success.

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -39,7 +39,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `container.uptime` | Gauge | `s` | The time the container has been running [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `container.uptime` | Gauge | `s` | The time the container has been running. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
 The actual accuracy would depend on the instrumentation and operating system.
@@ -62,7 +62,7 @@ This metric is [opt-in][MetricOptIn].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `container.cpu.time` | Counter | `s` | Total CPU time consumed [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `container.cpu.time` | Counter | `s` | Total CPU time consumed. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** Total CPU time consumed by the specific container on all available CPU cores
 
@@ -107,7 +107,7 @@ This metric is [opt-in][MetricOptIn].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `container.cpu.usage` | Gauge | `{cpu}` | Container's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `container.cpu.usage` | Gauge | `{cpu}` | Container's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** CPU usage of the specific container on all available CPU cores, averaged over the sample window
 
@@ -246,7 +246,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `container.filesystem.available` | UpDownCounter | `By` | Container filesystem available bytes [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`container`](/docs/registry/entities/container.md#container) |
+| `container.filesystem.available` | UpDownCounter | `By` | Container filesystem available bytes. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`container`](/docs/registry/entities/container.md#container) |
 
 **[1]:** In K8s, this metric is derived from the
 [FsStats.AvailableBytes](https://pkg.go.dev/k8s.io/kubelet@v0.33.0/pkg/apis/stats/v1alpha1#FsStats) field
@@ -271,7 +271,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `container.filesystem.capacity` | UpDownCounter | `By` | Container filesystem capacity [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`container`](/docs/registry/entities/container.md#container) |
+| `container.filesystem.capacity` | UpDownCounter | `By` | Container filesystem capacity. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`container`](/docs/registry/entities/container.md#container) |
 
 **[1]:** In K8s, this metric is derived from the
 [FsStats.CapacityBytes](https://pkg.go.dev/k8s.io/kubelet@v0.33.0/pkg/apis/stats/v1alpha1#FsStats) field
@@ -296,7 +296,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `container.filesystem.usage` | UpDownCounter | `By` | Container filesystem usage [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`container`](/docs/registry/entities/container.md#container) |
+| `container.filesystem.usage` | UpDownCounter | `By` | Container filesystem usage. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`container`](/docs/registry/entities/container.md#container) |
 
 **[1]:** This may not equal capacity - available.
 

--- a/docs/system/k8s-metrics.md
+++ b/docs/system/k8s-metrics.md
@@ -374,7 +374,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.volume.available` | UpDownCounter | `By` | Pod volume storage space available [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.volume.available` | UpDownCounter | `By` | Pod volume storage space available. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** This metric is derived from the
 [VolumeStats.AvailableBytes](https://pkg.go.dev/k8s.io/kubelet@v0.33.0/pkg/apis/stats/v1alpha1#VolumeStats) field
@@ -417,7 +417,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.volume.capacity` | UpDownCounter | `By` | Pod volume total capacity [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.volume.capacity` | UpDownCounter | `By` | Pod volume total capacity. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** This metric is derived from the
 [VolumeStats.CapacityBytes](https://pkg.go.dev/k8s.io/kubelet@v0.33.0/pkg/apis/stats/v1alpha1#VolumeStats) field
@@ -460,7 +460,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.volume.usage` | UpDownCounter | `By` | Pod volume usage [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.volume.usage` | UpDownCounter | `By` | Pod volume usage. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** This may not equal capacity - available.
 
@@ -505,7 +505,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.volume.inode.count` | UpDownCounter | `{inode}` | The total inodes in the filesystem of the Pod's volume [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.volume.inode.count` | UpDownCounter | `{inode}` | The total inodes in the filesystem of the Pod's volume. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** This metric is derived from the
 [VolumeStats.Inodes](https://pkg.go.dev/k8s.io/kubelet@v0.33.0/pkg/apis/stats/v1alpha1#VolumeStats) field
@@ -548,7 +548,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.volume.inode.used` | UpDownCounter | `{inode}` | The inodes used by the filesystem of the Pod's volume [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.volume.inode.used` | UpDownCounter | `{inode}` | The inodes used by the filesystem of the Pod's volume. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** This metric is derived from the
 [VolumeStats.InodesUsed](https://pkg.go.dev/k8s.io/kubelet@v0.33.0/pkg/apis/stats/v1alpha1#VolumeStats) field
@@ -593,7 +593,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.volume.inode.free` | UpDownCounter | `{inode}` | The free inodes in the filesystem of the Pod's volume [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.volume.inode.free` | UpDownCounter | `{inode}` | The free inodes in the filesystem of the Pod's volume. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** This metric is derived from the
 [VolumeStats.InodesFree](https://pkg.go.dev/k8s.io/kubelet@v0.33.0/pkg/apis/stats/v1alpha1#VolumeStats) field

--- a/docs/system/k8s-metrics.md
+++ b/docs/system/k8s-metrics.md
@@ -140,7 +140,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.uptime` | Gauge | `s` | The time the Pod has been running [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.uptime` | Gauge | `s` | The time the Pod has been running. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
 The actual accuracy would depend on the instrumentation and operating system.
@@ -163,7 +163,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.cpu.time` | Counter | `s` | Total CPU time consumed [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.cpu.time` | Counter | `s` | Total CPU time consumed. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** Total CPU time consumed by the specific Pod on all available CPU cores
 
@@ -185,7 +185,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.cpu.usage` | Gauge | `{cpu}` | Pod's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
+| `k8s.pod.cpu.usage` | Gauge | `{cpu}` | Pod's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs. [1] | ![Development](https://img.shields.io/badge/-development-blue) |  |
 
 **[1]:** CPU usage of the specific Pod on all available CPU cores, averaged over the sample window
 
@@ -207,7 +207,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.memory.usage` | Gauge | `By` | Memory usage of the Pod [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.memory.usage` | Gauge | `By` | Memory usage of the Pod. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** Total memory usage of the Pod
 
@@ -229,7 +229,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.network.io` | Counter | `By` | Network bytes for the Pod | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.network.io` | Counter | `By` | Network bytes for the Pod. | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -263,7 +263,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.network.errors` | Counter | `{error}` | Pod network errors | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.network.errors` | Counter | `{error}` | Pod network errors. | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -297,7 +297,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.filesystem.available` | UpDownCounter | `By` | Pod filesystem available bytes [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.filesystem.available` | UpDownCounter | `By` | Pod filesystem available bytes. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** This metric is derived from the
 [FsStats.AvailableBytes](https://pkg.go.dev/k8s.io/kubelet@v0.33.0/pkg/apis/stats/v1alpha1#FsStats) field
@@ -322,7 +322,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.filesystem.capacity` | UpDownCounter | `By` | Pod filesystem capacity [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.filesystem.capacity` | UpDownCounter | `By` | Pod filesystem capacity. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** This metric is derived from the
 [FsStats.CapacityBytes](https://pkg.go.dev/k8s.io/kubelet@v0.33.0/pkg/apis/stats/v1alpha1#FsStats) field
@@ -347,7 +347,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.filesystem.usage` | UpDownCounter | `By` | Pod filesystem usage [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.filesystem.usage` | UpDownCounter | `By` | Pod filesystem usage. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** This may not equal capacity - available.
 
@@ -640,7 +640,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.status.state` | UpDownCounter | `{container}` | Describes the number of K8s containers that are currently in a given state [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
+| `k8s.container.status.state` | UpDownCounter | `{container}` | Describes the number of K8s containers that are currently in a given state. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
 
 **[1]:** All possible container states will be reported at each time interval to avoid missing metrics.
 Only the value corresponding to the current state will be non-zero.
@@ -677,7 +677,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.status.reason` | UpDownCounter | `{container}` | Describes the number of K8s containers that are currently in a state for a given reason [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
+| `k8s.container.status.reason` | UpDownCounter | `{container}` | Describes the number of K8s containers that are currently in a state for a given reason. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
 
 **[1]:** All possible container state reasons will be reported at each time interval to avoid missing metrics.
 Only the value corresponding to the current state reason will be non-zero.
@@ -724,7 +724,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.uptime` | Gauge | `s` | The time the Node has been running [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.uptime` | Gauge | `s` | The time the Node has been running. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 **[1]:** Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
 The actual accuracy would depend on the instrumentation and operating system.
@@ -747,7 +747,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.allocatable.cpu` | UpDownCounter | `{cpu}` | Amount of cpu allocatable on the node | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.allocatable.cpu` | UpDownCounter | `{cpu}` | Amount of cpu allocatable on the node. | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -767,7 +767,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.allocatable.memory` | UpDownCounter | `By` | Amount of memory allocatable on the node | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.allocatable.memory` | UpDownCounter | `By` | Amount of memory allocatable on the node. | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -787,7 +787,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.allocatable.ephemeral_storage` | UpDownCounter | `By` | Amount of ephemeral-storage allocatable on the node | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.allocatable.ephemeral_storage` | UpDownCounter | `By` | Amount of ephemeral-storage allocatable on the node. | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -807,7 +807,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.allocatable.pods` | UpDownCounter | `{pod}` | Amount of pods allocatable on the node | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.allocatable.pods` | UpDownCounter | `{pod}` | Amount of pods allocatable on the node. | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -889,7 +889,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.cpu.time` | Counter | `s` | Total CPU time consumed [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.cpu.time` | Counter | `s` | Total CPU time consumed. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 **[1]:** Total CPU time consumed by the specific Node on all available CPU cores
 
@@ -911,7 +911,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.cpu.usage` | Gauge | `{cpu}` | Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.cpu.usage` | Gauge | `{cpu}` | Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 **[1]:** CPU usage of the specific Node on all available CPU cores, averaged over the sample window
 
@@ -933,7 +933,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.memory.usage` | Gauge | `By` | Memory usage of the Node [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.memory.usage` | Gauge | `By` | Memory usage of the Node. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 **[1]:** Total memory usage of the Node
 
@@ -955,7 +955,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.network.io` | Counter | `By` | Network bytes for the Node | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.network.io` | Counter | `By` | Network bytes for the Node. | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -989,7 +989,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.network.errors` | Counter | `{error}` | Node network errors | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.network.errors` | Counter | `{error}` | Node network errors. | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -1023,7 +1023,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.filesystem.available` | UpDownCounter | `By` | Node filesystem available bytes [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.filesystem.available` | UpDownCounter | `By` | Node filesystem available bytes. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 **[1]:** This metric is derived from the
 [FsStats.AvailableBytes](https://pkg.go.dev/k8s.io/kubelet@v0.33.0/pkg/apis/stats/v1alpha1#FsStats) field
@@ -1048,7 +1048,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.filesystem.capacity` | UpDownCounter | `By` | Node filesystem capacity [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.filesystem.capacity` | UpDownCounter | `By` | Node filesystem capacity. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 **[1]:** This metric is derived from the
 [FsStats.CapacityBytes](https://pkg.go.dev/k8s.io/kubelet@v0.33.0/pkg/apis/stats/v1alpha1#FsStats) field
@@ -1073,7 +1073,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.filesystem.usage` | UpDownCounter | `By` | Node filesystem usage [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.filesystem.usage` | UpDownCounter | `By` | Node filesystem usage. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 **[1]:** This may not equal capacity - available.
 
@@ -1104,7 +1104,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.deployment.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this deployment [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.deployment`](/docs/registry/entities/k8s.md#k8s-deployment) |
+| `k8s.deployment.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this deployment. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.deployment`](/docs/registry/entities/k8s.md#k8s-deployment) |
 
 **[1]:** This metric aligns with the `replicas` field of the
 [K8s DeploymentSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#deploymentspec-v1-apps).
@@ -1127,7 +1127,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.deployment.available_pods` | UpDownCounter | `{pod}` | Total number of available replica pods (ready for at least minReadySeconds) targeted by this deployment [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.deployment`](/docs/registry/entities/k8s.md#k8s-deployment) |
+| `k8s.deployment.available_pods` | UpDownCounter | `{pod}` | Total number of available replica pods (ready for at least minReadySeconds) targeted by this deployment. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.deployment`](/docs/registry/entities/k8s.md#k8s-deployment) |
 
 **[1]:** This metric aligns with the `availableReplicas` field of the
 [K8s DeploymentStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#deploymentstatus-v1-apps).
@@ -1154,7 +1154,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.replicaset.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this replicaset [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.replicaset`](/docs/registry/entities/k8s.md#k8s-replicaset) |
+| `k8s.replicaset.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this replicaset. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.replicaset`](/docs/registry/entities/k8s.md#k8s-replicaset) |
 
 **[1]:** This metric aligns with the `replicas` field of the
 [K8s ReplicaSetSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicasetspec-v1-apps).
@@ -1177,7 +1177,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.replicaset.available_pods` | UpDownCounter | `{pod}` | Total number of available replica pods (ready for at least minReadySeconds) targeted by this replicaset [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.replicaset`](/docs/registry/entities/k8s.md#k8s-replicaset) |
+| `k8s.replicaset.available_pods` | UpDownCounter | `{pod}` | Total number of available replica pods (ready for at least minReadySeconds) targeted by this replicaset. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.replicaset`](/docs/registry/entities/k8s.md#k8s-replicaset) |
 
 **[1]:** This metric aligns with the `availableReplicas` field of the
 [K8s ReplicaSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicasetstatus-v1-apps).
@@ -1204,7 +1204,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.replicationcontroller.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this replication controller [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.replicationcontroller`](/docs/registry/entities/k8s.md#k8s-replicationcontroller) |
+| `k8s.replicationcontroller.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this replication controller. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.replicationcontroller`](/docs/registry/entities/k8s.md#k8s-replicationcontroller) |
 
 **[1]:** This metric aligns with the `replicas` field of the
 [K8s ReplicationControllerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerspec-v1-core)
@@ -1227,7 +1227,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.replicationcontroller.available_pods` | UpDownCounter | `{pod}` | Total number of available replica pods (ready for at least minReadySeconds) targeted by this replication controller [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.replicationcontroller`](/docs/registry/entities/k8s.md#k8s-replicationcontroller) |
+| `k8s.replicationcontroller.available_pods` | UpDownCounter | `{pod}` | Total number of available replica pods (ready for at least minReadySeconds) targeted by this replication controller. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.replicationcontroller`](/docs/registry/entities/k8s.md#k8s-replicationcontroller) |
 
 **[1]:** This metric aligns with the `availableReplicas` field of the
 [K8s ReplicationControllerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerstatus-v1-core)
@@ -1254,7 +1254,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.statefulset.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this statefulset [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.statefulset`](/docs/registry/entities/k8s.md#k8s-statefulset) |
+| `k8s.statefulset.desired_pods` | UpDownCounter | `{pod}` | Number of desired replica pods in this statefulset. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.statefulset`](/docs/registry/entities/k8s.md#k8s-statefulset) |
 
 **[1]:** This metric aligns with the `replicas` field of the
 [K8s StatefulSetSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetspec-v1-apps).
@@ -1277,7 +1277,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.statefulset.ready_pods` | UpDownCounter | `{pod}` | The number of replica pods created for this statefulset with a Ready Condition [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.statefulset`](/docs/registry/entities/k8s.md#k8s-statefulset) |
+| `k8s.statefulset.ready_pods` | UpDownCounter | `{pod}` | The number of replica pods created for this statefulset with a Ready Condition. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.statefulset`](/docs/registry/entities/k8s.md#k8s-statefulset) |
 
 **[1]:** This metric aligns with the `readyReplicas` field of the
 [K8s StatefulSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps).
@@ -1300,7 +1300,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.statefulset.current_pods` | UpDownCounter | `{pod}` | The number of replica pods created by the statefulset controller from the statefulset version indicated by currentRevision [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.statefulset`](/docs/registry/entities/k8s.md#k8s-statefulset) |
+| `k8s.statefulset.current_pods` | UpDownCounter | `{pod}` | The number of replica pods created by the statefulset controller from the statefulset version indicated by currentRevision. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.statefulset`](/docs/registry/entities/k8s.md#k8s-statefulset) |
 
 **[1]:** This metric aligns with the `currentReplicas` field of the
 [K8s StatefulSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps).
@@ -1323,7 +1323,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.statefulset.updated_pods` | UpDownCounter | `{pod}` | Number of replica pods created by the statefulset controller from the statefulset version indicated by updateRevision [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.statefulset`](/docs/registry/entities/k8s.md#k8s-statefulset) |
+| `k8s.statefulset.updated_pods` | UpDownCounter | `{pod}` | Number of replica pods created by the statefulset controller from the statefulset version indicated by updateRevision. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.statefulset`](/docs/registry/entities/k8s.md#k8s-statefulset) |
 
 **[1]:** This metric aligns with the `updatedReplicas` field of the
 [K8s StatefulSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps).
@@ -1350,7 +1350,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.hpa.desired_pods` | UpDownCounter | `{pod}` | Desired number of replica pods managed by this horizontal pod autoscaler, as last calculated by the autoscaler [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.hpa`](/docs/registry/entities/k8s.md#k8s-hpa) |
+| `k8s.hpa.desired_pods` | UpDownCounter | `{pod}` | Desired number of replica pods managed by this horizontal pod autoscaler, as last calculated by the autoscaler. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.hpa`](/docs/registry/entities/k8s.md#k8s-hpa) |
 
 **[1]:** This metric aligns with the `desiredReplicas` field of the
 [K8s HorizontalPodAutoscalerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerstatus-v2-autoscaling)
@@ -1373,7 +1373,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.hpa.current_pods` | UpDownCounter | `{pod}` | Current number of replica pods managed by this horizontal pod autoscaler, as last seen by the autoscaler [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.hpa`](/docs/registry/entities/k8s.md#k8s-hpa) |
+| `k8s.hpa.current_pods` | UpDownCounter | `{pod}` | Current number of replica pods managed by this horizontal pod autoscaler, as last seen by the autoscaler. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.hpa`](/docs/registry/entities/k8s.md#k8s-hpa) |
 
 **[1]:** This metric aligns with the `currentReplicas` field of the
 [K8s HorizontalPodAutoscalerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerstatus-v2-autoscaling)
@@ -1396,7 +1396,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.hpa.max_pods` | UpDownCounter | `{pod}` | The upper limit for the number of replica pods to which the autoscaler can scale up [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.hpa`](/docs/registry/entities/k8s.md#k8s-hpa) |
+| `k8s.hpa.max_pods` | UpDownCounter | `{pod}` | The upper limit for the number of replica pods to which the autoscaler can scale up. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.hpa`](/docs/registry/entities/k8s.md#k8s-hpa) |
 
 **[1]:** This metric aligns with the `maxReplicas` field of the
 [K8s HorizontalPodAutoscalerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerspec-v2-autoscaling)
@@ -1419,7 +1419,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.hpa.min_pods` | UpDownCounter | `{pod}` | The lower limit for the number of replica pods to which the autoscaler can scale down [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.hpa`](/docs/registry/entities/k8s.md#k8s-hpa) |
+| `k8s.hpa.min_pods` | UpDownCounter | `{pod}` | The lower limit for the number of replica pods to which the autoscaler can scale down. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.hpa`](/docs/registry/entities/k8s.md#k8s-hpa) |
 
 **[1]:** This metric aligns with the `minReplicas` field of the
 [K8s HorizontalPodAutoscalerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerspec-v2-autoscaling)
@@ -1548,7 +1548,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.daemonset.current_scheduled_nodes` | UpDownCounter | `{node}` | Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.daemonset`](/docs/registry/entities/k8s.md#k8s-daemonset) |
+| `k8s.daemonset.current_scheduled_nodes` | UpDownCounter | `{node}` | Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.daemonset`](/docs/registry/entities/k8s.md#k8s-daemonset) |
 
 **[1]:** This metric aligns with the `currentNumberScheduled` field of the
 [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
@@ -1571,7 +1571,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.daemonset.desired_scheduled_nodes` | UpDownCounter | `{node}` | Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod) [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.daemonset`](/docs/registry/entities/k8s.md#k8s-daemonset) |
+| `k8s.daemonset.desired_scheduled_nodes` | UpDownCounter | `{node}` | Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod). [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.daemonset`](/docs/registry/entities/k8s.md#k8s-daemonset) |
 
 **[1]:** This metric aligns with the `desiredNumberScheduled` field of the
 [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
@@ -1594,7 +1594,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.daemonset.misscheduled_nodes` | UpDownCounter | `{node}` | Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.daemonset`](/docs/registry/entities/k8s.md#k8s-daemonset) |
+| `k8s.daemonset.misscheduled_nodes` | UpDownCounter | `{node}` | Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.daemonset`](/docs/registry/entities/k8s.md#k8s-daemonset) |
 
 **[1]:** This metric aligns with the `numberMisscheduled` field of the
 [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
@@ -1617,7 +1617,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.daemonset.ready_nodes` | UpDownCounter | `{node}` | Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.daemonset`](/docs/registry/entities/k8s.md#k8s-daemonset) |
+| `k8s.daemonset.ready_nodes` | UpDownCounter | `{node}` | Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.daemonset`](/docs/registry/entities/k8s.md#k8s-daemonset) |
 
 **[1]:** This metric aligns with the `numberReady` field of the
 [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
@@ -1644,7 +1644,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.job.active_pods` | UpDownCounter | `{pod}` | The number of pending and actively running pods for a job [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.job`](/docs/registry/entities/k8s.md#k8s-job) |
+| `k8s.job.active_pods` | UpDownCounter | `{pod}` | The number of pending and actively running pods for a job. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.job`](/docs/registry/entities/k8s.md#k8s-job) |
 
 **[1]:** This metric aligns with the `active` field of the
 [K8s JobStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch).
@@ -1667,7 +1667,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.job.failed_pods` | UpDownCounter | `{pod}` | The number of pods which reached phase Failed for a job [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.job`](/docs/registry/entities/k8s.md#k8s-job) |
+| `k8s.job.failed_pods` | UpDownCounter | `{pod}` | The number of pods which reached phase Failed for a job. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.job`](/docs/registry/entities/k8s.md#k8s-job) |
 
 **[1]:** This metric aligns with the `failed` field of the
 [K8s JobStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch).
@@ -1690,7 +1690,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.job.successful_pods` | UpDownCounter | `{pod}` | The number of pods which reached phase Succeeded for a job [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.job`](/docs/registry/entities/k8s.md#k8s-job) |
+| `k8s.job.successful_pods` | UpDownCounter | `{pod}` | The number of pods which reached phase Succeeded for a job. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.job`](/docs/registry/entities/k8s.md#k8s-job) |
 
 **[1]:** This metric aligns with the `succeeded` field of the
 [K8s JobStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch).
@@ -1713,7 +1713,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.job.desired_successful_pods` | UpDownCounter | `{pod}` | The desired number of successfully finished pods the job should be run with [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.job`](/docs/registry/entities/k8s.md#k8s-job) |
+| `k8s.job.desired_successful_pods` | UpDownCounter | `{pod}` | The desired number of successfully finished pods the job should be run with. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.job`](/docs/registry/entities/k8s.md#k8s-job) |
 
 **[1]:** This metric aligns with the `completions` field of the
 [K8s JobSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobspec-v1-batch)..
@@ -1736,7 +1736,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.job.max_parallel_pods` | UpDownCounter | `{pod}` | The max desired number of pods the job should run at any given time [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.job`](/docs/registry/entities/k8s.md#k8s-job) |
+| `k8s.job.max_parallel_pods` | UpDownCounter | `{pod}` | The max desired number of pods the job should run at any given time. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.job`](/docs/registry/entities/k8s.md#k8s-job) |
 
 **[1]:** This metric aligns with the `parallelism` field of the
 [K8s JobSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobspec-v1-batch).
@@ -1763,7 +1763,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.cronjob.active_jobs` | UpDownCounter | `{job}` | The number of actively running jobs for a cronjob [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.cronjob`](/docs/registry/entities/k8s.md#k8s-cronjob) |
+| `k8s.cronjob.active_jobs` | UpDownCounter | `{job}` | The number of actively running jobs for a cronjob. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.cronjob`](/docs/registry/entities/k8s.md#k8s-cronjob) |
 
 **[1]:** This metric aligns with the `active` field of the
 [K8s CronJobStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#cronjobstatus-v1-batch).
@@ -1830,7 +1830,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.cpu.limit` | UpDownCounter | `{cpu}` | Maximum CPU resource limit set for the container [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
+| `k8s.container.cpu.limit` | UpDownCounter | `{cpu}` | Maximum CPU resource limit set for the container. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
 
 **[1]:** See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core for details.
 
@@ -1852,7 +1852,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.cpu.request` | UpDownCounter | `{cpu}` | CPU resource requested for the container [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
+| `k8s.container.cpu.request` | UpDownCounter | `{cpu}` | CPU resource requested for the container. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
 
 **[1]:** See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core for details.
 
@@ -1874,7 +1874,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.memory.limit` | UpDownCounter | `By` | Maximum memory resource limit set for the container [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
+| `k8s.container.memory.limit` | UpDownCounter | `By` | Maximum memory resource limit set for the container. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
 
 **[1]:** See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core for details.
 
@@ -1896,7 +1896,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.memory.request` | UpDownCounter | `By` | Memory resource requested for the container [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
+| `k8s.container.memory.request` | UpDownCounter | `By` | Memory resource requested for the container. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
 
 **[1]:** See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core for details.
 
@@ -1918,7 +1918,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.storage.limit` | UpDownCounter | `By` | Maximum storage resource limit set for the container [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
+| `k8s.container.storage.limit` | UpDownCounter | `By` | Maximum storage resource limit set for the container. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
 
 **[1]:** See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core for details.
 
@@ -1940,7 +1940,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.storage.request` | UpDownCounter | `By` | Storage resource requested for the container [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
+| `k8s.container.storage.request` | UpDownCounter | `By` | Storage resource requested for the container. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
 
 **[1]:** See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core for details.
 
@@ -1962,7 +1962,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.ephemeral_storage.limit` | UpDownCounter | `By` | Maximum ephemeral storage resource limit set for the container [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
+| `k8s.container.ephemeral_storage.limit` | UpDownCounter | `By` | Maximum ephemeral storage resource limit set for the container. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
 
 **[1]:** See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core for details.
 
@@ -1984,7 +1984,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.ephemeral_storage.request` | UpDownCounter | `By` | Ephemeral storage resource requested for the container [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
+| `k8s.container.ephemeral_storage.request` | UpDownCounter | `By` | Ephemeral storage resource requested for the container. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
 
 **[1]:** See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core for details.
 
@@ -2006,7 +2006,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.restart.count` | UpDownCounter | `{restart}` | Describes how many times the container has restarted (since the last counter reset) [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
+| `k8s.container.restart.count` | UpDownCounter | `{restart}` | Describes how many times the container has restarted (since the last counter reset). [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
 
 **[1]:** This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0
 at any time depending on how your kubelet is configured to prune dead containers.
@@ -2032,7 +2032,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.container.ready` | UpDownCounter | `{container}` | Indicates whether the container is currently marked as ready to accept traffic, based on its readiness probe (1 = ready, 0 = not ready) [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
+| `k8s.container.ready` | UpDownCounter | `{container}` | Indicates whether the container is currently marked as ready to accept traffic, based on its readiness probe (1 = ready, 0 = not ready). [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.container`](/docs/registry/entities/k8s.md#k8s-container) |
 
 **[1]:** This metric SHOULD reflect the value of the `ready` field in the
 [K8s ContainerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstatus-v1-core).

--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -88,7 +88,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.uptime` | Gauge | `s` | The time the system has been running [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.uptime` | Gauge | `s` | The time the system has been running. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 **[1]:** Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
 The actual accuracy would depend on the instrumentation and operating system.
@@ -115,7 +115,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.cpu.physical.count` | UpDownCounter | `{cpu}` | Reports the number of actual physical processor cores on the hardware [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.cpu.physical.count` | UpDownCounter | `{cpu}` | Reports the number of actual physical processor cores on the hardware. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 **[1]:** Calculated by multiplying the number of sockets by the number of cores per socket
 
@@ -137,7 +137,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.cpu.logical.count` | UpDownCounter | `{cpu}` | Reports the number of logical (virtual) processor cores created by the operating system to manage multitasking [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.cpu.logical.count` | UpDownCounter | `{cpu}` | Reports the number of logical (virtual) processor cores created by the operating system to manage multitasking. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 **[1]:** Calculated by multiplying the number of sockets by the number of cores per socket, and then by the number of threads per core
 
@@ -159,7 +159,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.cpu.time` | Counter | `s` | Seconds each logical CPU spent on each mode | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.cpu.time` | Counter | `s` | Seconds each logical CPU spent on each mode. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -394,7 +394,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.paging.usage` | UpDownCounter | `By` | Unix swap or windows pagefile usage | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.paging.usage` | UpDownCounter | `By` | Unix swap or windows pagefile usage. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -610,7 +610,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.disk.io_time` | Counter | `s` | Time disk spent activated [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.disk.io_time` | Counter | `s` | Time disk spent activated. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 **[1]:** The real elapsed time ("wall clock") used in the I/O path (time from operations running in parallel are not counted). Measured as:
 
@@ -641,7 +641,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.disk.operation_time` | Counter | `s` | Sum of the time each operation took to complete [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.disk.operation_time` | Counter | `s` | Sum of the time each operation took to complete. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 **[1]:** Because it is the sum of time each request took, parallel-issued requests each contribute to make the count grow. Measured as:
 
@@ -714,7 +714,7 @@ This metric is [opt-in][MetricOptIn].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.disk.limit` | UpDownCounter | `By` | The total storage capacity of the disk | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.disk.limit` | UpDownCounter | `By` | The total storage capacity of the disk. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -847,7 +847,7 @@ This metric is [opt-in][MetricOptIn].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.filesystem.limit` | UpDownCounter | `By` | The total storage capacity of the filesystem | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.filesystem.limit` | UpDownCounter | `By` | The total storage capacity of the filesystem. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -891,7 +891,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.network.dropped` | Counter | `{packet}` | Count of packets that are dropped or discarded even though there was no error [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.network.dropped` | Counter | `{packet}` | Count of packets that are dropped or discarded even though there was no error. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 **[1]:** Measured as:
 
@@ -965,7 +965,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.network.errors` | Counter | `{error}` | Count of network errors detected [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.network.errors` | Counter | `{error}` | Count of network errors detected. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 **[1]:** Measured as:
 
@@ -1108,7 +1108,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.process.count` | UpDownCounter | `{process}` | Total number of processes in each state | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.process.count` | UpDownCounter | `{process}` | Total number of processes in each state. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
@@ -1143,7 +1143,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.process.created` | Counter | `{process}` | Total number of processes created over uptime of the host | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.process.created` | Counter | `{process}` | Total number of processes created over uptime of the host. | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -1193,7 +1193,7 @@ an `{os}` prefix to split this metric across OSes.
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `system.linux.memory.available` | UpDownCounter | `By` | An estimate of how much memory is available for starting new applications, without causing swapping [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
+| `system.linux.memory.available` | UpDownCounter | `By` | An estimate of how much memory is available for starting new applications, without causing swapping. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`host`](/docs/registry/entities/host.md#host) |
 
 **[1]:** This is an alternative to `system.memory.usage` metric with `state=free`.
 Linux starting from 3.14 exports "available" memory. It takes "free" memory as a baseline, and then factors in kernel-specific values.

--- a/model/azure/cosmosdb-metrics.yaml
+++ b/model/azure/cosmosdb-metrics.yaml
@@ -5,7 +5,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: double
-    brief: "[Request units](https://learn.microsoft.com/azure/cosmos-db/request-units) consumed by the operation"
+    brief: "[Request units](https://learn.microsoft.com/azure/cosmos-db/request-units) consumed by the operation."
     instrument: histogram
     unit: "{request_unit}"
     stability: development
@@ -26,7 +26,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: int
-    brief: "Number of active client instances"
+    brief: "Number of active client instances."
     instrument: updowncounter
     unit: "{instance}"
     stability: development

--- a/model/container/metrics.yaml
+++ b/model/container/metrics.yaml
@@ -7,7 +7,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "The time the container has been running"
+    brief: "The time the container has been running."
     note: |
       Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
       The actual accuracy would depend on the instrumentation and operating system.
@@ -21,7 +21,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Total CPU time consumed"
+    brief: "Total CPU time consumed."
     note: >
       Total CPU time consumed by the specific container on all available CPU cores
     instrument: counter
@@ -40,7 +40,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Container's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs"
+    brief: "Container's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs."
     note: >
       CPU usage of the specific container on all available CPU cores, averaged over the sample window
     instrument: gauge
@@ -108,7 +108,7 @@ groups:
     type: metric
     metric_name: container.filesystem.available
     stability: development
-    brief: "Container filesystem available bytes"
+    brief: "Container filesystem available bytes."
     instrument: updowncounter
     unit: "By"
     annotations:
@@ -125,7 +125,7 @@ groups:
     type: metric
     metric_name: container.filesystem.capacity
     stability: development
-    brief: "Container filesystem capacity"
+    brief: "Container filesystem capacity."
     instrument: updowncounter
     unit: "By"
     annotations:
@@ -142,7 +142,7 @@ groups:
     type: metric
     metric_name: container.filesystem.usage
     stability: development
-    brief: "Container filesystem usage"
+    brief: "Container filesystem usage."
     instrument: updowncounter
     unit: "By"
     annotations:

--- a/model/database/metrics.yaml
+++ b/model/database/metrics.yaml
@@ -44,7 +44,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of connections that are currently in state described by the `state` attribute"
+    brief: "The number of connections that are currently in state described by the `state` attribute."
     instrument: updowncounter
     unit: "{connection}"
     attributes:
@@ -60,7 +60,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The maximum number of idle open connections allowed"
+    brief: "The maximum number of idle open connections allowed."
     instrument: updowncounter
     unit: "{connection}"
     attributes:
@@ -74,7 +74,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The minimum number of idle open connections allowed"
+    brief: "The minimum number of idle open connections allowed."
     instrument: updowncounter
     unit: "{connection}"
     attributes:
@@ -88,7 +88,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The maximum number of open connections allowed"
+    brief: "The maximum number of open connections allowed."
     instrument: updowncounter
     unit: "{connection}"
     attributes:
@@ -102,7 +102,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of current pending requests for an open connection"
+    brief: "The number of current pending requests for an open connection."
     instrument: updowncounter
     unit: "{request}"
     attributes:
@@ -116,7 +116,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of connection timeouts that have occurred trying to obtain a connection from the pool"
+    brief: "The number of connection timeouts that have occurred trying to obtain a connection from the pool."
     instrument: counter
     unit: "{timeout}"
     attributes:
@@ -130,7 +130,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "The time it took to create a new connection"
+    brief: "The time it took to create a new connection."
     instrument: histogram
     unit: "s"
     attributes:
@@ -144,7 +144,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "The time it took to obtain an open connection from the pool"
+    brief: "The time it took to obtain an open connection from the pool."
     instrument: histogram
     unit: "s"
     attributes:
@@ -158,7 +158,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "The time between borrowing a connection and returning it to the pool"
+    brief: "The time between borrowing a connection and returning it to the pool."
     instrument: histogram
     unit: "s"
     attributes:

--- a/model/faas/metrics.yaml
+++ b/model/faas/metrics.yaml
@@ -6,7 +6,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Measures the duration of the function's logic execution"
+    brief: "Measures the duration of the function's logic execution."
     instrument: histogram
     unit: "s"
     attributes:
@@ -19,7 +19,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Measures the duration of the function's initialization, such as a cold start"
+    brief: "Measures the duration of the function's initialization, such as a cold start."
     instrument: histogram
     unit: "s"
     attributes:
@@ -32,7 +32,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of invocation cold starts"
+    brief: "Number of invocation cold starts."
     instrument: counter
     unit: "{coldstart}"
     attributes:
@@ -45,7 +45,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of invocation errors"
+    brief: "Number of invocation errors."
     instrument: counter
     unit: "{error}"
     attributes:
@@ -58,7 +58,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of successful invocations"
+    brief: "Number of successful invocations."
     instrument: counter
     unit: "{invocation}"
     attributes:
@@ -71,7 +71,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of invocation timeouts"
+    brief: "Number of invocation timeouts."
     instrument: counter
     unit: "{timeout}"
     attributes:
@@ -84,7 +84,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Distribution of max memory usage per invocation"
+    brief: "Distribution of max memory usage per invocation."
     instrument: histogram
     unit: "By"
     attributes:
@@ -97,7 +97,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Distribution of CPU usage per invocation"
+    brief: "Distribution of CPU usage per invocation."
     instrument: histogram
     unit: "s"
     attributes:
@@ -110,7 +110,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Distribution of net I/O usage per invocation"
+    brief: "Distribution of net I/O usage per invocation."
     instrument: histogram
     unit: "By"
     attributes:

--- a/model/gen-ai/metrics.yaml
+++ b/model/gen-ai/metrics.yaml
@@ -45,7 +45,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: int
-    brief: 'Measures number of input and output tokens used'
+    brief: 'Number of input and output tokens used.'
     instrument: histogram
     unit: "{token}"
     stability: development
@@ -59,7 +59,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: double
-    brief: 'GenAI operation duration'
+    brief: 'GenAI operation duration.'
     instrument: histogram
     unit: "s"
     stability: development
@@ -78,7 +78,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: double
-    brief: 'Generative AI server request duration such as time-to-last byte or last output token'
+    brief: 'Generative AI server request duration such as time-to-last byte or last output token.'
     instrument: histogram
     unit: "s"
     stability: development
@@ -89,7 +89,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: double
-    brief: 'Time per output token generated after the first token for successful responses'
+    brief: 'Time per output token generated after the first token for successful responses.'
     instrument: histogram
     unit: "s"
     stability: development
@@ -100,7 +100,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: double
-    brief: 'Time to generate first token for successful responses'
+    brief: 'Time to generate first token for successful responses.'
     instrument: histogram
     unit: "s"
     stability: development

--- a/model/hardware/common-metrics.yaml
+++ b/model/hardware/common-metrics.yaml
@@ -15,7 +15,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Energy consumed by the component"
+    brief: "Energy consumed by the component."
     instrument: counter
     unit: "J"
     extends: metric.hw.attributes
@@ -27,7 +27,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of errors encountered by the component"
+    brief: "Number of errors encountered by the component."
     instrument: counter
     unit: "{error}"
     extends: metric.hw.attributes
@@ -48,7 +48,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Instantaneous power consumed by the component"
+    brief: "Instantaneous power consumed by the component."
     note: >
       It is recommended to report `hw.energy` instead of `hw.power` when possible.
     instrument: gauge
@@ -62,7 +62,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Operational status: `1` (true) or `0` (false) for each of the possible states"
+    brief: "Operational status: `1` (true) or `0` (false) for each of the possible states."
     instrument: updowncounter
     unit: "1"
     extends: metric.hw.attributes

--- a/model/hardware/host-metrics.yaml
+++ b/model/hardware/host-metrics.yaml
@@ -7,7 +7,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Ambient (external) temperature of the physical host"
+    brief: "Ambient (external) temperature of the physical host."
     instrument: gauge
     unit: "Cel"
     extends: hardware.attributes.common
@@ -19,7 +19,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Total energy consumed by the entire physical host, in joules"
+    brief: "Total energy consumed by the entire physical host, in joules."
     instrument: counter
     unit: "J"
     extends: hardware.attributes.common
@@ -37,7 +37,7 @@ groups:
     stability: development
     brief: >
       By how many degrees Celsius the temperature of the physical host can be increased, before reaching a warning
-      threshold on one of the internal sensors
+      threshold on one of the internal sensors.
     instrument: gauge
     unit: "Cel"
     extends: hardware.attributes.common
@@ -50,7 +50,7 @@ groups:
         metric_value_type: double
     stability: development
     brief: >
-      Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred)
+      Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred).
     instrument: gauge
     unit: "W"
     extends: hardware.attributes.common

--- a/model/k8s/metrics.yaml
+++ b/model/k8s/metrics.yaml
@@ -7,7 +7,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "The time the Pod has been running"
+    brief: "The time the Pod has been running."
     entity_associations:
       - k8s.pod
     note: |
@@ -23,7 +23,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Total CPU time consumed"
+    brief: "Total CPU time consumed."
     entity_associations:
       - k8s.pod
     note: >
@@ -37,7 +37,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Pod's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs"
+    brief: "Pod's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs."
     note: >
       CPU usage of the specific Pod on all available CPU cores, averaged over the sample window
     instrument: gauge
@@ -51,7 +51,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Memory usage of the Pod"
+    brief: "Memory usage of the Pod."
     entity_associations:
       - k8s.pod
     note: >
@@ -67,7 +67,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Network bytes for the Pod"
+    brief: "Network bytes for the Pod."
     instrument: counter
     unit: "By"
     entity_associations:
@@ -82,7 +82,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Pod network errors"
+    brief: "Pod network errors."
     instrument: counter
     entity_associations:
       - k8s.pod
@@ -96,7 +96,7 @@ groups:
     type: metric
     metric_name: k8s.pod.filesystem.available
     stability: development
-    brief: "Pod filesystem available bytes"
+    brief: "Pod filesystem available bytes."
     instrument: updowncounter
     unit: "By"
     annotations:
@@ -113,7 +113,7 @@ groups:
     type: metric
     metric_name: k8s.pod.filesystem.capacity
     stability: development
-    brief: "Pod filesystem capacity"
+    brief: "Pod filesystem capacity."
     instrument: updowncounter
     unit: "By"
     annotations:
@@ -130,7 +130,7 @@ groups:
     type: metric
     metric_name: k8s.pod.filesystem.usage
     stability: development
-    brief: "Pod filesystem usage"
+    brief: "Pod filesystem usage."
     instrument: updowncounter
     unit: "By"
     annotations:
@@ -292,7 +292,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Describes the number of K8s containers that are currently in a given state"
+    brief: "Describes the number of K8s containers that are currently in a given state."
     note: |
       All possible container states will be reported at each time interval to avoid missing metrics.
       Only the value corresponding to the current state will be non-zero.
@@ -310,7 +310,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Describes the number of K8s containers that are currently in a state for a given reason"
+    brief: "Describes the number of K8s containers that are currently in a state for a given reason."
     instrument: updowncounter
     unit: "{container}"
     entity_associations:
@@ -330,7 +330,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "The time the Node has been running"
+    brief: "The time the Node has been running."
     note: |
       Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
       The actual accuracy would depend on the instrumentation and operating system.
@@ -346,7 +346,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Amount of cpu allocatable on the node"
+    brief: "Amount of cpu allocatable on the node."
     entity_associations:
       - k8s.node
     instrument: updowncounter
@@ -358,7 +358,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Amount of ephemeral-storage allocatable on the node"
+    brief: "Amount of ephemeral-storage allocatable on the node."
     entity_associations:
       - k8s.node
     instrument: updowncounter
@@ -370,7 +370,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Amount of memory allocatable on the node"
+    brief: "Amount of memory allocatable on the node."
     entity_associations:
       - k8s.node
     instrument: updowncounter
@@ -382,7 +382,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Amount of pods allocatable on the node"
+    brief: "Amount of pods allocatable on the node."
     entity_associations:
       - k8s.node
     instrument: updowncounter
@@ -416,7 +416,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Total CPU time consumed"
+    brief: "Total CPU time consumed."
     note: >
       Total CPU time consumed by the specific Node on all available CPU cores
     instrument: counter
@@ -430,7 +430,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs"
+    brief: "Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs."
     note: >
       CPU usage of the specific Node on all available CPU cores, averaged over the sample window
     instrument: gauge
@@ -443,7 +443,7 @@ groups:
     type: metric
     metric_name: k8s.node.filesystem.available
     stability: development
-    brief: "Node filesystem available bytes"
+    brief: "Node filesystem available bytes."
     instrument: updowncounter
     unit: "By"
     annotations:
@@ -460,7 +460,7 @@ groups:
     type: metric
     metric_name: k8s.node.filesystem.capacity
     stability: development
-    brief: "Node filesystem capacity"
+    brief: "Node filesystem capacity."
     instrument: updowncounter
     unit: "By"
     annotations:
@@ -477,7 +477,7 @@ groups:
     type: metric
     metric_name: k8s.node.filesystem.usage
     stability: development
-    brief: "Node filesystem usage"
+    brief: "Node filesystem usage."
     instrument: updowncounter
     unit: "By"
     annotations:
@@ -501,7 +501,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Memory usage of the Node"
+    brief: "Memory usage of the Node."
     note: >
       Total memory usage of the Node
     instrument: gauge
@@ -517,7 +517,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Network bytes for the Node"
+    brief: "Network bytes for the Node."
     instrument: counter
     unit: "By"
     entity_associations:
@@ -532,7 +532,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Node network errors"
+    brief: "Node network errors."
     instrument: counter
     unit: "{error}"
     entity_associations:
@@ -549,7 +549,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of desired replica pods in this deployment"
+    brief: "Number of desired replica pods in this deployment."
     entity_associations:
       - k8s.deployment
     note: |
@@ -566,7 +566,7 @@ groups:
     stability: development
     entity_associations:
       - k8s.deployment
-    brief: "Total number of available replica pods (ready for at least minReadySeconds) targeted by this deployment"
+    brief: "Total number of available replica pods (ready for at least minReadySeconds) targeted by this deployment."
     note: |
       This metric aligns with the `availableReplicas` field of the
       [K8s DeploymentStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#deploymentstatus-v1-apps).
@@ -581,7 +581,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of desired replica pods in this replicaset"
+    brief: "Number of desired replica pods in this replicaset."
     entity_associations:
       - k8s.replicaset
     note: |
@@ -598,7 +598,7 @@ groups:
     stability: development
     entity_associations:
       - k8s.replicaset
-    brief: "Total number of available replica pods (ready for at least minReadySeconds) targeted by this replicaset"
+    brief: "Total number of available replica pods (ready for at least minReadySeconds) targeted by this replicaset."
     note: |
       This metric aligns with the `availableReplicas` field of the
       [K8s ReplicaSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicasetstatus-v1-apps).
@@ -613,7 +613,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of desired replica pods in this replication controller"
+    brief: "Number of desired replica pods in this replication controller."
     entity_associations:
       - k8s.replicationcontroller
     note: |
@@ -630,7 +630,7 @@ groups:
     stability: development
     entity_associations:
       - k8s.replicationcontroller
-    brief: "Total number of available replica pods (ready for at least minReadySeconds) targeted by this replication controller"
+    brief: "Total number of available replica pods (ready for at least minReadySeconds) targeted by this replication controller."
     note: |
       This metric aligns with the `availableReplicas` field of the
       [K8s ReplicationControllerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerstatus-v1-core)
@@ -645,7 +645,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of desired replica pods in this statefulset"
+    brief: "Number of desired replica pods in this statefulset."
     entity_associations:
       - k8s.statefulset
     note: |
@@ -662,7 +662,7 @@ groups:
     stability: development
     entity_associations:
       - k8s.statefulset
-    brief: "The number of replica pods created for this statefulset with a Ready Condition"
+    brief: "The number of replica pods created for this statefulset with a Ready Condition."
     note: |
       This metric aligns with the `readyReplicas` field of the
       [K8s StatefulSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps).
@@ -677,7 +677,7 @@ groups:
     stability: development
     entity_associations:
       - k8s.statefulset
-    brief: "The number of replica pods created by the statefulset controller from the statefulset version indicated by currentRevision"
+    brief: "The number of replica pods created by the statefulset controller from the statefulset version indicated by currentRevision."
     note: |
       This metric aligns with the `currentReplicas` field of the
       [K8s StatefulSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps).
@@ -692,7 +692,7 @@ groups:
     stability: development
     entity_associations:
       - k8s.statefulset
-    brief: "Number of replica pods created by the statefulset controller from the statefulset version indicated by updateRevision"
+    brief: "Number of replica pods created by the statefulset controller from the statefulset version indicated by updateRevision."
     note: |
       This metric aligns with the `updatedReplicas` field of the
       [K8s StatefulSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps).
@@ -707,7 +707,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Desired number of replica pods managed by this horizontal pod autoscaler, as last calculated by the autoscaler"
+    brief: "Desired number of replica pods managed by this horizontal pod autoscaler, as last calculated by the autoscaler."
     note: |
       This metric aligns with the `desiredReplicas` field of the
       [K8s HorizontalPodAutoscalerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerstatus-v2-autoscaling)
@@ -722,7 +722,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Current number of replica pods managed by this horizontal pod autoscaler, as last seen by the autoscaler"
+    brief: "Current number of replica pods managed by this horizontal pod autoscaler, as last seen by the autoscaler."
     note: |
       This metric aligns with the `currentReplicas` field of the
       [K8s HorizontalPodAutoscalerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerstatus-v2-autoscaling)
@@ -737,7 +737,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The upper limit for the number of replica pods to which the autoscaler can scale up"
+    brief: "The upper limit for the number of replica pods to which the autoscaler can scale up."
     note: |
       This metric aligns with the `maxReplicas` field of the
       [K8s HorizontalPodAutoscalerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerspec-v2-autoscaling)
@@ -752,7 +752,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The lower limit for the number of replica pods to which the autoscaler can scale down"
+    brief: "The lower limit for the number of replica pods to which the autoscaler can scale down."
     note: |
       This metric aligns with the `minReplicas` field of the
       [K8s HorizontalPodAutoscalerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerspec-v2-autoscaling)
@@ -829,7 +829,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod"
+    brief: "Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod."
     note: |
       This metric aligns with the `currentNumberScheduled` field of the
       [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
@@ -844,7 +844,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)"
+    brief: "Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)."
     note: |
       This metric aligns with the `desiredNumberScheduled` field of the
       [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
@@ -859,7 +859,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod"
+    brief: "Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod."
     note: |
       This metric aligns with the `numberMisscheduled` field of the
       [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
@@ -874,7 +874,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready"
+    brief: "Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready."
     note: |
       This metric aligns with the `numberReady` field of the
       [K8s DaemonSetStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps).
@@ -891,7 +891,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of pending and actively running pods for a job"
+    brief: "The number of pending and actively running pods for a job."
     instrument: updowncounter
     unit: "{pod}"
     entity_associations:
@@ -906,7 +906,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of pods which reached phase Failed for a job"
+    brief: "The number of pods which reached phase Failed for a job."
     instrument: updowncounter
     unit: "{pod}"
     entity_associations:
@@ -921,7 +921,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of pods which reached phase Succeeded for a job"
+    brief: "The number of pods which reached phase Succeeded for a job."
     instrument: updowncounter
     unit: "{pod}"
     entity_associations:
@@ -936,7 +936,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The desired number of successfully finished pods the job should be run with"
+    brief: "The desired number of successfully finished pods the job should be run with."
     instrument: updowncounter
     unit: "{pod}"
     entity_associations:
@@ -951,7 +951,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The max desired number of pods the job should run at any given time"
+    brief: "The max desired number of pods the job should run at any given time."
     instrument: updowncounter
     unit: "{pod}"
     entity_associations:
@@ -968,7 +968,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of actively running jobs for a cronjob"
+    brief: "The number of actively running jobs for a cronjob."
     instrument: updowncounter
     unit: "{job}"
     entity_associations:
@@ -1002,7 +1002,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Maximum CPU resource limit set for the container"
+    brief: "Maximum CPU resource limit set for the container."
     entity_associations:
       - k8s.container
     note: |
@@ -1016,7 +1016,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "CPU resource requested for the container"
+    brief: "CPU resource requested for the container."
     entity_associations:
       - k8s.container
     note: |
@@ -1030,7 +1030,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Maximum memory resource limit set for the container"
+    brief: "Maximum memory resource limit set for the container."
     entity_associations:
       - k8s.container
     note: |
@@ -1044,7 +1044,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Memory resource requested for the container"
+    brief: "Memory resource requested for the container."
     entity_associations:
       - k8s.container
     note: |
@@ -1058,7 +1058,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Maximum storage resource limit set for the container"
+    brief: "Maximum storage resource limit set for the container."
     entity_associations:
       - k8s.container
     note: |
@@ -1072,7 +1072,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Storage resource requested for the container"
+    brief: "Storage resource requested for the container."
     entity_associations:
       - k8s.container
     note: |
@@ -1086,7 +1086,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Maximum ephemeral storage resource limit set for the container"
+    brief: "Maximum ephemeral storage resource limit set for the container."
     entity_associations:
       - k8s.container
     note: |
@@ -1100,7 +1100,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Ephemeral storage resource requested for the container"
+    brief: "Ephemeral storage resource requested for the container."
     entity_associations:
       - k8s.container
     note: |
@@ -1114,7 +1114,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Describes how many times the container has restarted (since the last counter reset)"
+    brief: "Describes how many times the container has restarted (since the last counter reset)."
     instrument: updowncounter
     unit: "{restart}"
     entity_associations:
@@ -1134,7 +1134,7 @@ groups:
     stability: development
     brief: >
       Indicates whether the container is currently marked as ready to accept traffic,
-      based on its readiness probe (1 = ready, 0 = not ready)
+      based on its readiness probe (1 = ready, 0 = not ready).
     instrument: updowncounter
     unit: "{container}"
     entity_associations:

--- a/model/k8s/metrics.yaml
+++ b/model/k8s/metrics.yaml
@@ -154,7 +154,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: int
-    brief: "Pod volume storage space available"
+    brief: "Pod volume storage space available."
     instrument: updowncounter
     unit: "By"
     entity_associations:
@@ -173,7 +173,7 @@ groups:
     type: metric
     metric_name: k8s.pod.volume.capacity
     stability: development
-    brief: "Pod volume total capacity"
+    brief: "Pod volume total capacity."
     instrument: updowncounter
     annotations:
       code_generation:
@@ -195,7 +195,7 @@ groups:
     type: metric
     metric_name: k8s.pod.volume.usage
     stability: development
-    brief: "Pod volume usage"
+    brief: "Pod volume usage."
     instrument: updowncounter
     annotations:
       code_generation:
@@ -219,7 +219,7 @@ groups:
     type: metric
     metric_name: k8s.pod.volume.inode.count
     stability: development
-    brief: "The total inodes in the filesystem of the Pod's volume"
+    brief: "The total inodes in the filesystem of the Pod's volume."
     instrument: updowncounter
     annotations:
       code_generation:
@@ -241,7 +241,7 @@ groups:
     type: metric
     metric_name: k8s.pod.volume.inode.used
     stability: development
-    brief: "The inodes used by the filesystem of the Pod's volume"
+    brief: "The inodes used by the filesystem of the Pod's volume."
     instrument: updowncounter
     annotations:
       code_generation:
@@ -265,7 +265,7 @@ groups:
     type: metric
     metric_name: k8s.pod.volume.inode.free
     stability: development
-    brief: "The free inodes in the filesystem of the Pod's volume"
+    brief: "The free inodes in the filesystem of the Pod's volume."
     instrument: updowncounter
     annotations:
       code_generation:

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -6,7 +6,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of created spans with `recording=true` for which the end operation has not been called yet"
+    brief: "The number of created spans with `recording=true` for which the end operation has not been called yet."
     instrument: updowncounter
     unit: "{span}"
     attributes:
@@ -19,7 +19,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of created spans"
+    brief: "The number of created spans."
     instrument: counter
     unit: "{span}"
     note: |
@@ -35,7 +35,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of spans in the queue of a given instance of an SDK span processor"
+    brief: "The number of spans in the queue of a given instance of an SDK span processor."
     note: |
       Only applies to span processors which use a queue, e.g. the SDK Batching Span Processor.
     instrument: updowncounter
@@ -51,7 +51,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The maximum number of spans the queue of a given instance of an SDK span processor can hold"
+    brief: "The maximum number of spans the queue of a given instance of an SDK span processor can hold."
     note: |
       Only applies to span processors which use a queue, e.g. the SDK Batching Span Processor.
     instrument: updowncounter
@@ -67,7 +67,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of spans for which the processing has finished, either successful or failed"
+    brief: "The number of spans for which the processing has finished, either successful or failed."
     note: |
       For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
       For the SDK Simple and Batching Span Processor a span is considered to be processed already when it has been submitted to the exporter, not when the corresponding export call has finished.
@@ -88,7 +88,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of spans which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)"
+    brief: "The number of spans which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)."
     note: |
       For successful exports, `error.type` MUST NOT be set. For failed exports, `error.type` MUST contain the failure cause.
     instrument: updowncounter
@@ -110,7 +110,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of spans for which the export has finished, either successful or failed"
+    brief: "The number of spans for which the export has finished, either successful or failed."
     note: |
       For successful exports, `error.type` MUST NOT be set. For failed exports, `error.type` MUST contain the failure cause.
       For exporters with partial success semantics (e.g. OTLP with `rejected_spans`), rejected spans MUST count as failed and only non-rejected spans count as success.
@@ -136,7 +136,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of logs submitted to enabled SDK Loggers"
+    brief: "The number of logs submitted to enabled SDK Loggers."
     instrument: counter
     unit: "{log_record}"
 
@@ -147,7 +147,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of log records in the queue of a given instance of an SDK log processor"
+    brief: "The number of log records in the queue of a given instance of an SDK log processor."
     note: |
       Only applies to log record processors which use a queue, e.g. the SDK Batching Log Record Processor.
     instrument: updowncounter
@@ -163,7 +163,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The maximum number of log records the queue of a given instance of an SDK Log Record processor can hold"
+    brief: "The maximum number of log records the queue of a given instance of an SDK Log Record processor can hold."
     note: |
       Only applies to Log Record processors which use a queue, e.g. the SDK Batching Log Record Processor.
     instrument: updowncounter
@@ -179,7 +179,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of log records for which the processing has finished, either successful or failed"
+    brief: "The number of log records for which the processing has finished, either successful or failed."
     note: |
       For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
       For the SDK Simple and Batching Log Record Processor a log record is considered to be processed already when it has been submitted to the exporter,
@@ -201,7 +201,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of log records which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)"
+    brief: "The number of log records which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)."
     note: |
       For successful exports, `error.type` MUST NOT be set. For failed exports, `error.type` MUST contain the failure cause.
     instrument: updowncounter
@@ -223,7 +223,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of log records for which the export has finished, either successful or failed"
+    brief: "The number of log records for which the export has finished, either successful or failed."
     note: |
       For successful exports, `error.type` MUST NOT be set. For failed exports, `error.type` MUST contain the failure cause.
       For exporters with partial success semantics (e.g. OTLP with `rejected_log_records`), rejected log records MUST count as failed and only non-rejected log records count as success.
@@ -249,7 +249,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of metric data points which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)"
+    brief: "The number of metric data points which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)."
     note: |
       For successful exports, `error.type` MUST NOT be set. For failed exports, `error.type` MUST contain the failure cause.
     instrument: updowncounter
@@ -271,7 +271,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The number of metric data points for which the export has finished, either successful or failed"
+    brief: "The number of metric data points for which the export has finished, either successful or failed."
     note: |
       For successful exports, `error.type` MUST NOT be set. For failed exports, `error.type` MUST contain the failure cause.
       For exporters with partial success semantics (e.g. OTLP with `rejected_data_points`), rejected data points MUST count as failed and only non-rejected data points count as success.

--- a/model/system/deprecated/metrics-deprecated.yaml
+++ b/model/system/deprecated/metrics-deprecated.yaml
@@ -6,7 +6,7 @@ groups:
     deprecated:
       reason: renamed
       renamed_to: system.network.connection.count
-    brief: "Deprecated, use `system.network.connection.count` instead"
+    brief: "Deprecated, use `system.network.connection.count` instead."
     instrument: updowncounter
     unit: "{connection}"
     attributes:

--- a/model/system/metrics.yaml
+++ b/model/system/metrics.yaml
@@ -7,7 +7,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "The time the system has been running"
+    brief: "The time the system has been running."
     note: |
       Instrumentations SHOULD use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
       The actual accuracy would depend on the instrumentation and operating system.
@@ -24,7 +24,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Reports the number of actual physical processor cores on the hardware"
+    brief: "Reports the number of actual physical processor cores on the hardware."
     note: "Calculated by multiplying the number of sockets by the number of cores per socket"
     instrument: updowncounter
     unit: "{cpu}"
@@ -39,7 +39,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Reports the number of logical (virtual) processor cores created by the operating system to manage multitasking"
+    brief: "Reports the number of logical (virtual) processor cores created by the operating system to manage multitasking."
     note: "Calculated by multiplying the number of sockets by the number of cores per socket, and then by the number of threads per core"
     instrument: updowncounter
     unit: "{cpu}"
@@ -54,7 +54,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Seconds each logical CPU spent on each mode"
+    brief: "Seconds each logical CPU spent on each mode."
     instrument: counter
     unit: "s"
     attributes:
@@ -170,7 +170,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Unix swap or windows pagefile usage"
+    brief: "Unix swap or windows pagefile usage."
     instrument: updowncounter
     unit: "By"
     attributes:
@@ -270,7 +270,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Time disk spent activated"
+    brief: "Time disk spent activated."
     instrument: counter
     unit: "s"
     note: |
@@ -292,7 +292,7 @@ groups:
       code_generation:
         metric_value_type: double
     stability: development
-    brief: "Sum of the time each operation took to complete"
+    brief: "Sum of the time each operation took to complete."
     instrument: counter
     unit: "s"
     note: |
@@ -329,7 +329,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The total storage capacity of the disk"
+    brief: "The total storage capacity of the disk."
     instrument: updowncounter
     unit: "By"
     attributes:
@@ -390,7 +390,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "The total storage capacity of the filesystem"
+    brief: "The total storage capacity of the filesystem."
     instrument: updowncounter
     unit: "By"
     attributes:
@@ -411,7 +411,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Count of packets that are dropped or discarded even though there was no error"
+    brief: "Count of packets that are dropped or discarded even though there was no error."
     instrument: counter
     unit: "{packet}"
     note: |
@@ -449,7 +449,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Count of network errors detected"
+    brief: "Count of network errors detected."
     instrument: counter
     unit: "{error}"
     note: |
@@ -505,7 +505,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Total number of processes in each state"
+    brief: "Total number of processes in each state."
     instrument: updowncounter
     unit: "{process}"
     attributes:
@@ -520,7 +520,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "Total number of processes created over uptime of the host"
+    brief: "Total number of processes created over uptime of the host."
     instrument: counter
     unit: "{process}"
     attributes: []
@@ -535,7 +535,7 @@ groups:
       code_generation:
         metric_value_type: int
     stability: development
-    brief: "An estimate of how much memory is available for starting new applications, without causing swapping"
+    brief: "An estimate of how much memory is available for starting new applications, without causing swapping."
     note: |
       This is an alternative to `system.memory.usage` metric with `state=free`.
       Linux starting from 3.14 exports "available" memory. It takes "free" memory as a baseline, and then factors in kernel-specific values.

--- a/model/vcs/metrics.yaml
+++ b/model/vcs/metrics.yaml
@@ -5,7 +5,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: int
-    brief: 'The number of changes (pull requests/merge requests/changelists) in a repository, categorized by their state (e.g. open or merged)'
+    brief: 'The number of changes (pull requests/merge requests/changelists) in a repository, categorized by their state (e.g. open or merged).'
     instrument: updowncounter
     unit: "{change}"
     stability: development
@@ -189,7 +189,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: int
-    brief: 'The number of revisions (commits) a ref (branch) is ahead/behind the branch from the `vcs.ref.base.name` attribute'
+    brief: 'The number of revisions (commits) a ref (branch) is ahead/behind the branch from the `vcs.ref.base.name` attribute.'
     note: |
       This metric should be reported for each `vcs.revision_delta.direction` value. For example if branch `a` is 3 commits behind and 2 commits ahead of `trunk`,
       instrumentation SHOULD report two measurements: 3 and 2 (both positive numbers) and `vcs.ref.base.name` is set to `trunk`.
@@ -226,7 +226,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: double
-    brief: 'Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` attribute will always be `branch`'
+    brief: 'Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` attribute will always be `branch`.'
     instrument: gauge
     unit: "s"
     stability: development
@@ -251,7 +251,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: int
-    brief: 'The number of unique contributors to a repository'
+    brief: 'The number of unique contributors to a repository.'
     instrument: gauge
     unit: "{contributor}"
     stability: development

--- a/policies/metric_brief_format.rego
+++ b/policies/metric_brief_format.rego
@@ -1,0 +1,32 @@
+package before_resolution
+import rego.v1
+
+# This file enforces formatting policy for metric briefs.
+# Non-empty metric briefs should end with a period (.).
+
+metric_brief_violation(description, group_id) = violation if {
+    violation := {
+        "id": description,
+        "type": "semconv_attribute",
+        "category": "metric_brief_formatting",
+        "group": group_id,
+        "attr": "",
+    }
+}
+
+# Check that metric briefs end with a period
+deny contains metric_brief_violation(description, group.id) if {
+    group := input.groups[_]
+    group.type == "metric"
+    brief := group.brief
+    brief != null
+
+    # Remove trailing whitespace and check if it ends with period
+    trimmed_brief := trim(brief, " \n")
+
+    # Allow empty briefs - only check non-empty ones
+    trimmed_brief != ""
+    not endswith(trimmed_brief, ".")
+    
+    description := sprintf("Non-empty metric brief '%s' must end with a period (.).", [trimmed_brief])
+}

--- a/policies_test/metric_brief_format_test.rego
+++ b/policies_test/metric_brief_format_test.rego
@@ -1,0 +1,55 @@
+package before_resolution_test
+import data.before_resolution
+import future.keywords.if
+
+test_metric_brief_ends_with_period if {
+    # Should pass: metric brief ends with period
+    count(before_resolution.deny) == 0 with input as {"groups": [
+        {"id": "metric.test", "type": "metric", "brief": "This is a valid metric brief.", "stability": "development"}
+    ]}
+
+    # Should pass: metric brief ends with period after trimming whitespace
+    count(before_resolution.deny) == 0 with input as {"groups": [
+        {"id": "metric.test2", "type": "metric", "brief": "This is a valid metric brief.   ", "stability": "development"}
+    ]}
+}
+
+test_metric_brief_without_period if {
+    # Should fail: metric brief doesn't end with period
+    count(before_resolution.deny) > 0 with input as {"groups": [
+        {"id": "metric.test", "type": "metric", "brief": "This metric brief is missing a period", "stability": "development"}
+    ]}
+
+    # Should fail: metric brief doesn't end with period (with whitespace)
+    count(before_resolution.deny) > 0 with input as {"groups": [
+        {"id": "metric.test2", "type": "metric", "brief": "This metric brief is missing a period   ", "stability": "development"}
+    ]}
+}
+
+test_metric_without_brief if {
+    # Should pass: metric without brief is ignored (handled by other policies)
+    count(before_resolution.deny) == 0 with input as {"groups": [
+        {"id": "metric.test", "type": "metric", "stability": "development"}
+    ]}
+}
+
+test_metric_with_empty_brief if {
+    # Should pass: metric with empty brief is allowed
+    count(before_resolution.deny) == 0 with input as {"groups": [
+        {"id": "metric.test", "type": "metric", "brief": "", "stability": "development"}
+    ]}
+
+    # Should pass: metric with whitespace-only brief is treated as empty and allowed
+    count(before_resolution.deny) == 0 with input as {"groups": [
+        {"id": "metric.test2", "type": "metric", "brief": "   ", "stability": "development"}
+    ]}
+}
+
+test_non_metric_groups_ignored if {
+    # Should pass: non-metric groups are ignored
+    count(before_resolution.deny) == 0 with input as {"groups": [
+        {"id": "span.test", "type": "span", "brief": "This span brief doesn't end with period", "stability": "development"},
+        {"id": "event.test", "type": "event", "brief": "This event brief doesn't end with period", "stability": "development"},
+        {"id": "registry.attribute_test", "type": "attribute_group", "brief": "This attribute brief doesn't end with period"}
+    ]}
+}


### PR DESCRIPTION
Enforce consistency of metric briefs. Picked ending them with (.), primarily(?) since some of them are two sentences.

Open to alternative arguments, my only specific desire is to have consistency since currently it's about 50-50, and whether to add (.) has come up in multiple reviews of Java specific metrics in the Java repos.