### PR TITLE
[chore] Set enum briefs for K8s

### DIFF
--- a/docs/registry/attributes/k8s.md
+++ b/docs/registry/attributes/k8s.md
@@ -293,9 +293,9 @@ When this occurs, the exact value as reported by the Kubernetes API SHOULD be us
 
 | Value  | Description | Stability |
 |---|---|---|
-| `false` | condition_false | ![Development](https://img.shields.io/badge/-development-blue) |
-| `true` | condition_true | ![Development](https://img.shields.io/badge/-development-blue) |
-| `unknown` | condition_unknown | ![Development](https://img.shields.io/badge/-development-blue) |
+| `false` | False | ![Development](https://img.shields.io/badge/-development-blue) |
+| `true` | True | ![Development](https://img.shields.io/badge/-development-blue) |
+| `unknown` | Unknown | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 

--- a/docs/system/k8s-metrics.md
+++ b/docs/system/k8s-metrics.md
@@ -855,9 +855,9 @@ When this occurs, the exact value as reported by the Kubernetes API SHOULD be us
 
 | Value  | Description | Stability |
 |---|---|---|
-| `false` | condition_false | ![Development](https://img.shields.io/badge/-development-blue) |
-| `true` | condition_true | ![Development](https://img.shields.io/badge/-development-blue) |
-| `unknown` | condition_unknown | ![Development](https://img.shields.io/badge/-development-blue) |
+| `false` | False | ![Development](https://img.shields.io/badge/-development-blue) |
+| `true` | True | ![Development](https://img.shields.io/badge/-development-blue) |
+| `unknown` | Unknown | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 

--- a/model/k8s/registry.yaml
+++ b/model/k8s/registry.yaml
@@ -587,12 +587,15 @@ groups:
           members:
             - id: condition_true
               value: 'true'
+              brief: "True"
               stability: development
             - id: condition_false
               value: 'false'
+              brief: "False"
               stability: development
             - id: condition_unknown
               value: 'unknown'
+              brief: Unknown
               stability: development
       - id: k8s.container.status.state
         stability: experimental


### PR DESCRIPTION
Progresses #2555

## Changes

Please provide a brief description of the changes here.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
