### PR TITLE
[editorial] cpu-metrics-guidelines: make page title a H1

### DIFF
--- a/docs/non-normative/groups/system/cpu-metrics-guidelines.md
+++ b/docs/non-normative/groups/system/cpu-metrics-guidelines.md
@@ -1,4 +1,4 @@
-## Recommended vs Opt-In CPU Metrics
+# Recommended vs Opt-In CPU Metrics
 
 The [**Instrument Naming**](/docs/general/naming.md#instrument-naming)
 section defines the `*.usage`, `*.limit`, `*.utilization`, and `*.time` metrics, but it does **not** specify


### PR DESCRIPTION
- Followup to #2804
- Fixes issue reported by OTel.io build: https://github.com/open-telemetry/opentelemetry.io/actions/runs/18093975280/job/51481031511?pr=7863

  > WARN: tmp/semconv/docs/non-normative/groups/system/cpu-metrics-guidelines.md: no level 1 heading found, so no page will be generated at scripts/content-modules/adjust-pages.pl line 149

/cc @open-telemetry/docs-approvers
