### PR TITLE
[chore] Set enum briefs for Cassandra

### DIFF
--- a/docs/database/cassandra.md
+++ b/docs/database/cassandra.md
@@ -158,17 +158,17 @@ and SHOULD be provided **at span creation time** (if provided at all):
 
 | Value  | Description | Stability |
 |---|---|---|
-| `all` | all | ![Development](https://img.shields.io/badge/-development-blue) |
-| `any` | any | ![Development](https://img.shields.io/badge/-development-blue) |
-| `each_quorum` | each_quorum | ![Development](https://img.shields.io/badge/-development-blue) |
-| `local_one` | local_one | ![Development](https://img.shields.io/badge/-development-blue) |
-| `local_quorum` | local_quorum | ![Development](https://img.shields.io/badge/-development-blue) |
-| `local_serial` | local_serial | ![Development](https://img.shields.io/badge/-development-blue) |
-| `one` | one | ![Development](https://img.shields.io/badge/-development-blue) |
-| `quorum` | quorum | ![Development](https://img.shields.io/badge/-development-blue) |
-| `serial` | serial | ![Development](https://img.shields.io/badge/-development-blue) |
-| `three` | three | ![Development](https://img.shields.io/badge/-development-blue) |
-| `two` | two | ![Development](https://img.shields.io/badge/-development-blue) |
+| `all` | All | ![Development](https://img.shields.io/badge/-development-blue) |
+| `any` | Any | ![Development](https://img.shields.io/badge/-development-blue) |
+| `each_quorum` | Each Quorum | ![Development](https://img.shields.io/badge/-development-blue) |
+| `local_one` | Local One | ![Development](https://img.shields.io/badge/-development-blue) |
+| `local_quorum` | Local Quorum | ![Development](https://img.shields.io/badge/-development-blue) |
+| `local_serial` | Local Serial | ![Development](https://img.shields.io/badge/-development-blue) |
+| `one` | One | ![Development](https://img.shields.io/badge/-development-blue) |
+| `quorum` | Quorum | ![Development](https://img.shields.io/badge/-development-blue) |
+| `serial` | Serial | ![Development](https://img.shields.io/badge/-development-blue) |
+| `three` | Three | ![Development](https://img.shields.io/badge/-development-blue) |
+| `two` | Two | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 

--- a/docs/registry/attributes/cassandra.md
+++ b/docs/registry/attributes/cassandra.md
@@ -22,14 +22,14 @@ This section defines attributes for Cassandra.
 
 | Value  | Description | Stability |
 |---|---|---|
-| `all` | all | ![Development](https://img.shields.io/badge/-development-blue) |
-| `any` | any | ![Development](https://img.shields.io/badge/-development-blue) |
-| `each_quorum` | each_quorum | ![Development](https://img.shields.io/badge/-development-blue) |
-| `local_one` | local_one | ![Development](https://img.shields.io/badge/-development-blue) |
-| `local_quorum` | local_quorum | ![Development](https://img.shields.io/badge/-development-blue) |
-| `local_serial` | local_serial | ![Development](https://img.shields.io/badge/-development-blue) |
-| `one` | one | ![Development](https://img.shields.io/badge/-development-blue) |
-| `quorum` | quorum | ![Development](https://img.shields.io/badge/-development-blue) |
-| `serial` | serial | ![Development](https://img.shields.io/badge/-development-blue) |
-| `three` | three | ![Development](https://img.shields.io/badge/-development-blue) |
-| `two` | two | ![Development](https://img.shields.io/badge/-development-blue) |
+| `all` | All | ![Development](https://img.shields.io/badge/-development-blue) |
+| `any` | Any | ![Development](https://img.shields.io/badge/-development-blue) |
+| `each_quorum` | Each Quorum | ![Development](https://img.shields.io/badge/-development-blue) |
+| `local_one` | Local One | ![Development](https://img.shields.io/badge/-development-blue) |
+| `local_quorum` | Local Quorum | ![Development](https://img.shields.io/badge/-development-blue) |
+| `local_serial` | Local Serial | ![Development](https://img.shields.io/badge/-development-blue) |
+| `one` | One | ![Development](https://img.shields.io/badge/-development-blue) |
+| `quorum` | Quorum | ![Development](https://img.shields.io/badge/-development-blue) |
+| `serial` | Serial | ![Development](https://img.shields.io/badge/-development-blue) |
+| `three` | Three | ![Development](https://img.shields.io/badge/-development-blue) |
+| `two` | Two | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/model/cassandra/registry.yaml
+++ b/model/cassandra/registry.yaml
@@ -24,36 +24,47 @@ groups:
           members:
             - id: all
               value: "all"
+              brief: All
               stability: development
             - id: each_quorum
               value: "each_quorum"
+              brief: Each Quorum
               stability: development
             - id: quorum
               value: "quorum"
+              brief: Quorum
               stability: development
             - id: local_quorum
               value: "local_quorum"
+              brief: Local Quorum
               stability: development
             - id: one
               value: "one"
+              brief: One
               stability: development
             - id: two
               value: "two"
+              brief: Two
               stability: development
             - id: three
               value: "three"
+              brief: Three
               stability: development
             - id: local_one
               value: "local_one"
+              brief: Local One
               stability: development
             - id: any
               value: "any"
+              brief: Any
               stability: development
             - id: serial
               value: "serial"
+              brief: Serial
               stability: development
             - id: local_serial
               value: "local_serial"
+              brief: Local Serial
               stability: development
         stability: development
       - id: cassandra.query.idempotent


### PR DESCRIPTION
Progresses #2555

## Changes

Sets the brief property for enum members to human readable version of the value text.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
