### PR TITLE
[chore] Add guideline for cpu metrics' requirement level

### DIFF
--- a/docs/non-normative/groups/system/cpu-metrics-guidelines.md
+++ b/docs/non-normative/groups/system/cpu-metrics-guidelines.md
@@ -9,7 +9,7 @@ This document provides guidance regarding the requirement level of the CPU metri
 across the different areas of the Semantic Conventions.
 
 ## Policy
-* **RECOMMENDED**: `*.cpu.time`
+* **recommended**: `*.cpu.time`
 * **OPTIONAL (Opt-In)**: `*.cpu.utilization`, `*.cpu.usage`,
   `*.cpu.limit_utilization`, `*.cpu.request_utilization`
 

--- a/docs/non-normative/groups/system/cpu-metrics-guidelines.md
+++ b/docs/non-normative/groups/system/cpu-metrics-guidelines.md
@@ -1,6 +1,6 @@
 ## Recommended vs Opt-In CPU Metrics
 
-The [**Instrument Naming**](../../../docs/general/naming.md#instrument-naming)
+The [**Instrument Naming**](/docs/general/naming.md#instrument-naming)
 section defines the `*.usage`, `*.limit`, `*.utilization`, and `*.time` metrics, but it does **not** specify
 their **requirement levels** (Recommended vs. Optional). Because these metrics convey overlapping information
 in different forms, implementations may become inconsistent without explicit guidance.

--- a/docs/non-normative/groups/system/cpu-metrics-guidelines.md
+++ b/docs/non-normative/groups/system/cpu-metrics-guidelines.md
@@ -9,6 +9,7 @@ This document provides guidance regarding the requirement level of the CPU metri
 across the different areas of the Semantic Conventions.
 
 ## Policy
+
 * **recommended**: `*.cpu.time`
 * **opt-in** (optional): `*.cpu.utilization`, `*.cpu.usage`,
   `*.cpu.limit_utilization`, `*.cpu.request_utilization`
@@ -34,12 +35,14 @@ not uniquely implemented in other systems like the
 [Docker stats API](https://docs.docker.com/reference/api/engine/version/v1.51/#tag/Container/operation/ContainerStats).
 
 ## Implementation Guidance
+
 * SHOULD emit `*.cpu.time` by default for system, process container, and k8s
   resources.
 * SHOULD gate `*.cpu.*utilization` and `*.cpu.usage` metrics behind explicit
   configuration.
 
 ## Backend Guidance
+
 * SHOULD provide transforms or views to derive utilization/usage from
   `*.cpu.time` when helpful.
 * SHOULD treat `*.cpu.time` as the canonical source of truth across system,
@@ -66,7 +69,6 @@ can be found bellow:
 This is the PromQL equivalent. The rate() function is equivalent to
 the subtraction of the current to the previous value, while the denominator is
 the elapsed time in seconds.
-
 
 ### CPU Time to Utilization
 
@@ -97,7 +99,7 @@ Projects like [Prometheus Node Exporter](https://github.com/prometheus/node_expo
 come with their own formula for calculating System's utilization.
 
 The standardization of `k8s.*.cpu.usage` is an exception since it is collected
-directly from the Kubelet's Stats API and is K8s specific. 
+directly from the Kubelet's Stats API and is K8s specific.
 
 ## References
 

--- a/docs/non-normative/groups/system/cpu-metrics-guidelines.md
+++ b/docs/non-normative/groups/system/cpu-metrics-guidelines.md
@@ -34,7 +34,7 @@ not uniquely implemented in other systems like the
 [Docker stats API](https://docs.docker.com/reference/api/engine/version/v1.51/#tag/Container/operation/ContainerStats).
 
 ## Implementation Guidance
-* MUST emit `*.cpu.time` by default for system, process container, and k8s
+* SHOULD emit `*.cpu.time` by default for system, process container, and k8s
   resources.
 * SHOULD gate `*.cpu.*utilization` and `*.cpu.usage` metrics behind explicit
   configuration.

--- a/docs/non-normative/groups/system/cpu-metrics-guidelines.md
+++ b/docs/non-normative/groups/system/cpu-metrics-guidelines.md
@@ -1,0 +1,100 @@
+## Recommended vs Opt-In CPU Metrics
+
+The [**Instrument Naming**](../../../docs/general/naming.md#instrument-naming)
+section defines the `*.usage`, `*.limit`, `*.utilization`, and `*.time` metrics, but it does **not** specify
+their **requirement levels** (Recommended vs. Optional). Because these metrics convey overlapping information
+in different forms, implementations may become inconsistent without explicit guidance.
+
+This document provides guidance regarding the requirement level of the CPU metrics
+across the different areas of the Semantic Conventions.
+
+## Policy
+* **RECOMMENDED**: `*.cpu.time`
+* **OPTIONAL (Opt-In)**: `*.cpu.utilization`, `*.cpu.usage`,
+  `*.cpu.limit_utilization`, `*.cpu.request_utilization`
+
+## Rationale
+
+`*.cpu.time` metrics are unambiguous, as they are measured directly from the
+operating system or runtime. They aggregate cleanly across CPUs and resources,
+support spatial aggregation, and form a consistent base for deriving usage and
+utilization in backends or at the time of collection for convenience when possible.
+
+By contrast, `*.cpu.usage` and `*.cpu.utilization` are derived or
+presentation-focused metrics. Their definitions may vary across implementations,
+especially in containerized and Kubernetes environments where CPU limits are
+defined per container or Pod. This leads to ambiguity and inconsistencies in
+how these metrics should be calculated and reported. While they can be
+convenient for dashboards and alerts, they should remain optional and only
+implemented when specific environments explicitly provide them. For example
+[Kubelet's stats endpoint](https://github.com/kubernetes/kubernetes/blob/dbc7fe1b7fec4a76562d5e1565072a447fec5439/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go#L230-L233)
+provides an opinionated metrics for `*.cpu.usage` that can be used directly,
+yet should be optional since it is derived from the `.cpu.time` metrics and is
+not uniquely implemented in other systems like the
+[Docker stats API](https://docs.docker.com/reference/api/engine/version/v1.51/#tag/Container/operation/ContainerStats).
+
+## Implementation Guidance
+* MUST emit `*.cpu.time` by default for system, process container, and k8s
+  resources.
+* SHOULD gate `*.cpu.*utilization` and `*.cpu.usage` metrics behind explicit
+  configuration.
+
+## Backend Guidance
+* SHOULD provide transforms or views to derive utilization/usage from
+  `*.cpu.time` when helpful.
+* SHOULD treat `*.cpu.time` as the canonical source of truth across system,
+  container, and k8s resources.
+
+## Using CPU Time
+
+The cumulative CPU time values can be used to derive the utilization or usage metrics.
+
+**Usage** metric can be computed using a `rate()` function with a given window,
+dividing by the window size.
+CPU usage usually is measured in core-seconds.
+
+**Utilization** can be computed using the above result divided by the given CPU limit
+and is usually in the range of [0, 1].
+
+Examples of how the CPU time can be used to derive usage or utilization metrics,
+can be found bellow:
+
+### CPU Time to Usage
+
+`rate(system.cpu.time[5m])/(5*60)` measured in core-seconds.
+
+This is the PromQL equivalent. The rate() function is equivalent to
+the subtraction of the current to the previous value, while the denominator is
+the elapsed time in seconds.
+
+
+### CPU Time to Utilization
+
+`rate(system.cpu.time[5m])/(5*60)` measured in [0 ,1] per core (limit equals to 1 core)
+
+`rate(k8s.pod.cpu.time[5m])/(5*60)/k8s.pod.cpu.limit`
+
+The above will give the `k8s.pod.cpu.limit_utilization` derived metric.
+
+### Utilization excluding non-`idle` states
+
+To represent the utilization as an expression of the percentage of time the system spent
+in non-`idle` states, the following can be used:
+
+`sum(rate(system.cpu.time{cpu.mode!="idle"}[5m]) without (cpu.mode))/(5*60))`
+measured in [0, 1] per core.
+
+### Total utilization of the whole system
+
+To get the utilization of the whole system, an average across all cores can be used:
+
+`avg(sum(rate(system.cpu.time{cpu.mode!="idle"}[5m])) by (cpu.logical_number))/(5*60)`
+
+Note that the above formulas can be ambigous and hence they are not standardized
+as part of the Semantic Conventions project. They are only provided as examples.
+
+Projects like [Prometheus Node Exporter](https://github.com/prometheus/node_exporter/blob/b959d48df950d5c446660eca3354c26eb997ca44/docs/node-mixin/lib/prom-mixin.libsonnet#L85-L87)
+come with their own formula for calculating System's utilization.
+
+The standardization of `k8s.*.cpu.usage` is an exception since it is collected
+directly from the Kubelet's Stats API and is K8s specific. 

--- a/docs/non-normative/groups/system/cpu-metrics-guidelines.md
+++ b/docs/non-normative/groups/system/cpu-metrics-guidelines.md
@@ -2,7 +2,7 @@
 
 The [**Instrument Naming**](/docs/general/naming.md#instrument-naming)
 section defines the `*.usage`, `*.limit`, `*.utilization`, and `*.time` metrics, but it does **not** specify
-their [**requirement levels**](/docs/general/metric-requirement-level.md) (`required`,`recommended, `opt-in`). Because these metrics convey overlapping information
+their [**requirement levels**](/docs/general/metric-requirement-level.md) (`required`,`recommended`, `opt-in`). Because these metrics convey overlapping information
 in different forms, implementations may become inconsistent without explicit guidance.
 
 This document provides guidance regarding the requirement level of the CPU metrics

--- a/docs/non-normative/groups/system/cpu-metrics-guidelines.md
+++ b/docs/non-normative/groups/system/cpu-metrics-guidelines.md
@@ -2,7 +2,7 @@
 
 The [**Instrument Naming**](/docs/general/naming.md#instrument-naming)
 section defines the `*.usage`, `*.limit`, `*.utilization`, and `*.time` metrics, but it does **not** specify
-their **requirement levels** (Recommended vs. Optional). Because these metrics convey overlapping information
+their [**requirement levels**](/docs/general/metric-requirement-level.md) (`required`,`recommended, `opt-in`). Because these metrics convey overlapping information
 in different forms, implementations may become inconsistent without explicit guidance.
 
 This document provides guidance regarding the requirement level of the CPU metrics

--- a/docs/non-normative/groups/system/cpu-metrics-guidelines.md
+++ b/docs/non-normative/groups/system/cpu-metrics-guidelines.md
@@ -10,7 +10,7 @@ across the different areas of the Semantic Conventions.
 
 ## Policy
 * **recommended**: `*.cpu.time`
-* **OPTIONAL (Opt-In)**: `*.cpu.utilization`, `*.cpu.usage`,
+* **opt-in** (optional): `*.cpu.utilization`, `*.cpu.usage`,
   `*.cpu.limit_utilization`, `*.cpu.request_utilization`
 
 ## Rationale

--- a/docs/non-normative/groups/system/cpu-metrics-guidelines.md
+++ b/docs/non-normative/groups/system/cpu-metrics-guidelines.md
@@ -70,7 +70,7 @@ the elapsed time in seconds.
 
 ### CPU Time to Utilization
 
-`rate(system.cpu.time[5m])/(5*60)` measured in [0 ,1] per core (limit equals to 1 core)
+`rate(system.cpu.time[5m])/(5*60)` measured in [0, 1] per core (limit equals to 1 core)
 
 `rate(k8s.pod.cpu.time[5m])/(5*60)/k8s.pod.cpu.limit`
 

--- a/docs/non-normative/groups/system/cpu-metrics-guidelines.md
+++ b/docs/non-normative/groups/system/cpu-metrics-guidelines.md
@@ -98,3 +98,8 @@ come with their own formula for calculating System's utilization.
 
 The standardization of `k8s.*.cpu.usage` is an exception since it is collected
 directly from the Kubelet's Stats API and is K8s specific. 
+
+## References
+
+1. [System CPU Utilization gist](https://gist.github.com/braydonk/b2381da98dc3c4fd5ac064045d556634) by Braydon Kains (@braydonk)
+2. Attempt to introduce an [optional normalized total CPU utilization metric](https://github.com/open-telemetry/semantic-conventions/issues/1873)


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/2177

Prio art:

1. [System CPU Utilization gist](https://gist.github.com/braydonk/b2381da98dc3c4fd5ac064045d556634) by Braydon Kains (@braydonk). PromQL queries come in this PR come from this gist
2. Attempt to introduce an [optional normalized total CPU utilization metric](https://github.com/open-telemetry/semantic-conventions/issues/1873)

## Changes

Please provide a brief description of the changes here.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
