### PR TITLE
Allow complex attributes on spans

### DIFF
--- a/docs/how-to-write-conventions/README.md
+++ b/docs/how-to-write-conventions/README.md
@@ -103,8 +103,8 @@ When defining a new attribute:
     This is useful for capturing user-defined key-value pairs, such as HTTP headers.
   - Represent complex values as a set of flat attributes whenever possible.
     - Complex or structured attributes (not listed in the
-      [set of standard attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.44.0/specification/common/README.md#attribute))
-      are supported on events and logs only. <!-- This may change, check out https://github.com/open-telemetry/opentelemetry-specification/pull/4485 to monitor the progress -->
+      [set of standard attributes](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/specification/common/README.md#attribute))
+      could be referenced on events and spans (![Development](https://img.shields.io/badge/-development-blue)) only. 
 
       Semantic convention authors should assume that backends do not index individual properties of complex attributes,
       that querying or aggregating on such properties is inefficient and complicated,

--- a/docs/how-to-write-conventions/README.md
+++ b/docs/how-to-write-conventions/README.md
@@ -104,7 +104,7 @@ When defining a new attribute:
   - Represent complex values as a set of flat attributes whenever possible.
     - Complex or structured attributes (not listed in the
       [set of standard attributes](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/specification/common/README.md#attribute))
-      could be referenced on events and spans (![Development](https://img.shields.io/badge/-development-blue)) only. 
+      could be referenced on events and spans (![Development](https://img.shields.io/badge/-development-blue)) only.
 
       Semantic convention authors should assume that backends do not index individual properties of complex attributes,
       that querying or aggregating on such properties is inefficient and complicated,

--- a/policies/attribute_types.rego
+++ b/policies/attribute_types.rego
@@ -5,12 +5,13 @@ import rego.v1
 deny contains group_stability_violation(description, group.id, attr.name) if {
     group := input.groups[_]
     group.type != "event"
+    group.type != "span"
     group.type != "attribute_group"
 
     attr := group.attributes[_]
     attr.type in ["any", "template[any]"]
 
-    description := sprintf("Attribute '%s' has type '%s' and is referenced on group '%s' of type '%s'. Complex attributes are only allowed on events.", [attr.name, attr.type, group.id, group.type])
+    description := sprintf("Attribute '%s' has type '%s' and is referenced on group '%s' of type '%s'. Complex attributes are only allowed on events and spans.", [attr.name, attr.type, group.id, group.type])
 }
 
 attribute_type_violation(description, group, attr) = violation if {

--- a/policies_test/attribute_types_test.rego
+++ b/policies_test/attribute_types_test.rego
@@ -3,7 +3,7 @@ import future.keywords
 
 test_fails_on_complex_attribute if {
     attribute_types := ["any", "template[any]"]
-    group_types = ["span", "entity", "resource", "metric"]
+    group_types = ["entity", "resource", "metric"]
     every attribute_type in attribute_types {
         every group_type in group_types {
             count(deny) == 1 with input as {"groups": [{ "id": concat(".", [group_type, "attr"]),
@@ -21,7 +21,7 @@ test_fails_on_complex_attribute if {
 
 test_pass_on_complex_attribute if {
     attribute_types := ["any", "template[any]"]
-    group_types = ["attribute_group", "event"]
+    group_types = ["attribute_group", "event", "span"]
     every attribute_type in attribute_types {
         every group_type in group_types {
             count(deny) == 0 with input as {"groups": [{ "id": concat(".", [group_type, "attr"]),


### PR DESCRIPTION
Following up on https://github.com/open-telemetry/opentelemetry-specification/pull/4485, this PR relaxes `any` attribute usage on spans.

We're actively experimenting with complex attributes in GenAI SIG #2179 where we have chat history recorded on spans or events. 
While OTel implementations don't allow complex attributes on spans, we suggest to record them as JSON strings as a temporary workaround in unstable instrumentations.

