### PR TITLE
Fix release workflow: remove obsolete schema-next.yaml check

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -30,11 +30,6 @@ jobs:
 
       - name: Update schema files
         run: |
-          if ! grep -q "^  next:$" schema-next.yaml; then
-            echo "String 'next:' not found in the file"
-            exit 1
-          fi
-
           version=${{ inputs.version }}
           make generate-schema-next SCHEMA_NEXT_VERSION=$version
           git add "schemas/$version"


### PR DESCRIPTION
The schema-next.yaml file was removed in commit 0c4e76a5 when schema generation was automated. The workflow was still checking for this file, causing the release preparation to fail.

This removes the obsolete check since make generate-schema-next now handles schema generation automatically.

See https://github.com/open-telemetry/semantic-conventions/actions/runs/17078052669/job/48424548950