### PR TITLE
Fix make targets on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-# All documents to be used in spell check.
-ALL_DOCS := $(shell find . -type f -name '*.md' -not -path './.github/*' -not -path './node_modules/*' | sort)
 PWD := $(shell pwd)
 
 # Determine OS & Arch for specific OS only tools on Unix based systems
@@ -90,11 +88,11 @@ $(MISSPELL):
 
 .PHONY: misspell
 misspell:	$(MISSPELL)
-	$(MISSPELL) -error $(ALL_DOCS)
+	find . -type f -name '*.md' -not -path './.github/*' -not -path './node_modules/*' -not -path './.git/*' -exec $(MISSPELL) -error {} +
 
 .PHONY: misspell-correction
 misspell-correction:	$(MISSPELL)
-	$(MISSPELL) -w $(ALL_DOCS)
+	find . -type f -name '*.md' -not -path './.github/*' -not -path './node_modules/*' -not -path './.git/*' -exec $(MISSPELL) -w {} +
 
 .PHONY: normalized-link-check
 # NOTE: Search "model/*/**" rather than "model" to skip `model/README.md`, which
@@ -127,21 +125,21 @@ markdown-link-check-local-only: normalized-link-check
 .PHONY: markdown-toc
 markdown-toc:
 	@if ! npm ls markdown-toc; then npm install; fi
-	@for f in $(ALL_DOCS); do \
-		if grep -q '<!-- tocstop -->' $$f; then \
-			echo markdown-toc: processing $$f; \
-			npx --no -- markdown-toc --bullets "-" --no-first-h1 --no-stripHeadingTags -i $$f || exit 1; \
-		elif grep -q '<!-- toc -->' $$f; then \
-			echo markdown-toc: ERROR: '<!-- tocstop -->' missing from $$f; exit 1; \
+	@find . -type f -name '*.md' -not -path './.github/*' -not -path './node_modules/*' -not -path './.git/*' | while read -r f; do \
+		if grep -q '<!-- tocstop -->' "$$f"; then \
+			echo markdown-toc: processing "$$f"; \
+			npx --no -- markdown-toc --bullets "-" --no-first-h1 --no-stripHeadingTags -i "$$f" || exit 1; \
+		elif grep -q '<!-- toc -->' "$$f"; then \
+			echo markdown-toc: ERROR: '<!-- tocstop -->' missing from "$$f"; exit 1; \
 		else \
-			echo markdown-toc: no TOC markers, skipping $$f; \
+			echo markdown-toc: no TOC markers, skipping "$$f"; \
 		fi; \
 	done
 
 .PHONY: markdownlint
 markdownlint:
 	@if ! npm ls markdownlint-cli; then npm install; fi
-	npx --no -- markdownlint-cli -c .markdownlint.yaml $(ALL_DOCS)
+	npx --no -- markdownlint-cli -c .markdownlint.yaml "**/*.md" --ignore ./.github/ --ignore ./node_modules/ --ignore ./.git/
 
 .PHONY: install-yamllint
 install-yamllint:


### PR DESCRIPTION
The make targets are failing on Windows due to command-line length limitations.

This PR fixes it by not creating and passing the large `ALL_DOCS` on the command line.