### PR TITLE
[chore] Use rename deprecations for ios/Android #2602

### DIFF
--- a/docs/registry/attributes/android.md
+++ b/docs/registry/attributes/android.md
@@ -33,7 +33,7 @@ This document defines attributes that represents an occurrence of a lifecycle tr
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
-| <a id="android-state" href="#android-state">`android.state`</a> | string | Deprecated. Use `android.app.state` attribute instead. | `created`; `background`; `foreground` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Use `android.app.state` attribute instead. |
+| <a id="android-state" href="#android-state">`android.state`</a> | string | Deprecated. Use `android.app.state` attribute instead. | `created`; `background`; `foreground` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `android.app.state`. |
 
 ---
 

--- a/docs/registry/attributes/ios.md
+++ b/docs/registry/attributes/ios.md
@@ -34,7 +34,7 @@ The iOS platform on which the iOS application is running.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
-| <a id="ios-state" href="#ios-state">`ios.state`</a> | string | Deprecated. Use the `ios.app.state` attribute. [2] | `active`; `inactive`; `background` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by the `ios.app.state` attribute. |
+| <a id="ios-state" href="#ios-state">`ios.state`</a> | string | Deprecated. Use the `ios.app.state` attribute. [2] | `active`; `inactive`; `background` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `ios.app.state`. |
 
 **[2] `ios.state`:** The iOS lifecycle states are defined in the [UIApplicationDelegate documentation](https://developer.apple.com/documentation/uikit/uiapplicationdelegate), and from which the `OS terminology` column values are derived.
 

--- a/model/android/deprecated/registry-deprecated.yaml
+++ b/model/android/deprecated/registry-deprecated.yaml
@@ -9,8 +9,8 @@ groups:
         stability: development
         brief: Deprecated. Use `android.app.state` attribute instead.
         deprecated:
-          reason: uncategorized
-          note: Use `android.app.state` attribute instead.
+          reason: renamed
+          renamed_to: android.app.state
         type:
           members:
             - id: created

--- a/model/ios/deprecated/registry-deprecated.yaml
+++ b/model/ios/deprecated/registry-deprecated.yaml
@@ -10,9 +10,8 @@ groups:
         brief: >
           Deprecated. Use the `ios.app.state` attribute.
         deprecated:
-          reason: uncategorized
-          note:
-            Replaced by the `ios.app.state` attribute.
+          reason: renamed
+          renamed_to: ios.app.state
         note: >
           The iOS lifecycle states are defined in the [UIApplicationDelegate documentation](https://developer.apple.com/documentation/uikit/uiapplicationdelegate),
           and from which the `OS terminology` column values are derived.


### PR DESCRIPTION
Progesses #2602

## Changes

This uses a structured rename deprecation for the mobile os.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
