### PR TITLE
Add in Itron as OS type

### DIFF
--- a/.chloggen/add_itron.yaml
+++ b/.chloggen/add_itron.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: os
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add in Itron as an os.type as per rust instrumentation.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1257]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/os.md
+++ b/docs/registry/attributes/os.md
@@ -26,6 +26,7 @@ The operating system (OS) on which the process represented by this resource is r
 | `dragonflybsd` | DragonFly BSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `freebsd` | FreeBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `hpux` | HP-UX (Hewlett Packard Unix) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `itron` | Industrial TRON | ![Development](https://img.shields.io/badge/-development-blue) |
 | `linux` | Linux | ![Development](https://img.shields.io/badge/-development-blue) |
 | `netbsd` | NetBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `openbsd` | OpenBSD | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/registry/entities/os.md
+++ b/docs/registry/entities/os.md
@@ -45,6 +45,7 @@
 | `dragonflybsd` | DragonFly BSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `freebsd` | FreeBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `hpux` | HP-UX (Hewlett Packard Unix) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `itron` | Industrial TRON | ![Development](https://img.shields.io/badge/-development-blue) |
 | `linux` | Linux | ![Development](https://img.shields.io/badge/-development-blue) |
 | `netbsd` | NetBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `openbsd` | OpenBSD | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/resource/os.md
+++ b/docs/resource/os.md
@@ -43,6 +43,7 @@ In case of virtualized environments, this is the operating system as it is obser
 | `dragonflybsd` | DragonFly BSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `freebsd` | FreeBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `hpux` | HP-UX (Hewlett Packard Unix) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `itron` | Industrial TRON | ![Development](https://img.shields.io/badge/-development-blue) |
 | `linux` | Linux | ![Development](https://img.shields.io/badge/-development-blue) |
 | `netbsd` | NetBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `openbsd` | OpenBSD | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/resource/zos.md
+++ b/docs/resource/zos.md
@@ -92,6 +92,7 @@ The following table describes how to populate the operating system attributes on
 | `dragonflybsd` | DragonFly BSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `freebsd` | FreeBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `hpux` | HP-UX (Hewlett Packard Unix) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `itron` | Industrial TRON | ![Development](https://img.shields.io/badge/-development-blue) |
 | `linux` | Linux | ![Development](https://img.shields.io/badge/-development-blue) |
 | `netbsd` | NetBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `openbsd` | OpenBSD | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/model/os/registry.yaml
+++ b/model/os/registry.yaml
@@ -62,6 +62,10 @@ groups:
               value: 'zos'
               brief: "IBM z/OS"
               stability: development
+            - id: itron
+              value: 'itron'
+              brief: "Industrial TRON"
+              stability: development
         brief: >
           The operating system type.
         stability: development


### PR DESCRIPTION
Progresses #1257

## Changes

Adds in itron as a os type. Itron is defined as an os by rust hence the rust resource detector will be reporting this value: https://doc.rust-lang.org/std/env/consts/constant.FAMILY.html

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] Links to the prototypes or existing instrumentations (when adding or changing conventions)
