### PR TITLE
Add new descriptive attributes - owner, business_unit, cost_center

### DIFF
--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: service
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds new descriptive attributes - owner, business_unit, cost_center to service
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2837]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/service.md
+++ b/docs/registry/attributes/service.md
@@ -9,9 +9,12 @@ A service instance.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
+| <a id="service-business-unit" href="#service-business-unit">`service.business_unit`</a> | string | The business unit or department responsible for the resource. |  | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="service-cost-center" href="#service-cost-center">`service.cost_center`</a> | string | The billing entity for the resource. |  | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="service-instance-id" href="#service-instance-id">`service.instance.id`</a> | string | The string ID of the service instance. [1] | `627cc493-f310-47de-96bd-71410b7dec09` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="service-name" href="#service-name">`service.name`</a> | string | Logical name of the service. [2] | `shoppingcart` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | <a id="service-namespace" href="#service-namespace">`service.namespace`</a> | string | A namespace for `service.name`. [3] | `Shop` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="service-owner" href="#service-owner">`service.owner`</a> | string | Owner of the resource. |  | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="service-version" href="#service-version">`service.version`</a> | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 **[1] `service.instance.id`:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words

--- a/docs/registry/attributes/service.md
+++ b/docs/registry/attributes/service.md
@@ -9,12 +9,12 @@ A service instance.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
-| <a id="service-business-unit" href="#service-business-unit">`service.business_unit`</a> | string | The business unit or department responsible for the resource. |  | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="service-cost-center" href="#service-cost-center">`service.cost_center`</a> | string | The billing entity for the resource. |  | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="service-business-unit" href="#service-business-unit">`service.business_unit`</a> | string | The business unit or department responsible for the resource. | `Ads`; `Cloud` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="service-cost-center" href="#service-cost-center">`service.cost_center`</a> | string | The billing entity for the resource. | `us-east1` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="service-instance-id" href="#service-instance-id">`service.instance.id`</a> | string | The string ID of the service instance. [1] | `627cc493-f310-47de-96bd-71410b7dec09` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="service-name" href="#service-name">`service.name`</a> | string | Logical name of the service. [2] | `shoppingcart` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | <a id="service-namespace" href="#service-namespace">`service.namespace`</a> | string | A namespace for `service.name`. [3] | `Shop` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="service-owner" href="#service-owner">`service.owner`</a> | string | Owner of the resource. |  | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="service-owner" href="#service-owner">`service.owner`</a> | string | Owner of the resource. | `pbansal124` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="service-version" href="#service-version">`service.version`</a> | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 **[1] `service.instance.id`:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words

--- a/docs/registry/entities/service.md
+++ b/docs/registry/entities/service.md
@@ -56,6 +56,9 @@ port.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
+| [`service.business_unit`](/docs/registry/attributes/service.md) | string | The business unit or department responsible for the resource. |  | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.cost_center`](/docs/registry/attributes/service.md) | string | The billing entity for the resource. |  | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.owner`](/docs/registry/attributes/service.md) | string | Owner of the resource. |  | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`service.version`](/docs/registry/attributes/service.md) | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 

--- a/docs/registry/entities/service.md
+++ b/docs/registry/entities/service.md
@@ -56,9 +56,9 @@ port.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`service.business_unit`](/docs/registry/attributes/service.md) | string | The business unit or department responsible for the resource. |  | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`service.cost_center`](/docs/registry/attributes/service.md) | string | The billing entity for the resource. |  | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`service.owner`](/docs/registry/attributes/service.md) | string | Owner of the resource. |  | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.business_unit`](/docs/registry/attributes/service.md) | string | The business unit or department responsible for the resource. | `Ads`; `Cloud` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.cost_center`](/docs/registry/attributes/service.md) | string | The billing entity for the resource. | `us-east1` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.owner`](/docs/registry/attributes/service.md) | string | Owner of the resource. | `pbansal124` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`service.version`](/docs/registry/attributes/service.md) | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -84,8 +84,11 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`service.name`](/docs/registry/attributes/service.md) | string | Logical name of the service. [1] | `shoppingcart` | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`service.business_unit`](/docs/registry/attributes/service.md) | string | The business unit or department responsible for the resource. | `Ads`; `Cloud` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.cost_center`](/docs/registry/attributes/service.md) | string | The billing entity for the resource. | `us-east1` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`service.instance.id`](/docs/registry/attributes/service.md) | string | The string ID of the service instance. [2] | `627cc493-f310-47de-96bd-71410b7dec09` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`service.namespace`](/docs/registry/attributes/service.md) | string | A namespace for `service.name`. [3] | `Shop` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`service.owner`](/docs/registry/attributes/service.md) | string | Owner of the resource. | `pbansal124` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`service.version`](/docs/registry/attributes/service.md) | string | The version string of the service API or implementation. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 **[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.

--- a/model/service/entities.yaml
+++ b/model/service/entities.yaml
@@ -15,3 +15,9 @@ groups:
         role: identifying
       - ref: service.instance.id
         role: identifying
+      - ref: service.owner
+        role: descriptive
+      - ref: service.cost_center
+        role: descriptive
+      - ref: service.business_unit
+        role: descriptive

--- a/model/service/registry.yaml
+++ b/model/service/registry.yaml
@@ -74,13 +74,16 @@ groups:
         stability: development
         brief: >
           Owner of the resource.
+        examples: ["pbansal124"]
       - id: service.cost_center
         type: string
         stability: development
         brief: >
           The billing entity for the resource.
+        examples: ["us-east1"]
       - id: service.business_unit
         type: string
         stability: development
         brief: >
           The business unit or department responsible for the resource.
+        examples: ["Ads", "Cloud"]

--- a/model/service/registry.yaml
+++ b/model/service/registry.yaml
@@ -69,3 +69,18 @@ groups:
           for that telemetry. This is typically the case for scraping receivers, as they know the target address and
           port.
         examples: ["627cc493-f310-47de-96bd-71410b7dec09"]
+      - id: service.owner
+        type: string
+        stability: development
+        brief: >
+          Owner of the resource.
+      - id: service.cost_center
+        type: string
+        stability: development
+        brief: >
+          The billing entity for the resource.
+      - id: service.business_unit
+        type: string
+        stability: development
+        brief: >
+          The business unit or department responsible for the resource.


### PR DESCRIPTION
Fixes #

## Changes
This PR adds new descriptive attributes - owner, business_unit, cost_center under service entity.
More details - https://github.com/open-telemetry/community/pull/2837 and 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] Links to the prototypes or existing instrumentations (when adding or changing conventions)
