### PR TITLE
Allow constants to be indicated via annotations

### DIFF
--- a/docs/browser/events.md
+++ b/docs/browser/events.md
@@ -24,6 +24,8 @@ The event name MUST be `browser.web_vital`.
 
 This event describes the website performance metrics introduced by Google, See [web vitals](https://web.dev/vitals).
 
+
+
 **Body fields:**
 
 :warning: Body fields will be moved to complex attributes once the

--- a/docs/database/mariadb.md
+++ b/docs/database/mariadb.md
@@ -26,14 +26,13 @@ linkTitle: MariaDB
 
 Spans representing calls to MariaDB adhere to the general [Semantic Conventions for Database Client Spans](/docs/database/README.md).
 
-`db.system.name` MUST be set to `"mariadb"` and SHOULD be provided **at span creation time**.
-
 **Span kind** SHOULD be `CLIENT`.
 
 **Span status** SHOULD follow the [Recording Errors](/docs/general/recording-errors.md) document.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
+| [`db.system.name`](/docs/registry/attributes/db.md) | string (Constant) | The database management system (DBMS) product as identified by the client instrumentation. | `mariadb` | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`db.namespace`](/docs/registry/attributes/db.md) | string | The database associated with the connection. [1] | `products`; `customers` | `Conditionally Required` If available without an additional network call. | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`db.response.status_code`](/docs/registry/attributes/db.md) | string | [Maria DB error code](https://mariadb.com/kb/en/mariadb-error-code-reference/) represented as a string. [2] | `1008`; `3058` | `Conditionally Required` If response has ended with warning or an error. | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | [`error.type`](/docs/registry/attributes/error.md) | string | Describes a class of error the operation ended with. [3] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | `Conditionally Required` If and only if the operation failed. | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
@@ -131,6 +130,7 @@ and SHOULD be provided **at span creation time** (if provided at all):
 * [`db.namespace`](/docs/registry/attributes/db.md)
 * [`db.query.summary`](/docs/registry/attributes/db.md)
 * [`db.query.text`](/docs/registry/attributes/db.md)
+* [`db.system.name`](/docs/registry/attributes/db.md)
 * [`server.address`](/docs/registry/attributes/server.md)
 * [`server.port`](/docs/registry/attributes/server.md)
 

--- a/model/database/spans.yaml
+++ b/model/database/spans.yaml
@@ -260,9 +260,15 @@ groups:
     span_kind: client
     brief: >
       Spans representing calls to MariaDB adhere to the general [Semantic Conventions for Database Client Spans](/docs/database/README.md).
-    note: >
-      `db.system.name` MUST be set to `"mariadb"` and SHOULD be provided **at span creation time**.
     attributes:
+      - ref: db.system.name
+        note: ""
+        examples: mariadb
+        requirement_level: required
+        sampling_relevant: true
+        annotations:
+          code_generation:
+            fixed_value: true
       - ref: db.namespace
         sampling_relevant: true
         brief: The database associated with the connection.

--- a/templates/registry/markdown/attribute_table.j2
+++ b/templates/registry/markdown/attribute_table.j2
@@ -8,6 +8,8 @@
 {#- Macro for creating attribute table -#}
 {% macro generate(attributes, tag_filter, attribute_registry_base_url, lineage_attributes) %}{% if (tag_filter | length == 0) %}{% set filtered_attributes = attributes %}{% else %}{% set filtered_attributes = attributes | selectattr("tag", "in", tag_filter) %}{% endif %}{% if (filtered_attributes is defined) and (filtered_attributes | length > 0) %}| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-{% for attribute in filtered_attributes | attribute_sort %}| {{ attrs.name_with_link(attribute, attribute_registry_base_url, lineage_attributes) }} | {{ attrs.type(attribute) }} | {{ attribute.brief | trim }}{{ notes.add({"note": attribute.note, "name": attrs.name(attribute)}) }} | {{ examples.format(attribute) | trim }} | {{ requirement.render({"level": attribute.requirement_level, "name": attrs.name(attribute)}, notes) | trim }} | {{ stability.badge(attribute.stability, attribute.deprecated, attribute.brief) | trim }} |
-{% endfor %}{{ notes.render() }}{{ sampling.snippet(filtered_attributes, attribute_registry_base_url, lineage_attributes) }}{{ enums.tables(filtered_attributes | selectattr("type", "mapping"), notes) }}
-{% endif %}{% endmacro %}
+{% for attribute in filtered_attributes | attribute_sort %}| {{ attrs.name_with_link(attribute, attribute_registry_base_url, lineage_attributes) }} | {{ attrs.type(attribute) }} {% if attribute.annotations and attribute.annotations.code_generation.fixed_value %}(Constant) {% endif %}| {{ attribute.brief | trim }}{{ notes.add({"note": attribute.note, "name": attrs.name(attribute)}) }} | {{ examples.format(attribute) | trim }} | {{ requirement.render({"level": attribute.requirement_level, "name": attrs.name(attribute)}, notes) | trim }} | {{ stability.badge(attribute.stability, attribute.deprecated, attribute.brief) | trim }} |
+{% endfor %}{{ notes.render() }}{{ sampling.snippet(filtered_attributes, attribute_registry_base_url, lineage_attributes) }}
+{{ enums.tables(filtered_attributes | selectattr("type", "mapping"), notes) | trim }}
+{% endif %}
+{% endmacro %}

--- a/templates/registry/markdown/enum_macros.j2
+++ b/templates/registry/markdown/enum_macros.j2
@@ -1,7 +1,7 @@
 {% import 'stability.j2' as stability %}
 {% macro filter(member) %}{% if (member.deprecated is undefined or member.deprecated is none) %}{{ "True" }}{% else %}{{ "False" }}{% endif %}{% endmacro %}
 {% macro table(enum, notes) %}
----
+{% if enum.annotations and enum.annotations.code_generation.fixed_value %}{% else %}---
 
 `{{enum.name}}` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
@@ -10,7 +10,7 @@
 {% for espec in enum.type.members | sort(attribute='value') %}
 {%- if filter(espec) == "True" -%}
 | `{{ espec.value }}` | {{ (espec.brief or espec.id) | trim }}{{ notes.add({"note": espec.note}) }} | {{ stability.badge(espec.stability, espec.deprecated, espec.brief) }} |
-{% endif %}{% endfor %}{{ notes.render() }}{% endmacro %}
+{% endif %}{% endfor %}{{ notes.render() }}{% endif %}{% endmacro %}
 {% macro tables(enums, notes) -%}
 {% for enum in enums | sort(attribute="name") -%}
 {{ table(enum, notes) -}}

--- a/templates/registry/markdown/snippet.md.j2
+++ b/templates/registry/markdown/snippet.md.j2
@@ -12,23 +12,31 @@
 {%- set entity_registry_base_url=params.registry_base_url~"entities" %}
 
 {% macro generate_event(group) -%}
-{{ event.header(group) }}{{ generate_attributes(group) }}{{ event.body(group.body) }}{% endmacro -%}
+{{ event.header(group) }}{{ generate_attributes(group) | trim }}
+
+{{ event.body(group.body) }}{% endmacro -%}
 {%- macro generate_resource(group) -%}
 {{ resource.header(group) }}{{ generate_attributes(group) }}{% endmacro -%}
 {%- macro generate_metric(group, entity_registry_base_url) -%}
 {{ mt.generate(group, entity_registry_base_url) }}
-{{ generate_attributes(group) }}{% endmacro -%}
+{{ generate_attributes(group) | trim}}
+
+{% endmacro -%}
 {%- macro generate_span(group) -%}
 {{ span.header(group) }}{{ generate_attributes(group) }}{% endmacro -%}
 {%- macro generate_attributes(group) -%}
-{{ at.generate(group.attributes, tag_filter, attribute_registry_base_url, group.lineage.attributes) }}{% endmacro -%}
+{{ at.generate(group.attributes, tag_filter, attribute_registry_base_url, group.lineage.attributes) | trim }}
+
+{% endmacro -%}
 
 {% if group.type == "event" -%}
-{{ generate_event(group) -}}
+{{ generate_event(group) | trim -}}{{"\n\n"}}
+
 {%- elif group.type == "resource" or group.type == "entity" -%}
 {{ generate_resource(group) }}
 {%- elif group.type == "metric" -%}
-{{ generate_metric(group, entity_registry_base_url) }}
+{{ generate_metric(group, entity_registry_base_url) | trim }}{{"\n\n"}}
+
 {%- elif group.type == "span" -%}
 {{ generate_span(group) }}
 {%- else -%}


### PR DESCRIPTION
## Changes

Introduce meaningful annotations for indicating constants ie db.system.name

With this change we gain:
- Attribute is listed in the attribute table including link to definition
- Attribute is included in sampling relevant list if applicable
- The need to override the note with info about expected db system etc is removed
- Code generation could enforce the value to be set
- reduced copy paste as attribute can now be defined much closer to the base item being extended.

What this solution doesn't solve but final solution will need to
- Restricting enum to subset of values
- Multi usage of metrics which requires different constant values

This should not be seen as the final solution but a stepping stone which offers an improvement to the status quo.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
