### PR TITLE
Rename process state attribute #1803

### DIFF
--- a/.chloggen/system-ProcessState.yaml
+++ b/.chloggen/system-ProcessState.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: process, system
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: This renames `system.process.status` to `process.state` to follow semconv guidance.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1803]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/process.md
+++ b/docs/registry/attributes/process.md
@@ -41,6 +41,7 @@ An operating system process.
 | <a id="process-saved-user-id" href="#process-saved-user-id">`process.saved_user.id`</a> | int | The saved user ID (SUID) of the process. | `1002` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-saved-user-name" href="#process-saved-user-name">`process.saved_user.name`</a> | string | The username of the saved user. | `operator` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-session-leader-pid" href="#process-session-leader-pid">`process.session_leader.pid`</a> | int | The PID of the process's session leader. This is also the session ID (SID) of the process. | `14` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="process-state" href="#process-state">`process.state`</a> | string | The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES) | `running` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-title" href="#process-title">`process.title`</a> | string | Process title (proctitle) [3] | `cat /etc/hostname`; `xfce4-session`; `bash` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-user-id" href="#process-user-id">`process.user.id`</a> | int | The effective user ID (EUID) of the process. | `1001` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-user-name" href="#process-user-name">`process.user.name`</a> | string | The username of the effective user of the process. | `root` | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -79,6 +80,17 @@ with value `"/usr/local/bin:/usr/bin"`.
 |---|---|---|
 | `major` | major | ![Development](https://img.shields.io/badge/-development-blue) |
 | `minor` | minor | ![Development](https://img.shields.io/badge/-development-blue) |
+
+---
+
+`process.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `defunct` | Defunct | ![Development](https://img.shields.io/badge/-development-blue) |
+| `running` | Running | ![Development](https://img.shields.io/badge/-development-blue) |
+| `sleeping` | Sleeping | ![Development](https://img.shields.io/badge/-development-blue) |
+| `stopped` | Stopped | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ## Process Linux Attributes
 

--- a/docs/registry/attributes/system.md
+++ b/docs/registry/attributes/system.md
@@ -7,7 +7,6 @@
 - [Filesystem Attributes](#filesystem-attributes)
 - [System Memory Attributes](#system-memory-attributes)
 - [System Paging Attributes](#system-paging-attributes)
-- [System Process Attributes](#system-process-attributes)
 - [Deprecated System Attributes](#deprecated-system-attributes)
 
 ## General System Attributes
@@ -110,25 +109,6 @@ Describes System Memory Paging attributes
 | `major` | major | ![Development](https://img.shields.io/badge/-development-blue) |
 | `minor` | minor | ![Development](https://img.shields.io/badge/-development-blue) |
 
-## System Process Attributes
-
-Describes System Process attributes
-
-| Attribute | Type | Description | Examples | Stability |
-|---|---|---|---|---|
-| <a id="system-process-status" href="#system-process-status">`system.process.status`</a> | string | The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES) | `running` | ![Development](https://img.shields.io/badge/-development-blue) |
-
----
-
-`system.process.status` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
-
-| Value  | Description | Stability |
-|---|---|---|
-| `defunct` | defunct | ![Development](https://img.shields.io/badge/-development-blue) |
-| `running` | running | ![Development](https://img.shields.io/badge/-development-blue) |
-| `sleeping` | sleeping | ![Development](https://img.shields.io/badge/-development-blue) |
-| `stopped` | stopped | ![Development](https://img.shields.io/badge/-development-blue) |
-
 ## Deprecated System Attributes
 
 Deprecated system attributes.
@@ -138,7 +118,8 @@ Deprecated system attributes.
 | <a id="system-cpu-logical-number" href="#system-cpu-logical-number">`system.cpu.logical_number`</a> | int | Deprecated, use `cpu.logical_number` instead. | `1` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="system-cpu-state" href="#system-cpu-state">`system.cpu.state`</a> | string | Deprecated, use `cpu.mode` instead. | `idle`; `interrupt` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `cpu.mode`. |
 | <a id="system-network-state" href="#system-network-state">`system.network.state`</a> | string | Deprecated, use `network.connection.state` instead. | `close_wait` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `network.connection.state`. |
-| <a id="system-processes-status" href="#system-processes-status">`system.processes.status`</a> | string | Deprecated, use `system.process.status` instead. | `running` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `system.process.status`. |
+| <a id="system-process-status" href="#system-process-status">`system.process.status`</a> | string | The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES) | `running` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `process.state`. |
+| <a id="system-processes-status" href="#system-processes-status">`system.processes.status`</a> | string | Deprecated, use `process.state` instead. | `running` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `process.state`. |
 
 ---
 
@@ -175,11 +156,22 @@ Deprecated system attributes.
 
 ---
 
+`system.process.status` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `defunct` | Defunct | ![Development](https://img.shields.io/badge/-development-blue) |
+| `running` | Running | ![Development](https://img.shields.io/badge/-development-blue) |
+| `sleeping` | Sleeping | ![Development](https://img.shields.io/badge/-development-blue) |
+| `stopped` | Stopped | ![Development](https://img.shields.io/badge/-development-blue) |
+
+---
+
 `system.processes.status` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|
-| `defunct` | defunct | ![Development](https://img.shields.io/badge/-development-blue) |
-| `running` | running | ![Development](https://img.shields.io/badge/-development-blue) |
-| `sleeping` | sleeping | ![Development](https://img.shields.io/badge/-development-blue) |
-| `stopped` | stopped | ![Development](https://img.shields.io/badge/-development-blue) |
+| `defunct` | Defunct | ![Development](https://img.shields.io/badge/-development-blue) |
+| `running` | Running | ![Development](https://img.shields.io/badge/-development-blue) |
+| `sleeping` | Sleeping | ![Development](https://img.shields.io/badge/-development-blue) |
+| `stopped` | Stopped | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -1111,7 +1111,19 @@ This metric is [recommended][MetricRecommended].
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`system.process.status`](/docs/registry/attributes/system.md) | string | The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES) | `running` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`process.state`](/docs/registry/attributes/process.md) | string | The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES) | `running` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`system.process.status`](/docs/registry/attributes/system.md) | string | The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES) | `running` | `Recommended` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `process.state`. |
+
+---
+
+`process.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `defunct` | Defunct | ![Development](https://img.shields.io/badge/-development-blue) |
+| `running` | Running | ![Development](https://img.shields.io/badge/-development-blue) |
+| `sleeping` | Sleeping | ![Development](https://img.shields.io/badge/-development-blue) |
+| `stopped` | Stopped | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
@@ -1119,10 +1131,10 @@ This metric is [recommended][MetricRecommended].
 
 | Value  | Description | Stability |
 |---|---|---|
-| `defunct` | defunct | ![Development](https://img.shields.io/badge/-development-blue) |
-| `running` | running | ![Development](https://img.shields.io/badge/-development-blue) |
-| `sleeping` | sleeping | ![Development](https://img.shields.io/badge/-development-blue) |
-| `stopped` | stopped | ![Development](https://img.shields.io/badge/-development-blue) |
+| `defunct` | Defunct | ![Development](https://img.shields.io/badge/-development-blue) |
+| `running` | Running | ![Development](https://img.shields.io/badge/-development-blue) |
+| `sleeping` | Sleeping | ![Development](https://img.shields.io/badge/-development-blue) |
+| `stopped` | Stopped | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/model/process/registry.yaml
+++ b/model/process/registry.yaml
@@ -258,6 +258,29 @@ groups:
         type: template[string]
         stability: development
         examples: ['ubuntu', '/usr/local/bin:/usr/bin']
+      - id: process.state
+        type:
+          members:
+            - id: running
+              value: 'running'
+              brief: Running
+              stability: development
+            - id: sleeping
+              value: 'sleeping'
+              brief: Sleeping
+              stability: development
+            - id: stopped
+              value: 'stopped'
+              brief: Stopped
+              stability: development
+            - id: defunct
+              value: 'defunct'
+              brief: Defunct
+              stability: development
+        stability: development
+        brief: >
+          The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES)
+        examples: ["running"]
   # process.linux* attribute group
   - id: registry.process.linux
     type: attribute_group

--- a/model/system/deprecated/registry-deprecated.yaml
+++ b/model/system/deprecated/registry-deprecated.yaml
@@ -9,20 +9,24 @@ groups:
           members:
             - id: running
               value: 'running'
+              brief: Running
               stability: development
             - id: sleeping
               value: 'sleeping'
+              brief: Sleeping
               stability: development
             - id: stopped
               value: 'stopped'
+              brief: Stopped
               stability: development
             - id: defunct
               value: 'defunct'
+              brief: Defunct
               stability: development
-        brief: "Deprecated, use `system.process.status` instead."
+        brief: "Deprecated, use `process.state` instead."
         deprecated:
           reason: renamed
-          renamed_to: system.process.status
+          renamed_to: process.state
         stability: development
         examples: ["running"]
       - id: system.cpu.state
@@ -105,3 +109,29 @@ groups:
         stability: development
         brief: "Deprecated, use `cpu.logical_number` instead."
         examples: [1]
+      - id: system.process.status
+        deprecated:
+          reason: renamed
+          renamed_to: process.state
+        type:
+          members:
+            - id: running
+              value: 'running'
+              brief: Running
+              stability: development
+            - id: sleeping
+              value: 'sleeping'
+              brief: Sleeping
+              stability: development
+            - id: stopped
+              value: 'stopped'
+              brief: Stopped
+              stability: development
+            - id: defunct
+              value: 'defunct'
+              brief: Defunct
+              stability: development
+        stability: development
+        brief: >
+          The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES)
+        examples: ["running"]

--- a/model/system/metrics.yaml
+++ b/model/system/metrics.yaml
@@ -505,6 +505,7 @@ groups:
     unit: "{process}"
     attributes:
       - ref: system.process.status
+      - ref: process.state
     entity_associations:
       - host
 

--- a/model/system/registry.yaml
+++ b/model/system/registry.yaml
@@ -143,28 +143,3 @@ groups:
         stability: development
         brief: "The filesystem mount path"
         examples: ["/mnt/data"]
-  # system.process.* attribute group
-  - id: registry.system.process
-    type: attribute_group
-    display_name: System Process Attributes
-    brief: "Describes System Process attributes"
-    attributes:
-      - id: system.process.status
-        type:
-          members:
-            - id: running
-              value: 'running'
-              stability: development
-            - id: sleeping
-              value: 'sleeping'
-              stability: development
-            - id: stopped
-              value: 'stopped'
-              stability: development
-            - id: defunct
-              value: 'defunct'
-              stability: development
-        stability: development
-        brief: >
-          The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES)
-        examples: ["running"]


### PR DESCRIPTION
Progresses #1803

## Changes

This renames `system.process.status` to `process.state` to follow semconv guidance.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
