### PR TITLE
[chore] Clarify behaviour for db.query.parameter.<key>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@
 
 <!-- next version -->
 
-- Clarify behaviour for `db.query.parameter.<key>`.
- ([#2684](https://github.com/open-telemetry/semantic-conventions/pull/2684))
-
 ## v1.37.0
 
 ### 🛑 Breaking changes 🛑

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 <!-- next version -->
 
+- Clarify behaviour for `db.query.parameter.<key>`.
+ ([#2684](https://github.com/open-telemetry/semantic-conventions/pull/2684))
+
 ## v1.37.0
 
 ### 🛑 Breaking changes 🛑

--- a/docs/database/cassandra.md
+++ b/docs/database/cassandra.md
@@ -131,6 +131,9 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
+`db.query.parameter.<key>` SHOULD match the name of the parameterized
+placeholders verbatim, such as matching the exact casing of names.
+
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 
 Examples:
@@ -138,8 +141,8 @@ Examples:
 - For a query `SELECT * FROM users where username =  %s` with the parameter `"jdoe"`,
   the attribute `db.query.parameter.0` SHOULD be set to `"jdoe"`.
 
-- For a query `"SELECT * FROM users WHERE username = %(username)s;` with parameter
-  `username = "jdoe"`, the attribute `db.query.parameter.username` SHOULD be set to `"jdoe"`.
+- For a query `"SELECT * FROM users WHERE username = %(userName)s;` with parameter
+  `userName = "jdoe"`, the attribute `db.query.parameter.userName` SHOULD be set to `"jdoe"`.
 
 The following attributes can be important for making sampling decisions
 and SHOULD be provided **at span creation time** (if provided at all):

--- a/docs/database/cassandra.md
+++ b/docs/database/cassandra.md
@@ -131,8 +131,8 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
-`db.query.parameter.<key>` SHOULD match the name of the parameterized
-placeholders verbatim, such as matching the exact casing of names.
+It is RECOMMENDED to capture the value as provided by the application
+without attempting to do any case normalization.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/database/cosmosdb.md
+++ b/docs/database/cosmosdb.md
@@ -235,6 +235,9 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
+`db.query.parameter.<key>` SHOULD match the name of the parameterized
+placeholders verbatim, such as matching the exact casing of names.
+
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 
 Examples:
@@ -242,8 +245,8 @@ Examples:
 - For a query `SELECT * FROM users where username =  %s` with the parameter `"jdoe"`,
   the attribute `db.query.parameter.0` SHOULD be set to `"jdoe"`.
 
-- For a query `"SELECT * FROM users WHERE username = %(username)s;` with parameter
-  `username = "jdoe"`, the attribute `db.query.parameter.username` SHOULD be set to `"jdoe"`.
+- For a query `"SELECT * FROM users WHERE username = %(userName)s;` with parameter
+  `userName = "jdoe"`, the attribute `db.query.parameter.userName` SHOULD be set to `"jdoe"`.
 
 The following attributes can be important for making sampling decisions
 and SHOULD be provided **at span creation time** (if provided at all):

--- a/docs/database/cosmosdb.md
+++ b/docs/database/cosmosdb.md
@@ -235,8 +235,8 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
-`db.query.parameter.<key>` SHOULD match the name of the parameterized
-placeholders verbatim, such as matching the exact casing of names.
+It is RECOMMENDED to capture the value as provided by the application
+without attempting to do any case normalization.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -218,8 +218,8 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
-`db.query.parameter.<key>` SHOULD match the name of the parameterized
-placeholders verbatim, such as matching the exact casing of names.
+It is RECOMMENDED to capture the value as provided by the application
+without attempting to do any case normalization.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/database/database-spans.md
+++ b/docs/database/database-spans.md
@@ -218,6 +218,9 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
+`db.query.parameter.<key>` SHOULD match the name of the parameterized
+placeholders verbatim, such as matching the exact casing of names.
+
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 
 Examples:
@@ -225,8 +228,8 @@ Examples:
 - For a query `SELECT * FROM users where username =  %s` with the parameter `"jdoe"`,
   the attribute `db.query.parameter.0` SHOULD be set to `"jdoe"`.
 
-- For a query `"SELECT * FROM users WHERE username = %(username)s;` with parameter
-  `username = "jdoe"`, the attribute `db.query.parameter.username` SHOULD be set to `"jdoe"`.
+- For a query `"SELECT * FROM users WHERE username = %(userName)s;` with parameter
+  `userName = "jdoe"`, the attribute `db.query.parameter.userName` SHOULD be set to `"jdoe"`.
 
 The following attributes can be important for making sampling decisions
 and SHOULD be provided **at span creation time** (if provided at all):

--- a/docs/database/mariadb.md
+++ b/docs/database/mariadb.md
@@ -115,6 +115,9 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
+`db.query.parameter.<key>` SHOULD match the name of the parameterized
+placeholders verbatim, such as matching the exact casing of names.
+
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 
 Examples:
@@ -122,8 +125,8 @@ Examples:
 - For a query `SELECT * FROM users where username =  %s` with the parameter `"jdoe"`,
   the attribute `db.query.parameter.0` SHOULD be set to `"jdoe"`.
 
-- For a query `"SELECT * FROM users WHERE username = %(username)s;` with parameter
-  `username = "jdoe"`, the attribute `db.query.parameter.username` SHOULD be set to `"jdoe"`.
+- For a query `"SELECT * FROM users WHERE username = %(userName)s;` with parameter
+  `userName = "jdoe"`, the attribute `db.query.parameter.userName` SHOULD be set to `"jdoe"`.
 
 The following attributes can be important for making sampling decisions
 and SHOULD be provided **at span creation time** (if provided at all):

--- a/docs/database/mariadb.md
+++ b/docs/database/mariadb.md
@@ -115,8 +115,8 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
-`db.query.parameter.<key>` SHOULD match the name of the parameterized
-placeholders verbatim, such as matching the exact casing of names.
+It is RECOMMENDED to capture the value as provided by the application
+without attempting to do any case normalization.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/database/mysql.md
+++ b/docs/database/mysql.md
@@ -115,6 +115,9 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
+`db.query.parameter.<key>` SHOULD match the name of the parameterized
+placeholders verbatim, such as matching the exact casing of names.
+
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 
 Examples:
@@ -122,8 +125,8 @@ Examples:
 - For a query `SELECT * FROM users where username =  %s` with the parameter `"jdoe"`,
   the attribute `db.query.parameter.0` SHOULD be set to `"jdoe"`.
 
-- For a query `"SELECT * FROM users WHERE username = %(username)s;` with parameter
-  `username = "jdoe"`, the attribute `db.query.parameter.username` SHOULD be set to `"jdoe"`.
+- For a query `"SELECT * FROM users WHERE username = %(userName)s;` with parameter
+  `userName = "jdoe"`, the attribute `db.query.parameter.userName` SHOULD be set to `"jdoe"`.
 
 The following attributes can be important for making sampling decisions
 and SHOULD be provided **at span creation time** (if provided at all):

--- a/docs/database/mysql.md
+++ b/docs/database/mysql.md
@@ -115,8 +115,8 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
-`db.query.parameter.<key>` SHOULD match the name of the parameterized
-placeholders verbatim, such as matching the exact casing of names.
+It is RECOMMENDED to capture the value as provided by the application
+without attempting to do any case normalization.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/database/oracledb.md
+++ b/docs/database/oracledb.md
@@ -109,8 +109,8 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
-`db.query.parameter.<key>` SHOULD match the name of the parameterized
-placeholders verbatim, such as matching the exact casing of names.
+It is RECOMMENDED to capture the value as provided by the application
+without attempting to do any case normalization.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/database/oracledb.md
+++ b/docs/database/oracledb.md
@@ -109,6 +109,9 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
+`db.query.parameter.<key>` SHOULD match the name of the parameterized
+placeholders verbatim, such as matching the exact casing of names.
+
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 
 Examples:
@@ -116,8 +119,8 @@ Examples:
 - For a query `SELECT * FROM users where username =  %s` with the parameter `"jdoe"`,
   the attribute `db.query.parameter.0` SHOULD be set to `"jdoe"`.
 
-- For a query `"SELECT * FROM users WHERE username = %(username)s;` with parameter
-  `username = "jdoe"`, the attribute `db.query.parameter.username` SHOULD be set to `"jdoe"`.
+- For a query `"SELECT * FROM users WHERE username = %(userName)s;` with parameter
+  `userName = "jdoe"`, the attribute `db.query.parameter.userName` SHOULD be set to `"jdoe"`.
 
 The following attributes can be important for making sampling decisions
 and SHOULD be provided **at span creation time** (if provided at all):

--- a/docs/database/postgresql.md
+++ b/docs/database/postgresql.md
@@ -123,8 +123,8 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
-`db.query.parameter.<key>` SHOULD match the name of the parameterized
-placeholders verbatim, such as matching the exact casing of names.
+It is RECOMMENDED to capture the value as provided by the application
+without attempting to do any case normalization.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/database/postgresql.md
+++ b/docs/database/postgresql.md
@@ -123,6 +123,9 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
+`db.query.parameter.<key>` SHOULD match the name of the parameterized
+placeholders verbatim, such as matching the exact casing of names.
+
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 
 Examples:
@@ -130,8 +133,8 @@ Examples:
 - For a query `SELECT * FROM users where username =  %s` with the parameter `"jdoe"`,
   the attribute `db.query.parameter.0` SHOULD be set to `"jdoe"`.
 
-- For a query `"SELECT * FROM users WHERE username = %(username)s;` with parameter
-  `username = "jdoe"`, the attribute `db.query.parameter.username` SHOULD be set to `"jdoe"`.
+- For a query `"SELECT * FROM users WHERE username = %(userName)s;` with parameter
+  `userName = "jdoe"`, the attribute `db.query.parameter.userName` SHOULD be set to `"jdoe"`.
 
 The following attributes can be important for making sampling decisions
 and SHOULD be provided **at span creation time** (if provided at all):

--- a/docs/database/sql-server.md
+++ b/docs/database/sql-server.md
@@ -122,6 +122,9 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
+`db.query.parameter.<key>` SHOULD match the name of the parameterized
+placeholders verbatim, such as matching the exact casing of names.
+
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 
 Examples:
@@ -129,8 +132,8 @@ Examples:
 - For a query `SELECT * FROM users where username =  %s` with the parameter `"jdoe"`,
   the attribute `db.query.parameter.0` SHOULD be set to `"jdoe"`.
 
-- For a query `"SELECT * FROM users WHERE username = %(username)s;` with parameter
-  `username = "jdoe"`, the attribute `db.query.parameter.username` SHOULD be set to `"jdoe"`.
+- For a query `"SELECT * FROM users WHERE username = %(userName)s;` with parameter
+  `userName = "jdoe"`, the attribute `db.query.parameter.userName` SHOULD be set to `"jdoe"`.
 
 The following attributes can be important for making sampling decisions
 and SHOULD be provided **at span creation time** (if provided at all):

--- a/docs/database/sql-server.md
+++ b/docs/database/sql-server.md
@@ -122,8 +122,8 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
-`db.query.parameter.<key>` SHOULD match the name of the parameterized
-placeholders verbatim, such as matching the exact casing of names.
+It is RECOMMENDED to capture the value as provided by the application
+without attempting to do any case normalization.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/database/sql.md
+++ b/docs/database/sql.md
@@ -172,6 +172,9 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
+`db.query.parameter.<key>` SHOULD match the name of the parameterized
+placeholders verbatim, such as matching the exact casing of names.
+
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 
 Examples:
@@ -179,8 +182,8 @@ Examples:
 - For a query `SELECT * FROM users where username =  %s` with the parameter `"jdoe"`,
   the attribute `db.query.parameter.0` SHOULD be set to `"jdoe"`.
 
-- For a query `"SELECT * FROM users WHERE username = %(username)s;` with parameter
-  `username = "jdoe"`, the attribute `db.query.parameter.username` SHOULD be set to `"jdoe"`.
+- For a query `"SELECT * FROM users WHERE username = %(userName)s;` with parameter
+  `userName = "jdoe"`, the attribute `db.query.parameter.userName` SHOULD be set to `"jdoe"`.
 
 The following attributes can be important for making sampling decisions
 and SHOULD be provided **at span creation time** (if provided at all):

--- a/docs/database/sql.md
+++ b/docs/database/sql.md
@@ -172,8 +172,8 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
-`db.query.parameter.<key>` SHOULD match the name of the parameterized
-placeholders verbatim, such as matching the exact casing of names.
+It is RECOMMENDED to capture the value as provided by the application
+without attempting to do any case normalization.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/registry/attributes/db.md
+++ b/docs/registry/attributes/db.md
@@ -71,8 +71,8 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
-`db.query.parameter.<key>` SHOULD match the name of the parameterized
-placeholders verbatim, such as matching the exact casing of names.
+It is RECOMMENDED to capture the value as provided by the application
+without attempting to do any case normalization.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/registry/attributes/db.md
+++ b/docs/registry/attributes/db.md
@@ -71,6 +71,9 @@ then `<key>` SHOULD be the 0-based index.
 `db.query.parameter.<key>` SHOULD match
 up with the parameterized placeholders present in `db.query.text`.
 
+`db.query.parameter.<key>` SHOULD match the name of the parameterized
+placeholders verbatim, such as matching the exact casing of names.
+
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 
 Examples:
@@ -78,8 +81,8 @@ Examples:
 - For a query `SELECT * FROM users where username =  %s` with the parameter `"jdoe"`,
   the attribute `db.query.parameter.0` SHOULD be set to `"jdoe"`.
 
-- For a query `"SELECT * FROM users WHERE username = %(username)s;` with parameter
-  `username = "jdoe"`, the attribute `db.query.parameter.username` SHOULD be set to `"jdoe"`.
+- For a query `"SELECT * FROM users WHERE username = %(userName)s;` with parameter
+  `userName = "jdoe"`, the attribute `db.query.parameter.userName` SHOULD be set to `"jdoe"`.
 
 **[7] `db.query.summary`:** The query summary describes a class of database queries and is useful
 as a grouping key, especially when analyzing telemetry for database

--- a/model/database/registry.yaml
+++ b/model/database/registry.yaml
@@ -91,6 +91,9 @@ groups:
           `db.query.parameter.<key>` SHOULD match
           up with the parameterized placeholders present in `db.query.text`.
 
+          `db.query.parameter.<key>` SHOULD match the name of the parameterized
+          placeholders verbatim, such as matching the exact casing of names.
+
           `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 
           Examples:
@@ -98,8 +101,8 @@ groups:
           - For a query `SELECT * FROM users where username =  %s` with the parameter `"jdoe"`,
             the attribute `db.query.parameter.0` SHOULD be set to `"jdoe"`.
 
-          - For a query `"SELECT * FROM users WHERE username = %(username)s;` with parameter
-            `username = "jdoe"`, the attribute `db.query.parameter.username` SHOULD be set to `"jdoe"`.
+          - For a query `"SELECT * FROM users WHERE username = %(userName)s;` with parameter
+            `userName = "jdoe"`, the attribute `db.query.parameter.userName` SHOULD be set to `"jdoe"`.
 
         examples: ["someval", "55"]
       - id: db.query.summary

--- a/model/database/registry.yaml
+++ b/model/database/registry.yaml
@@ -91,8 +91,8 @@ groups:
           `db.query.parameter.<key>` SHOULD match
           up with the parameterized placeholders present in `db.query.text`.
 
-          `db.query.parameter.<key>` SHOULD match the name of the parameterized
-          placeholders verbatim, such as matching the exact casing of names.
+          It is RECOMMENDED to capture the value as provided by the application
+          without attempting to do any case normalization.
 
           `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 


### PR DESCRIPTION
Fixes #2667

## Changes

Clarify that the casing of any named parameters should be left as-is.

Rather than introduce a new example, changes the casing of the existing example.

## Merge requirement checklist

* [x] ~~[CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.~~
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] ~~Links to the prototypes or existing instrumentations (when adding or changing conventions)~~
