### PR TITLE
[chore] Cleanup the General Log Page

### DIFF
--- a/docs/registry/attributes/log.md
+++ b/docs/registry/attributes/log.md
@@ -9,7 +9,7 @@
 
 ## General Log Attributes
 
-This document defines log attributes
+The I/O stream to which the log was emitted.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|

--- a/model/log/registry.yaml
+++ b/model/log/registry.yaml
@@ -3,7 +3,10 @@ groups:
     type: attribute_group
     display_name: General Log Attributes
     brief: >
-      This document defines log attributes
+      The I/O stream to which the log was emitted.
+    note: >
+      The following attributes do not describe entities that produce telemetry. Rather, they describe mechanisms of log transmission.
+      As such, these should be recorded as Log Record attributes when applicable. They should not be recorded as Resource attributes.
     attributes:
       - id: log.iostream
         stability: development
@@ -25,6 +28,9 @@ groups:
     display_name: Log File Attributes
     brief: >
       Attributes for a file to which log was emitted.
+    note: >
+      The following attributes do not describe entities that produce telemetry. Rather, they describe mechanisms of log transmission.
+      As such, these should be recorded as Log Record attributes when applicable. They should not be recorded as Resource attributes.
     attributes:
       - id: log.file.name
         type: string


### PR DESCRIPTION
## Changes

This moves some info from the general attributes to be defined on the yaml enabling it to be rendered in the registry and with #2710 it would also be rendered on the general page. 

By moving it yaml, we gain the header and description managed via the yaml hence reducing maintaince effort and ensure consistency.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
