### PR TITLE
feat: Define app.screen.name

### DIFF
--- a/.chloggen/feat_screen-name.yaml
+++ b/.chloggen/feat_screen-name.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: app
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `app.screen.name` attribute to capture application screen names.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2743]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/app/app-events.md
+++ b/docs/app/app-events.md
@@ -43,9 +43,9 @@ The `app.screen.click` event can be used to indicate that a user has clicked or 
 |---|---|---|---|---|---|
 | [`app.screen.coordinate.x`](/docs/registry/attributes/app.md) | int | The x (horizontal) coordinate of a screen coordinate, in screen pixels. | `0`; `131` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`app.screen.coordinate.y`](/docs/registry/attributes/app.md) | int | The y (vertical) component of a screen coordinate, in screen pixels. | `12`; `99` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`app.screen.name`](/docs/registry/attributes/app.md) | string | The name of an application screen. [1] | `Home`; `Cart`; `MainActivity` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`app.screen.name`](/docs/registry/attributes/app.md) | string | The name of an application screen. [1] | `/products`; `MainActivity`; `ProductDetailFragment`; `ProfileView`; `ProfileViewController` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[1] `app.screen.name`:** A screen represents a distinct view or page within an application,  typically containing multiple widgets or UI components.
+**[1] `app.screen.name`:** A screen represents a distinct view or page within an application,  typically containing multiple widgets or UI components. A screen  is larger in scope than individual widgets but may not fill the  entire device display - multiple screens can coexist on the same  display simultaneously.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -74,12 +74,12 @@ Use this event to indicate that visual application component has been clicked, t
 | [`app.widget.id`](/docs/registry/attributes/app.md) | string | An identifier that uniquely differentiates this widget from other widgets in the same application. [1] | `f9bc787d-ff05-48ad-90e1-fca1d46130b3`; `submit_order_1829` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`app.screen.coordinate.x`](/docs/registry/attributes/app.md) | int | The x (horizontal) coordinate of a screen coordinate, in screen pixels. | `0`; `131` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`app.screen.coordinate.y`](/docs/registry/attributes/app.md) | int | The y (vertical) component of a screen coordinate, in screen pixels. | `12`; `99` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`app.screen.name`](/docs/registry/attributes/app.md) | string | The name of an application screen. [2] | `Home`; `Cart`; `MainActivity` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`app.screen.name`](/docs/registry/attributes/app.md) | string | The name of an application screen. [2] | `/products`; `MainActivity`; `ProductDetailFragment`; `ProfileView`; `ProfileViewController` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`app.widget.name`](/docs/registry/attributes/app.md) | string | The name of an application widget. [3] | `submit`; `attack`; `Clear Cart` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 **[1] `app.widget.id`:** A widget is an application component, typically an on-screen visual GUI element.
 
-**[2] `app.screen.name`:** A screen represents a distinct view or page within an application,  typically containing multiple widgets or UI components.
+**[2] `app.screen.name`:** A screen represents a distinct view or page within an application, typically containing multiple widgets or UI components. A screen is larger in scope than individual widgets but may not fill the entire device display - multiple screens can coexist on the same display simultaneously.
 
 **[3] `app.widget.name`:** A widget is an application component, typically an on-screen visual GUI element.
 

--- a/docs/app/app-events.md
+++ b/docs/app/app-events.md
@@ -43,6 +43,9 @@ The `app.screen.click` event can be used to indicate that a user has clicked or 
 |---|---|---|---|---|---|
 | [`app.screen.coordinate.x`](/docs/registry/attributes/app.md) | int | The x (horizontal) coordinate of a screen coordinate, in screen pixels. | `0`; `131` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`app.screen.coordinate.y`](/docs/registry/attributes/app.md) | int | The y (vertical) component of a screen coordinate, in screen pixels. | `12`; `99` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`app.screen.name`](/docs/registry/attributes/app.md) | string | The name of an application screen. [1] | `Home`; `Cart`; `MainActivity` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
