### PR TITLE
Add triage document

### DIFF
--- a/issue-management.md
+++ b/issue-management.md
@@ -53,8 +53,9 @@ graph TD
     SIG_REJECTED --> REJECTED([Label: triage:rejected:declined])
     L_READY_SIG([Label: **triage:accepted:ready-with-sig**])
 
-    NEEDS_INFO -->|No, small in scope| L_READY([Label: **triage:accepted:ready**])
-    NEEDS_INFO -->|No, SIG issue | L_READY_SIG
+    NEEDS_INFO -->|No| L_CHECK_SCOPE{What's the scope of the issue?}
+    L_CHECK_SCOPE -->|Small or Trivial| L_READY([Label: **triage:accepted:ready**])
+    L_CHECK_SCOPE -->|Other| SIG_EXISTS{Does a SIG/project exist?}
 
     %% Define Classes
     classDef styleStart fill:#c6dcff,stroke:#498bf5,stroke-width:2px,color:#000,font-size:1.2em;


### PR DESCRIPTION
Fixes #2699

## Changes

This PR introduces the issue management document, where the issue triage workflow is defined, along with roles and labels involved in the process.

The goal is to get agreement on this first, and next start implementing automation to enforce it. 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
