### PR TITLE
[chore] Desiginate event.name as obsoleted

### DIFF
--- a/model/event/deprecated/registry-deprecated.yaml
+++ b/model/event/deprecated/registry-deprecated.yaml
@@ -9,7 +9,7 @@ groups:
         type: string
         stability: development
         deprecated:
-          reason: uncategorized
+          reason: obsoleted
           note: >
             Replaced by EventName top-level field on the LogRecord.
         brief: >


### PR DESCRIPTION
## Changes

This marks event.name as obsoleted rather than uncategorised,

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
