### PR TITLE
[chore] Use rename deprecations for Enduser #2602

### DIFF
--- a/docs/registry/attributes/enduser.md
+++ b/docs/registry/attributes/enduser.md
@@ -31,5 +31,5 @@ Describes deprecated enduser attributes.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
-| <a id="enduser-role" href="#enduser-role">`enduser.role`</a> | string | Deprecated, use `user.roles` instead. | `admin` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Use `user.roles` attribute instead. |
+| <a id="enduser-role" href="#enduser-role">`enduser.role`</a> | string | Deprecated, use `user.roles` instead. | `admin` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `user.roles`. |
 | <a id="enduser-scope" href="#enduser-scope">`enduser.scope`</a> | string | Deprecated, no replacement at this time. | `read:message, write:files` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed, no replacement at this time. |

--- a/model/enduser/deprecated/registry-deprecated.yaml
+++ b/model/enduser/deprecated/registry-deprecated.yaml
@@ -7,8 +7,8 @@ groups:
       - id: enduser.role
         type: string
         deprecated:
-          reason: uncategorized
-          note: "Use `user.roles` attribute instead."
+          reason: renamed
+          renamed_to: user.roles
         stability: development
         brief: "Deprecated, use `user.roles` instead."
         examples: 'admin'


### PR DESCRIPTION
Progresses #2602

## Changes

This uses a structured rename deprecation for the Enduser

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
