### PR TITLE
Add CICD conventions for logs

### DIFF
--- a/.chloggen/1714-cicd-logs-guidance.yaml
+++ b/.chloggen/1714-cicd-logs-guidance.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: cicd
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add guidance on CI/CD logs
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1714]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/cicd/README.md
+++ b/docs/cicd/README.md
@@ -12,5 +12,6 @@ Semantic conventions for CICD are defined for the following signals:
 
 * [CICD Spans](cicd-spans.md): Semantic Conventions for CICD *spans*.
 * [CICD Metrics](cicd-metrics.md): Semantic Conventions for CICD *metrics*.
+* [CICD Logs](cicd-logs.md): Semantic Conventions for CICD *logs*.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/cicd/cicd-logs.md
+++ b/docs/cicd/cicd-logs.md
@@ -1,0 +1,22 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Logs
+--->
+
+# Semantic conventions for CICD logs
+
+**Status**: [Development][DocumentStatus]
+
+CI/CD systems emit logs as part of pipeline runs, usually consisting of the stdout/stderr
+of any processes launched as part of the pipeline run.
+
+The controller of any CI/CD system may also emit logs (e.g. "Starting pipeline run").
+
+Any logs emitted by CI/CD systems SHOULD follow the [General Semantic Conventions for logs](/docs/general/logs.md).
+
+When a trace context is available (cf. [CICD Spans](cicd-spans.md)) then emitted logs SHOULD be correlated to the execution context as defined in the [logs specification](https://opentelemetry.io/docs/specs/otel/logs/#log-correlation).
+
+Any resources of the [CICD and VCS resource conventions][cicdres] that apply SHOULD be used.
+
+[cicdres]: /docs/resource/cicd.md (CICD and VCS resource conventions)
+
+[DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status


### PR DESCRIPTION
Fixes #1714

## Changes

For discoverability we give a short description of CI/CD logs and link to general log SemConv, the specification for log correlation with spans and CICD resources.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* Links to the prototypes or existing instrumentations (when adding or changing conventions) → NA
