### PR TITLE
Ensure metrics are deprecated rather than removed

### DIFF
--- a/.chloggen/restore_deleted_metrics.yaml
+++ b/.chloggen/restore_deleted_metrics.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: system
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The `system.network.dropped` and `system.network.packets` metrics have been added as deprecated rather than being removed.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2828]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/model/system/deprecated/metrics-deprecated.yaml
+++ b/model/system/deprecated/metrics-deprecated.yaml
@@ -15,3 +15,46 @@ groups:
       - ref: network.transport
     entity_associations:
       - host
+  - id: metric.system.network.dropped
+    type: metric
+    metric_name: system.network.dropped
+    annotations:
+      code_generation:
+        metric_value_type: int
+    stability: development
+    deprecated:
+      reason: renamed
+      renamed_to: system.network.packet.dropped
+    brief: "Count of packets that are dropped or discarded even though there was no error."
+    instrument: counter
+    unit: "{packet}"
+    note: |
+      Measured as:
+
+      - Linux: the `drop` column in `/proc/dev/net` ([source](https://web.archive.org/web/20180321091318/http://www.onlamp.com/pub/a/linux/2000/11/16/LinuxAdmin.html))
+      - Windows: [`InDiscards`/`OutDiscards`](https://docs.microsoft.com/windows/win32/api/netioapi/ns-netioapi-mib_if_row2)
+        from [`GetIfEntry2`](https://docs.microsoft.com/windows/win32/api/netioapi/nf-netioapi-getifentry2)
+    attributes:
+      - ref: network.interface.name
+      - ref: network.io.direction
+    entity_associations:
+      - host
+
+  - id: metric.system.network.packets
+    type: metric
+    metric_name: system.network.packets
+    annotations:
+      code_generation:
+        metric_value_type: int
+    stability: development
+    deprecated:
+      reason: renamed
+      renamed_to: system.network.packet.count
+    brief: The number of packets transferred.
+    instrument: counter
+    unit: "{packet}"
+    attributes:
+      - ref: system.device
+      - ref: network.io.direction
+    entity_associations:
+      - host


### PR DESCRIPTION
Fixes #2828

## Changes

With #2629 metrics were mistakenly removed rather than deprecated. This adds the metrics back in but as depreacted with the deprecation pointing to the new metrics.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