+
+**[1] `app.screen.name`:** A screen represents a distinct view or page within an application,  typically containing multiple widgets or UI components.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -71,11 +74,14 @@ Use this event to indicate that visual application component has been clicked, t
 | [`app.widget.id`](/docs/registry/attributes/app.md) | string | An identifier that uniquely differentiates this widget from other widgets in the same application. [1] | `f9bc787d-ff05-48ad-90e1-fca1d46130b3`; `submit_order_1829` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`app.screen.coordinate.x`](/docs/registry/attributes/app.md) | int | The x (horizontal) coordinate of a screen coordinate, in screen pixels. | `0`; `131` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`app.screen.coordinate.y`](/docs/registry/attributes/app.md) | int | The y (vertical) component of a screen coordinate, in screen pixels. | `12`; `99` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`app.widget.name`](/docs/registry/attributes/app.md) | string | The name of an application widget. [2] | `submit`; `attack`; `Clear Cart` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`app.screen.name`](/docs/registry/attributes/app.md) | string | The name of an application screen. [2] | `Home`; `Cart`; `MainActivity` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`app.widget.name`](/docs/registry/attributes/app.md) | string | The name of an application widget. [3] | `submit`; `attack`; `Clear Cart` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 **[1] `app.widget.id`:** A widget is an application component, typically an on-screen visual GUI element.
 
