### PR TITLE
Add link to OTel roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ provide meaning to data when collecting, producing and consuming it.
 The human-readable version of the semantic conventions resides in the [docs](docs/README.md) folder.
 Major parts of these Markdown documents are generated from the YAML definitions located in the [model](model/README.md) folder.
 
+## Roadmap
+
+For an overview of the current focus areas and active initiatives
+the Semantic Conventions project is committed to, check out the
+[OpenTelemetry Roadmap](https://github.com/orgs/open-telemetry/projects/158/views/1?filterQuery=sig%3A%22Semantic+Conventions%3A+*%22).
+
+> [!IMPORTANT]
+> Due to limited maintainer and reviewer bandwidth, priority is given to initiatives
+> listed in the roadmap. Contributions outside these areas may be delayed or
+> not accepted unless they are formally added to the roadmap through the
+> established project proposal process.
+
 ## Areas and Special Interest Groups
 
 See: [Areas](AREAS.md)


### PR DESCRIPTION
Fixes #2698

## Changes

This adds a link to the OTel roadmap, filtering for Semconv initiatives. I also added a note about the fact that maintainers/sigs are focused on those areas in the roadmap and other requests may not be actively looked. This note is just a first step, coming up we hope to add automation to flag/label such cases. 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] Links to the prototypes or existing instrumentations (when adding or changing conventions)
