### PR TITLE
Add deployment type #2334

### DIFF
--- a/.chloggen/add_deployment_type.yaml
+++ b/.chloggen/add_deployment_type.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: deployment
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable the type of deployment to be captured to distinguish between provisioning and storage.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2334]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/deployment.md
+++ b/docs/registry/attributes/deployment.md
@@ -16,6 +16,7 @@ This document defines attributes for software deployments.
 | <a id="deployment-id" href="#deployment-id">`deployment.id`</a> | string | The id of the deployment. | `1208` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="deployment-name" href="#deployment-name">`deployment.name`</a> | string | The name of the deployment. | `deploy my app`; `deploy-frontend` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="deployment-status" href="#deployment-status">`deployment.status`</a> | string | The status of the deployment. | `failed`; `succeeded` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="deployment-type" href="#deployment-type">`deployment.type`</a> | string | The type of deployment which is occuring. | `publish`; `provision` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 **[1] `deployment.environment.name`:** `deployment.environment.name` does not affect the uniqueness constraints defined through
 the `service.namespace`, `service.name` and `service.instance.id` resource attributes.
@@ -33,6 +34,15 @@ considered to be identifying the same service:
 |---|---|---|
 | `failed` | failed | ![Development](https://img.shields.io/badge/-development-blue) |
 | `succeeded` | succeeded | ![Development](https://img.shields.io/badge/-development-blue) |
+
+---
+
+`deployment.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `provision` | The software is being provisioned on a machine aka the target. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `publish` | The software is being published to a registry/store. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ## Deployment Deprecated Attributes
 

--- a/model/deployment/registry.yaml
+++ b/model/deployment/registry.yaml
@@ -31,6 +31,20 @@ groups:
         brief: >
           The status of the deployment.
         stability: development
+      - id: deployment.type
+        stability: development
+        brief: >
+          The type of deployment which is occuring.
+        type:
+          members:
+            - id: publish
+              value: 'publish'
+              brief: The software is being published to a registry/store.
+              stability: development
+            - id: provision
+              value: 'provision'
+              brief: The software is being provisioned on a machine aka the target.
+              stability: development
       - id: deployment.environment.name
         type: string
         stability: development


### PR DESCRIPTION
Progresses #2334

## Changes

Records the type of deployment occuring so that provisioning of a new instance running the software can be differentiated from adding the files to a store.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
