### PR TITLE
[chore] Set enum briefs for Linux

### DIFF
--- a/docs/registry/attributes/linux.md
+++ b/docs/registry/attributes/linux.md
@@ -17,5 +17,5 @@ Describes Linux Memory attributes
 
 | Value  | Description | Stability |
 |---|---|---|
-| `reclaimable` | Reclaimable Slab Memory | ![Development](https://img.shields.io/badge/-development-blue) |
-| `unreclaimable` | Unreclaimable Slab Memory | ![Development](https://img.shields.io/badge/-development-blue) |
+| `reclaimable` | Slab Memory that might be reclaimed on memory pressure, such as cache objects like dentry. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `unreclaimable` | Slab Memory that cannot be reclaimed on memory pressure, such as in-use kernel data structures. | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -1234,8 +1234,8 @@ See also the [Slab allocator](https://blogs.oracle.com/linux/post/understanding-
 
 | Value  | Description | Stability |
 |---|---|---|
-| `reclaimable` | Reclaimable Slab Memory | ![Development](https://img.shields.io/badge/-development-blue) |
-| `unreclaimable` | Unreclaimable Slab Memory | ![Development](https://img.shields.io/badge/-development-blue) |
+| `reclaimable` | Slab Memory that might be reclaimed on memory pressure, such as cache objects like dentry. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `unreclaimable` | Slab Memory that cannot be reclaimed on memory pressure, such as in-use kernel data structures. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/model/linux/registry.yaml
+++ b/model/linux/registry.yaml
@@ -10,11 +10,11 @@ groups:
           members:
             - id: reclaimable
               value: 'reclaimable'
-              brief: Reclaimable Slab Memory
+              brief: Slab Memory that might be reclaimed on memory pressure, such as cache objects like dentry.
               stability: development
             - id: unreclaimable
               value: 'unreclaimable'
-              brief: Unreclaimable Slab Memory
+              brief: Slab Memory that cannot be reclaimed on memory pressure, such as in-use kernel data structures.
               stability: development
         stability: development
         brief: "The Linux Slab memory state"


### PR DESCRIPTION
Progresses #2555

## Changes

Sets the brief property for enum members to be informative summary of the value.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
