### PR TITLE
editorial: add alias for feature flag logs-events rename

### DIFF
--- a/docs/feature-flags/feature-flags-events.md
+++ b/docs/feature-flags/feature-flags-events.md
@@ -1,5 +1,6 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Events
+aliases: [feature-flags-logs]
 --->
 
 # Semantic conventions for feature flags in events


### PR DESCRIPTION
Follow-up to https://github.com/open-telemetry/semantic-conventions/pull/2781