### PR TITLE
[editorial] Add link to "how to write" and fix title

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,4 +44,7 @@ Semantic Conventions by signals:
 * [Resource](resource/README.md): Semantic Conventions for resources.
 * [Trace](general/trace.md): Semantic Conventions for traces and spans.
 
-Also see, [Non-normative supplementary information](non-normative/README.md).
+Also see:
+
+* [How to write semantic conventions](how-to-write-conventions/README.md)
+* [Non-normative supplementary information](non-normative/README.md)

--- a/docs/how-to-write-conventions/README.md
+++ b/docs/how-to-write-conventions/README.md
@@ -1,8 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: How to define new semantic conventions
+linkTitle: How to write conventions
 --->
 
-# How to define new semantic conventions
+# How to write semantic conventions
 
 **Status**: [Development][DocumentStatus]
 


### PR DESCRIPTION
- The "how to" page is under `docs/how-to-write-conventions`, but the page title uses the term "define". This editorial update resolves the inconsistency in the simplest possible way, by using "write".
- Adds a link to the "how to" page from the `docs` landing page