### PR TITLE
Add in WASM as OS

### DIFF
--- a/.chloggen/Add_Wasm_as_os.yaml
+++ b/.chloggen/Add_Wasm_as_os.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: os
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add in Wasm as an os so that it can be reported by resource detectors.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1257]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/os.md
+++ b/docs/registry/attributes/os.md
@@ -30,5 +30,6 @@ The operating system (OS) on which the process represented by this resource is r
 | `netbsd` | NetBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `openbsd` | OpenBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `solaris` | SunOS, Oracle Solaris | ![Development](https://img.shields.io/badge/-development-blue) |
+| `wasm` | WASM | ![Development](https://img.shields.io/badge/-development-blue) |
 | `windows` | Microsoft Windows | ![Development](https://img.shields.io/badge/-development-blue) |
 | `zos` | IBM z/OS | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/registry/entities/os.md
+++ b/docs/registry/entities/os.md
@@ -49,6 +49,7 @@
 | `netbsd` | NetBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `openbsd` | OpenBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `solaris` | SunOS, Oracle Solaris | ![Development](https://img.shields.io/badge/-development-blue) |
+| `wasm` | WASM | ![Development](https://img.shields.io/badge/-development-blue) |
 | `windows` | Microsoft Windows | ![Development](https://img.shields.io/badge/-development-blue) |
 | `zos` | IBM z/OS | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/resource/os.md
+++ b/docs/resource/os.md
@@ -47,6 +47,7 @@ In case of virtualized environments, this is the operating system as it is obser
 | `netbsd` | NetBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `openbsd` | OpenBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `solaris` | SunOS, Oracle Solaris | ![Development](https://img.shields.io/badge/-development-blue) |
+| `wasm` | WASM | ![Development](https://img.shields.io/badge/-development-blue) |
 | `windows` | Microsoft Windows | ![Development](https://img.shields.io/badge/-development-blue) |
 | `zos` | IBM z/OS | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/docs/resource/zos.md
+++ b/docs/resource/zos.md
@@ -96,6 +96,7 @@ The following table describes how to populate the operating system attributes on
 | `netbsd` | NetBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `openbsd` | OpenBSD | ![Development](https://img.shields.io/badge/-development-blue) |
 | `solaris` | SunOS, Oracle Solaris | ![Development](https://img.shields.io/badge/-development-blue) |
+| `wasm` | WASM | ![Development](https://img.shields.io/badge/-development-blue) |
 | `windows` | Microsoft Windows | ![Development](https://img.shields.io/badge/-development-blue) |
 | `zos` | IBM z/OS | ![Development](https://img.shields.io/badge/-development-blue) |
 

--- a/model/os/registry.yaml
+++ b/model/os/registry.yaml
@@ -62,6 +62,10 @@ groups:
               value: 'zos'
               brief: "IBM z/OS"
               stability: development
+            - id: wasm
+              value: 'wasm'
+              brief: "WASM"
+              stability: development
         brief: >
           The operating system type.
         stability: development


### PR DESCRIPTION
Progresses #1257

## Changes

Adds in Wasm as an OS as it provided by frameworks such as rust, dotnet, java etc,

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
