### PR TITLE
[chore] Set enum briefs for TLS

### DIFF
--- a/docs/dotnet/dotnet-network-traces.md
+++ b/docs/dotnet/dotnet-network-traces.md
@@ -383,8 +383,8 @@ side and `TLS server handshake` when authenticating the server.
 
 | Value  | Description | Stability |
 |---|---|---|
-| `ssl` | SSL | ![Development](https://img.shields.io/badge/-development-blue) |
-| `tls` | TLS | ![Development](https://img.shields.io/badge/-development-blue) |
+| `ssl` | Secure Socket Layer (SSL) security protocol | ![Development](https://img.shields.io/badge/-development-blue) |
+| `tls` | Transport Layer Security (TLS) security protocol | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/docs/registry/attributes/tls.md
+++ b/docs/registry/attributes/tls.md
@@ -49,8 +49,8 @@ This document defines semantic convention attributes in the TLS namespace.
 
 | Value  | Description | Stability |
 |---|---|---|
-| `ssl` | SSL | ![Development](https://img.shields.io/badge/-development-blue) |
-| `tls` | TLS | ![Development](https://img.shields.io/badge/-development-blue) |
+| `ssl` | Secure Socket Layer (SSL) security protocol | ![Development](https://img.shields.io/badge/-development-blue) |
+| `tls` | Transport Layer Security (TLS) security protocol | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ## TLS Deprecated Attributes
 

--- a/model/tls/registry.yaml
+++ b/model/tls/registry.yaml
@@ -110,11 +110,11 @@ groups:
           members:
             - id: ssl
               value: ssl
-              brief: SSL
+              brief: Secure Socket Layer (SSL) security protocol
               stability: development
             - id: tls
               value: tls
-              brief: TLS
+              brief: Transport Layer Security (TLS) security protocol
               stability: development
         stability: development
       - id: tls.protocol.version


### PR DESCRIPTION
Progresses #2555

## Changes

Sets the brief property for enum members to be human readable text providing additional information about the value.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
