### PR TITLE
Add `start_time ` and `end_time` to session events

### DIFF
--- a/.chloggen/feat_sessions.yaml
+++ b/.chloggen/feat_sessions.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: session
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `start_time` and `end_time` to session events to represent true lifecycle.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2769]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+  Currently, we only record `timeUnixNano` which marks when session events are observed. However, sessions start
+  and end based on expiration, meaning their true lifecycle is not captured. To address this, we will add
+  `start_time` and `end_time` to represent true session lifecycle.

--- a/docs/general/session.md
+++ b/docs/general/session.md
@@ -30,8 +30,10 @@ backends can link the two sessions (see [Session Start Event](#event-sessionstar
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`session.id`](/docs/registry/attributes/session.md) | string | A unique id to identify a session. | `00112233-4455-6677-8899-aabbccddeeff` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`session.id`](/docs/registry/attributes/session.md) | string | A unique id to identify a session. | `00112233-4455-6677-8899-aabbccddeeff` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`session.end_time`](/docs/registry/attributes/session.md) | int | The timestamp when the session expired (in unix nanoseconds). | `1757348656658491100` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`session.previous_id`](/docs/registry/attributes/session.md) | string | The previous `session.id` for this user, when known. | `00112233-4455-6677-8899-aabbccddeeff` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`session.start_time`](/docs/registry/attributes/session.md) | int | The timestamp when the session started (in unix nanoseconds). | `1757348655674899200` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -61,6 +63,7 @@ When the `session.start` event contains both `session.id` and `session.previous_
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`session.id`](/docs/registry/attributes/session.md) | string | The ID of the new session being started. | `00112233-4455-6677-8899-aabbccddeeff` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`session.start_time`](/docs/registry/attributes/session.md) | int | The true timestamp of when the session started. | `1757348655674899200` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`session.previous_id`](/docs/registry/attributes/session.md) | string | The previous `session.id` for this user, when known. | `00112233-4455-6677-8899-aabbccddeeff` | `Conditionally Required` [1] | ![Development](https://img.shields.io/badge/-development-blue) |
 
 **[1] `session.previous_id`:** If the new session is being created as a continuation of a previous session, the `session.previous_id` SHOULD be included in the event. The `session.id` and `session.previous_id` attributes MUST have different values.
@@ -89,7 +92,12 @@ For instrumentation that tracks user behavior during user sessions, a `session.e
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
+| [`session.end_time`](/docs/registry/attributes/session.md) | int | The true timestamp of when the session expired after a period of inactivity. | `1757348656658491100` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`session.id`](/docs/registry/attributes/session.md) | string | The ID of the session being ended. | `00112233-4455-6677-8899-aabbccddeeff` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`session.start_time`](/docs/registry/attributes/session.md) | int | The true timestamp of when the session started. | `1757348655674899200` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`session.previous_id`](/docs/registry/attributes/session.md) | string | The previous `session.id` for this user, when known. | `00112233-4455-6677-8899-aabbccddeeff` | `Conditionally Required` [1] | ![Development](https://img.shields.io/badge/-development-blue) |
+
+**[1] `session.previous_id`:** If the new session is being created as a continuation of a previous session, the `session.previous_id` SHOULD be included in the event. The `session.id` and `session.previous_id` attributes MUST have different values.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->

--- a/docs/registry/attributes/session.md
+++ b/docs/registry/attributes/session.md
@@ -8,8 +8,11 @@
 Session is defined as the period of time encompassing all activities performed by the application and the actions executed by the end user.
 Consequently, a Session is represented as a collection of Logs, Events, and Spans emitted by the Client Application throughout the Session's duration. Each Session is assigned a unique identifier, which is included as an attribute in the Logs, Events, and Spans generated during the Session's lifecycle.
 When a session reaches end of life, typically due to user inactivity or session timeout, a new session identifier will be assigned. The previous session identifier may be provided by the instrumentation so that telemetry backends can link the two sessions.
+When a session expires, then the end time is calculated by the expiry timestamp minus the session timeout interval. This is not necessarily the same as when session events are recorded, since they are only created after a period of inactivity. To account for this difference, session `start_time` and `end_time` represent the true session lifecycle, whereas `timeUnixNano` marks when session events are observed.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
+| <a id="session-end-time" href="#session-end-time">`session.end_time`</a> | int | The timestamp when the session expired (in unix nanoseconds). | `1757348656658491100` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="session-id" href="#session-id">`session.id`</a> | string | A unique id to identify a session. | `00112233-4455-6677-8899-aabbccddeeff` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="session-previous-id" href="#session-previous-id">`session.previous_id`</a> | string | The previous `session.id` for this user, when known. | `00112233-4455-6677-8899-aabbccddeeff` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="session-start-time" href="#session-start-time">`session.start_time`</a> | int | The timestamp when the session started (in unix nanoseconds). | `1757348655674899200` | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/model/session/common.yaml
+++ b/model/session/common.yaml
@@ -12,8 +12,16 @@ groups:
       When a session reaches end of life, typically due to user inactivity or session timeout, a new session identifier
       will be assigned. The previous session identifier may be provided by the instrumentation so that telemetry
       backends can link the two sessions.
+
+      When a session expires, then the end time is defined as the moment when the session expired after a period of inactivity,
+      which is not necessarily the same moment as when the session end was observed. To account for this difference, session
+      `start_time` and `end_time` represent the true session lifecycle, whereas `timeUnixNano` represents when these events are observed.
     attributes:
       - ref: session.id
-        requirement_level: opt_in
+        requirement_level: required
       - ref: session.previous_id
+        requirement_level: opt_in
+      - ref: session.start_time
+        requirement_level: opt_in
+      - ref: session.end_time
         requirement_level: opt_in

--- a/model/session/events.yaml
+++ b/model/session/events.yaml
@@ -26,6 +26,9 @@ groups:
             the `session.previous_id` SHOULD be included in the event. The `session.id` and `session.previous_id`
             attributes MUST have different values.
         brief: The previous `session.id` for this user, when known.
+      - ref: session.start_time
+        requirement_level: required
+        brief: The true timestamp of when the session started.
   - id: event.session.end
     stability: development
     type: event
@@ -40,3 +43,16 @@ groups:
       - ref: session.id
         requirement_level: required
         brief: The ID of the session being ended.
+      - ref: session.previous_id
+        requirement_level:
+          conditionally_required: >
+            If the new session is being created as a continuation of a previous session,
+            the `session.previous_id` SHOULD be included in the event. The `session.id` and `session.previous_id`
+            attributes MUST have different values.
+        brief: The previous `session.id` for this user, when known.
+      - ref: session.start_time
+        requirement_level: required
+        brief: The true timestamp of when the session started.
+      - ref: session.end_time
+        requirement_level: required
+        brief: The true timestamp of when the session expired after a period of inactivity.

--- a/model/session/registry.yaml
+++ b/model/session/registry.yaml
@@ -13,6 +13,11 @@ groups:
       When a session reaches end of life, typically due to user inactivity or session timeout, a new session identifier
       will be assigned. The previous session identifier may be provided by the instrumentation so that telemetry
       backends can link the two sessions.
+
+      When a session expires, then the end time is calculated by the expiry timestamp minus the session timeout interval.
+      This is not necessarily the same as when session events are recorded, since they are only created after a period of inactivity.
+      To account for this difference, session `start_time` and `end_time` represent the true session lifecycle, whereas `timeUnixNano`
+      marks when session events are observed.
     attributes:
       - id: session.id
         type: string
@@ -24,3 +29,13 @@ groups:
         stability: development
         brief: "The previous `session.id` for this user, when known."
         examples: "00112233-4455-6677-8899-aabbccddeeff"
+      - id: session.start_time
+        type: int
+        stability: development
+        brief: "The timestamp when the session started (in unix nanoseconds)."
+        examples: 1757348655674899200
+      - id: session.end_time
+        type: int
+        stability: development
+        brief: "The timestamp when the session expired (in unix nanoseconds)."
+        examples: 1757348656658491100


### PR DESCRIPTION
Fixes #2769

## Changes

Sessions start and end events are currently marked by their observed timestamps; however, these do not represent the true session lifecycle. Session are implement with time-based expirations that represent a user session. This means that session `start_time` and `end_times` occur earlier than when they are finally logged. 

1. `timeUnixNano` - timestamp of when the session start and end events are logged. 
2. `session.start_time` - timestamp of when the session was first created. This occurs either on the initial app start, or when a previous session was observed to be expired. 
3. `session.end_time` - timestamp of when the session ended. This can be thought of as the last timestamp during which the session was extended, or as session expire time minus session timeout interval. 

## Diff

`session.start` event
1. Add `session.start_time`

`session.end` event
1. Add `session.start_time`
2. Add `session.end_time`
3. Add `session.previous_id` (seemed strange that this was previously missing).

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ x ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ x ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ x ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
