### PR TITLE
[cloud] Add Digitalocean as cloud entity

### DIFF
--- a/docs/registry/attributes/cloud.md
+++ b/docs/registry/attributes/cloud.md
@@ -63,6 +63,7 @@ The following well-known definitions MUST be used if you set this attribute and 
 | `azure.functions` | Azure Functions | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.openshift` | Azure Red Hat OpenShift | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.vm` | Azure Virtual Machines | ![Development](https://img.shields.io/badge/-development-blue) |
+| `digitalocean_compute` | Compute on DigitalOcean | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp_app_engine` | Google Cloud App Engine (GAE) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp_bare_metal_solution` | Google Bare Metal Solution (BMS) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp_cloud_functions` | Google Cloud Functions (GCF) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -86,6 +87,7 @@ The following well-known definitions MUST be used if you set this attribute and 
 | `alibaba_cloud` | Alibaba Cloud | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws` | Amazon Web Services | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure` | Microsoft Azure | ![Development](https://img.shields.io/badge/-development-blue) |
+| `digitalocean` | DigitalOcean | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp` | Google Cloud Platform | ![Development](https://img.shields.io/badge/-development-blue) |
 | `heroku` | Heroku Platform as a Service | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm_cloud` | IBM Cloud | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/registry/entities/cloud.md
+++ b/docs/registry/entities/cloud.md
@@ -74,6 +74,7 @@ The following well-known definitions MUST be used if you set this attribute and 
 | `azure.functions` | Azure Functions | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.openshift` | Azure Red Hat OpenShift | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.vm` | Azure Virtual Machines | ![Development](https://img.shields.io/badge/-development-blue) |
+| `digitalocean_compute` | Compute on DigitalOcean | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp_app_engine` | Google Cloud App Engine (GAE) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp_bare_metal_solution` | Google Bare Metal Solution (BMS) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp_cloud_functions` | Google Cloud Functions (GCF) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -97,6 +98,7 @@ The following well-known definitions MUST be used if you set this attribute and 
 | `alibaba_cloud` | Alibaba Cloud | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws` | Amazon Web Services | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure` | Microsoft Azure | ![Development](https://img.shields.io/badge/-development-blue) |
+| `digitalocean` | DigitalOcean | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp` | Google Cloud Platform | ![Development](https://img.shields.io/badge/-development-blue) |
 | `heroku` | Heroku Platform as a Service | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm_cloud` | IBM Cloud | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/resource/cloud.md
+++ b/docs/resource/cloud.md
@@ -70,6 +70,7 @@ The following well-known definitions MUST be used if you set this attribute and 
 | `azure.functions` | Azure Functions | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.openshift` | Azure Red Hat OpenShift | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure.vm` | Azure Virtual Machines | ![Development](https://img.shields.io/badge/-development-blue) |
+| `digitalocean_compute` | Compute on DigitalOcean | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp_app_engine` | Google Cloud App Engine (GAE) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp_bare_metal_solution` | Google Bare Metal Solution (BMS) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp_cloud_functions` | Google Cloud Functions (GCF) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -93,6 +94,7 @@ The following well-known definitions MUST be used if you set this attribute and 
 | `alibaba_cloud` | Alibaba Cloud | ![Development](https://img.shields.io/badge/-development-blue) |
 | `aws` | Amazon Web Services | ![Development](https://img.shields.io/badge/-development-blue) |
 | `azure` | Microsoft Azure | ![Development](https://img.shields.io/badge/-development-blue) |
+| `digitalocean` | DigitalOcean | ![Development](https://img.shields.io/badge/-development-blue) |
 | `gcp` | Google Cloud Platform | ![Development](https://img.shields.io/badge/-development-blue) |
 | `heroku` | Heroku Platform as a Service | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm_cloud` | IBM Cloud | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/model/cloud/registry.yaml
+++ b/model/cloud/registry.yaml
@@ -20,6 +20,10 @@ groups:
               value: 'azure'
               brief: 'Microsoft Azure'
               stability: development
+            - id: 'digitalocean'
+              value: 'digitalocean'
+              brief: 'DigitalOcean'
+              stability: development
             - id: 'gcp'
               value: 'gcp'
               brief: 'Google Cloud Platform'
@@ -231,6 +235,10 @@ groups:
               annotations:
                 code_generation:
                   exclude: true
+            - id: digitalocean_compute
+              value: 'digitalocean_compute'
+              brief: Compute on DigitalOcean
+              stability: development
             - id: gcp_bare_metal_solution
               value: 'gcp_bare_metal_solution'
               brief: Google Bare Metal Solution (BMS)


### PR DESCRIPTION
Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42804

## Changes

This PR introduces new cloud.provider and cloud.platform values for DigitalOcean (digitalocean) and DigitalOcean Compute (digitalocean_compute).
These additions align with the new DigitalOcean resource detection processor in the Collector and ensure consistent attribute naming across all resources.

## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [X] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