-**[2] `app.widget.name`:** A widget is an application component, typically an on-screen visual GUI element.
+**[2] `app.screen.name`:** A screen represents a distinct view or page within an application,  typically containing multiple widgets or UI components.
+
+**[3] `app.widget.name`:** A widget is an application component, typically an on-screen visual GUI element.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/docs/registry/attributes/app.md
+++ b/docs/registry/attributes/app.md
@@ -16,8 +16,9 @@ Describes attributes related to client-side applications (e.g. web apps or mobil
 | <a id="app-jank-threshold" href="#app-jank-threshold">`app.jank.threshold`</a> | double | The minimum rendering threshold for this jank, in seconds. | `0.016`; `0.7`; `1.024` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="app-screen-coordinate-x" href="#app-screen-coordinate-x">`app.screen.coordinate.x`</a> | int | The x (horizontal) coordinate of a screen coordinate, in screen pixels. | `0`; `131` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="app-screen-coordinate-y" href="#app-screen-coordinate-y">`app.screen.coordinate.y`</a> | int | The y (vertical) component of a screen coordinate, in screen pixels. | `12`; `99` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="app-widget-id" href="#app-widget-id">`app.widget.id`</a> | string | An identifier that uniquely differentiates this widget from other widgets in the same application. [3] | `f9bc787d-ff05-48ad-90e1-fca1d46130b3`; `submit_order_1829` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="app-widget-name" href="#app-widget-name">`app.widget.name`</a> | string | The name of an application widget. [4] | `submit`; `attack`; `Clear Cart` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="app-screen-name" href="#app-screen-name">`app.screen.name`</a> | string | The name of an application screen. [3] | `Home`; `Cart`; `MainActivity` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="app-widget-id" href="#app-widget-id">`app.widget.id`</a> | string | An identifier that uniquely differentiates this widget from other widgets in the same application. [4] | `f9bc787d-ff05-48ad-90e1-fca1d46130b3`; `submit_order_1829` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="app-widget-name" href="#app-widget-name">`app.widget.name`</a> | string | The name of an application widget. [5] | `submit`; `attack`; `Clear Cart` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 **[1] `app.installation.id`:** Its value SHOULD persist across launches of the same application installation, including through application upgrades.
 It SHOULD change if the application is uninstalled or if all applications of the vendor are uninstalled.
@@ -39,6 +40,8 @@ More information about Android identifier best practices can be found in the [An
 
 **[2] `app.jank.frame_count`:** Depending on platform limitations, the value provided MAY be approximation.
 
-**[3] `app.widget.id`:** A widget is an application component, typically an on-screen visual GUI element.
+**[3] `app.screen.name`:** A screen represents a distinct view or page within an application,  typically containing multiple widgets or UI components.
 
-**[4] `app.widget.name`:** A widget is an application component, typically an on-screen visual GUI element.
+**[4] `app.widget.id`:** A widget is an application component, typically an on-screen visual GUI element.
+
+**[5] `app.widget.name`:** A widget is an application component, typically an on-screen visual GUI element.

--- a/docs/registry/attributes/app.md
+++ b/docs/registry/attributes/app.md
@@ -16,7 +16,7 @@ Describes attributes related to client-side applications (e.g. web apps or mobil
 | <a id="app-jank-threshold" href="#app-jank-threshold">`app.jank.threshold`</a> | double | The minimum rendering threshold for this jank, in seconds. | `0.016`; `0.7`; `1.024` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="app-screen-coordinate-x" href="#app-screen-coordinate-x">`app.screen.coordinate.x`</a> | int | The x (horizontal) coordinate of a screen coordinate, in screen pixels. | `0`; `131` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="app-screen-coordinate-y" href="#app-screen-coordinate-y">`app.screen.coordinate.y`</a> | int | The y (vertical) component of a screen coordinate, in screen pixels. | `12`; `99` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="app-screen-name" href="#app-screen-name">`app.screen.name`</a> | string | The name of an application screen. [3] | `Home`; `Cart`; `MainActivity` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="app-screen-name" href="#app-screen-name">`app.screen.name`</a> | string | The name of an application screen. [3] | `/products`; `MainActivity`; `ProductDetailFragment`; `ProfileView`; `ProfileViewController` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="app-widget-id" href="#app-widget-id">`app.widget.id`</a> | string | An identifier that uniquely differentiates this widget from other widgets in the same application. [4] | `f9bc787d-ff05-48ad-90e1-fca1d46130b3`; `submit_order_1829` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="app-widget-name" href="#app-widget-name">`app.widget.name`</a> | string | The name of an application widget. [5] | `submit`; `attack`; `Clear Cart` | ![Development](https://img.shields.io/badge/-development-blue) |
 
@@ -40,7 +40,7 @@ More information about Android identifier best practices can be found in the [An
 
 **[2] `app.jank.frame_count`:** Depending on platform limitations, the value provided MAY be approximation.
 
-**[3] `app.screen.name`:** A screen represents a distinct view or page within an application,  typically containing multiple widgets or UI components.
+**[3] `app.screen.name`:** A screen represents a distinct view or page within an application, typically containing multiple widgets or UI components. A screen is larger in scope than individual widgets but may not fill the entire device display - multiple screens can coexist on the same display simultaneously.
 
 **[4] `app.widget.id`:** A widget is an application component, typically an on-screen visual GUI element.
 

--- a/model/app/events.yaml
+++ b/model/app/events.yaml
@@ -19,6 +19,8 @@ groups:
         requirement_level: required
       - ref: app.screen.coordinate.y
         requirement_level: required
+      - ref: app.screen.name
+        requirement_level: opt_in
   - id: event.app.widget.click
     stability: development
     type: event
@@ -36,6 +38,8 @@ groups:
       - ref: app.screen.coordinate.x
         requirement_level: opt_in
       - ref: app.screen.coordinate.y
+        requirement_level: opt_in
+      - ref: app.screen.name
         requirement_level: opt_in
   - id: event.app.jank
     stability: development

--- a/model/app/registry.yaml
+++ b/model/app/registry.yaml
@@ -59,6 +59,14 @@ groups:
           The y (vertical) component of a screen coordinate, in screen pixels.
         stability: development
         examples: [ 12, 99 ]
+      - id: app.screen.name
+        type: string
+        stability: development
+        brief: The name of an application screen.
+        note: >
+          A screen represents a distinct view or page within an application, 
+          typically containing multiple widgets or UI components.
+        examples: ["Home", "Cart", "MainActivity"]
       - id: app.widget.id
         type: string
         stability: development

--- a/model/app/registry.yaml
+++ b/model/app/registry.yaml
@@ -65,8 +65,11 @@ groups:
         brief: The name of an application screen.
         note: >
           A screen represents a distinct view or page within an application, 
-          typically containing multiple widgets or UI components.
-        examples: ["Home", "Cart", "MainActivity"]
+          typically containing multiple widgets or UI components. A screen 
+          is larger in scope than individual widgets but may not fill the 
+          entire device display - multiple screens can coexist on the same 
+          display simultaneously.
+        examples: ["/products", "MainActivity", "ProductDetailFragment", "ProfileView", "ProfileViewController"]
       - id: app.widget.id
         type: string
         stability: development


### PR DESCRIPTION
Fixes #2743

## Changes

There is currently no semantic convention for capturing application screen names. This PR proposes `app.screen.name`, as discussed during Client SIG on [07/22/2025](https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w/edit?tab=t.0#heading=h.cgwi8r81t23c). 


## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [X] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
