### PR TITLE
model/nfs/registry.yaml: top level group should be registry.nfs only

### DIFF
--- a/model/nfs/registry.yaml
+++ b/model/nfs/registry.yaml
@@ -1,9 +1,9 @@
 groups:
-  - id: registry.nfs.server.repcache.status
+  - id: registry.nfs
     type: attribute_group
-    display_name: NFS Server Reply Cache Attributes
+    display_name: NFS Attributes
     brief: >
-      NFS Server replies check a Reply Cache (repcache), which can have one of 3 result states
+      Describes NFS Attributes
     attributes:
       - id: nfs.server.repcache.status
         type: string


### PR DESCRIPTION
## Changes

model/nfs/registry.yaml: Top-level entry too specific -- should just be registry.nfs, with the two attributes under an attribute_group.

Implementation https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40134 not merged yet, so no breaking changes.

## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [N/A] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [N/A] Links to the prototypes or existing instrumentations (when adding or changing conventions)
