### PR TITLE
Update Heroku Semantic Conventions to Match Official Documentation

### DIFF
--- a/docs/registry/attributes/heroku.md
+++ b/docs/registry/attributes/heroku.md
@@ -5,10 +5,22 @@
 
 ## Heroku Attributes
 
-This document defines attributes for the Heroku platform on which application/s are running.
+This document defines attributes for Heroku Fir applications. These attributes are automatically added to all telemetry data by the Heroku platform and provide context about the application and release information.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
-| <a id="heroku-app-id" href="#heroku-app-id">`heroku.app.id`</a> | string | Unique identifier for the application | `2daa2797-e42b-4624-9322-ec3f968df4da` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="heroku-release-commit" href="#heroku-release-commit">`heroku.release.commit`</a> | string | Commit hash for the current release | `e6134959463efd8966b20e75b913cafe3f5ec` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="heroku-release-creation-timestamp" href="#heroku-release-creation-timestamp">`heroku.release.creation_timestamp`</a> | string | Time and date the release was created | `2022-10-23T18:00:42Z` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="heroku-app-id" href="#heroku-app-id">`heroku.app.id`</a> | string | The unique identifier of the Heroku application. This is a UUID that uniquely identifies the application across the Heroku platform. [1] | `9daa2797-e49b-4624-932f-ec3f9688e3da`; `c3d3df33-8afb-4323-ac49-a9bf41a50dd1` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| <a id="heroku-app-name" href="#heroku-app-name">`heroku.app.name`</a> | string | The name of the Heroku application. This is the human-readable name of the application as it appears in the Heroku dashboard. [2] | `my-app`; `test-app` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| <a id="heroku-release-id" href="#heroku-release-id">`heroku.release.id`</a> | string | The unique identifier of the app release. This is a UUID that uniquely identifies each deployment/release of the application. [3] | `release-afc4d88c-7d89-4bc6-b364-7658cd60ba57`; `release-3bd90b80-16a1-4f5b-9465-a61e1b7464d4` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| <a id="heroku-release-version" href="#heroku-release-version">`heroku.release.version`</a> | string | The version of the app release when telemetry is generated. This is typically a version number or identifier for the specific release. [4] | `v19`; `v42`; `v1.2.3` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| <a id="heroku-workload-id" href="#heroku-workload-id">`heroku.workload.id`</a> | string | The workload identifier, as defined by the process type. This typically corresponds to the process type (web, worker, etc.) or specific workload identifier in the telemetry system. [5] | `web`; `worker`; `scheduler`; `release` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+
+**[1] `heroku.app.id`:** This attribute is automatically provided by Heroku and cannot be customized.
+
+**[2] `heroku.app.name`:** This attribute can be customized by renaming the application in the Heroku dashboard. It is used as the default value for service.name if not explicitly set.
+
+**[3] `heroku.release.id`:** This attribute is automatically provided by Heroku.
+
+**[4] `heroku.release.version`:** This attribute is automatically provided by Heroku. It is commonly used as the default value for service.version.
+
+**[5] `heroku.workload.id`:** This attribute is automatically provided by Heroku and is used to identify the workload type. It is particularly useful for filtering telemetry data by process type.

--- a/docs/registry/entities/heroku.md
+++ b/docs/registry/entities/heroku.md
@@ -11,7 +11,7 @@
 
 **type:** `heroku`
 
-**Description:** [Heroku dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata)
+**Description:** Heroku Fir Application Attributes as defined in the  [Heroku OpenTelemetry Signals and Attributes Reference](https://devcenter.heroku.com/articles/heroku-opentelemetry-signals-and-attributes-reference)
 
 **Other Attributes:**
 
@@ -20,9 +20,21 @@
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`heroku.app.id`](/docs/registry/attributes/heroku.md) | string | Unique identifier for the application | `2daa2797-e42b-4624-9322-ec3f968df4da` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`heroku.release.commit`](/docs/registry/attributes/heroku.md) | string | Commit hash for the current release | `e6134959463efd8966b20e75b913cafe3f5ec` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`heroku.release.creation_timestamp`](/docs/registry/attributes/heroku.md) | string | Time and date the release was created | `2022-10-23T18:00:42Z` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`heroku.app.id`](/docs/registry/attributes/heroku.md) | string | The unique identifier of the Heroku application. This is a UUID that uniquely identifies the application across the Heroku platform. [1] | `9daa2797-e49b-4624-932f-ec3f9688e3da`; `c3d3df33-8afb-4323-ac49-a9bf41a50dd1` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`heroku.app.name`](/docs/registry/attributes/heroku.md) | string | The name of the Heroku application. This is the human-readable name of the application as it appears in the Heroku dashboard. [2] | `my-app`; `test-app` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`heroku.release.id`](/docs/registry/attributes/heroku.md) | string | The unique identifier of the app release. This is a UUID that uniquely identifies each deployment/release of the application. [3] | `release-afc4d88c-7d89-4bc6-b364-7658cd60ba57`; `release-3bd90b80-16a1-4f5b-9465-a61e1b7464d4` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`heroku.release.version`](/docs/registry/attributes/heroku.md) | string | The version of the app release when telemetry is generated. This is typically a version number or identifier for the specific release. [4] | `v19`; `v42`; `v1.2.3` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`heroku.workload.id`](/docs/registry/attributes/heroku.md) | string | The workload identifier, as defined by the process type. This typically corresponds to the process type (web, worker, etc.) or specific workload identifier in the telemetry system. [5] | `web`; `worker`; `scheduler`; `release` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+
+**[1] `heroku.app.id`:** This attribute is automatically provided by Heroku and cannot be customized.
+
+**[2] `heroku.app.name`:** This attribute can be customized by renaming the application in the Heroku dashboard. It is used as the default value for service.name if not explicitly set.
+
+**[3] `heroku.release.id`:** This attribute is automatically provided by Heroku.
+
+**[4] `heroku.release.version`:** This attribute is automatically provided by Heroku. It is commonly used as the default value for service.version.
+
+**[5] `heroku.workload.id`:** This attribute is automatically provided by Heroku and is used to identify the workload type. It is particularly useful for filtering telemetry data by process type.
 
 
 <!-- markdownlint-restore -->

--- a/docs/resource/cloud-provider/heroku.md
+++ b/docs/resource/cloud-provider/heroku.md
@@ -12,13 +12,25 @@
 
 **type:** `heroku`
 
-**Description:** [Heroku dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata)
+**Description:** Heroku Fir Application Attributes as defined in the  [Heroku OpenTelemetry Signals and Attributes Reference](https://devcenter.heroku.com/articles/heroku-opentelemetry-signals-and-attributes-reference)
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`heroku.app.id`](/docs/registry/attributes/heroku.md) | string | Unique identifier for the application | `2daa2797-e42b-4624-9322-ec3f968df4da` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`heroku.release.commit`](/docs/registry/attributes/heroku.md) | string | Commit hash for the current release | `e6134959463efd8966b20e75b913cafe3f5ec` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`heroku.release.creation_timestamp`](/docs/registry/attributes/heroku.md) | string | Time and date the release was created | `2022-10-23T18:00:42Z` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`heroku.app.id`](/docs/registry/attributes/heroku.md) | string | The unique identifier of the Heroku application. This is a UUID that uniquely identifies the application across the Heroku platform. [1] | `9daa2797-e49b-4624-932f-ec3f9688e3da`; `c3d3df33-8afb-4323-ac49-a9bf41a50dd1` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`heroku.app.name`](/docs/registry/attributes/heroku.md) | string | The name of the Heroku application. This is the human-readable name of the application as it appears in the Heroku dashboard. [2] | `my-app`; `test-app` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`heroku.release.id`](/docs/registry/attributes/heroku.md) | string | The unique identifier of the app release. This is a UUID that uniquely identifies each deployment/release of the application. [3] | `release-afc4d88c-7d89-4bc6-b364-7658cd60ba57`; `release-3bd90b80-16a1-4f5b-9465-a61e1b7464d4` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`heroku.release.version`](/docs/registry/attributes/heroku.md) | string | The version of the app release when telemetry is generated. This is typically a version number or identifier for the specific release. [4] | `v19`; `v42`; `v1.2.3` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| [`heroku.workload.id`](/docs/registry/attributes/heroku.md) | string | The workload identifier, as defined by the process type. This typically corresponds to the process type (web, worker, etc.) or specific workload identifier in the telemetry system. [5] | `web`; `worker`; `scheduler`; `release` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+
+**[1] `heroku.app.id`:** This attribute is automatically provided by Heroku and cannot be customized.
+
+**[2] `heroku.app.name`:** This attribute can be customized by renaming the application in the Heroku dashboard. It is used as the default value for service.name if not explicitly set.
+
+**[3] `heroku.release.id`:** This attribute is automatically provided by Heroku.
+
+**[4] `heroku.release.version`:** This attribute is automatically provided by Heroku. It is commonly used as the default value for service.version.
+
+**[5] `heroku.workload.id`:** This attribute is automatically provided by Heroku and is used to identify the workload type. It is particularly useful for filtering telemetry data by process type.
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
@@ -27,13 +39,13 @@
 
 **Mapping:**
 
-| Dyno metadata environment variable | Resource attribute                  |
-|------------------------------------|-------------------------------------|
-| `HEROKU_APP_ID`                    | `heroku.app.id`                     |
-| `HEROKU_APP_NAME`                  | `service.name`                      |
-| `HEROKU_DYNO_ID`                   | `service.instance.id`               |
-| `HEROKU_RELEASE_CREATED_AT`        | `heroku.release.creation_timestamp` |
-| `HEROKU_RELEASE_VERSION`           | `service.version`                   |
-| `HEROKU_SLUG_COMMIT`               | `heroku.release.commit`             |
+For FIR applications, service-level attributes can be configured using standard OpenTelemetry environment variables:
+
+| OTEL Environment Variable | Resource Attribute | Description |
+|---------------------------|-------------------|-------------|
+| `OTEL_SERVICE_NAME` | `service.name` | Service name (replaces default application name) |
+| `OTEL_RESOURCE_ATTRIBUTES` | `service.namespace` | Namespace for service name |
+| `OTEL_RESOURCE_ATTRIBUTES` | `service.version` | Version of app release |
+| `OTEL_RESOURCE_ATTRIBUTES` | `service.instance.id` | Unique dyno identifier (Heroku-provided) |
 
 Additionally, [the `cloud.provider` resource attribute MUST be set to `heroku`](../cloud.md).

--- a/model/heroku/entities.yaml
+++ b/model/heroku/entities.yaml
@@ -4,11 +4,11 @@ groups:
     stability: development
     name: heroku
     brief: >
-      [Heroku dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata)
+      Heroku Fir Application Attributes as defined in the 
+      [Heroku OpenTelemetry Signals and Attributes Reference](https://devcenter.heroku.com/articles/heroku-opentelemetry-signals-and-attributes-reference)
     attributes:
-      - ref: heroku.release.creation_timestamp
-        requirement_level: opt_in
-      - ref: heroku.release.commit
-        requirement_level: opt_in
       - ref: heroku.app.id
-        requirement_level: opt_in
+      - ref: heroku.app.name
+      - ref: heroku.workload.id
+      - ref: heroku.release.id
+      - ref: heroku.release.version

--- a/model/heroku/registry.yaml
+++ b/model/heroku/registry.yaml
@@ -3,23 +3,64 @@ groups:
     type: attribute_group
     display_name: Heroku Attributes
     brief: >
-        This document defines attributes for the Heroku platform on which application/s are running.
+        This document defines attributes for Heroku Fir applications.
+        These attributes are automatically added to all telemetry data by the Heroku platform
+        and provide context about the application and release information.
     attributes:
-      - id: heroku.release.creation_timestamp
-        type: string
-        stability: development
-        brief: >
-          Time and date the release was created
-        examples: [ '2022-10-23T18:00:42Z' ]
-      - id: heroku.release.commit
-        type: string
-        stability: development
-        brief: >
-          Commit hash for the current release
-        examples: [ 'e6134959463efd8966b20e75b913cafe3f5ec' ]
+      # Core Application Attributes
       - id: heroku.app.id
         type: string
-        stability: development
+        stability: stable
         brief: >
-          Unique identifier for the application
-        examples: [ '2daa2797-e42b-4624-9322-ec3f968df4da' ]
+          The unique identifier of the Heroku application.
+          This is a UUID that uniquely identifies the application across the Heroku platform.
+        examples: [ '9daa2797-e49b-4624-932f-ec3f9688e3da', 'c3d3df33-8afb-4323-ac49-a9bf41a50dd1' ]
+        note: >
+          This attribute is automatically provided by Heroku and cannot be customized.
+
+      - id: heroku.app.name
+        type: string
+        stability: stable
+        brief: >
+          The name of the Heroku application.
+          This is the human-readable name of the application as it appears in the Heroku dashboard.
+        examples: [ 'my-app', 'test-app' ]
+        note: >
+          This attribute can be customized by renaming the application in the Heroku dashboard.
+          It is used as the default value for service.name if not explicitly set.
+
+      # Workload Attributes
+      - id: heroku.workload.id
+        type: string
+        stability: stable
+        brief: >
+          The workload identifier, as defined by the process type.
+          This typically corresponds to the process type (web, worker, etc.) or
+          specific workload identifier in the telemetry system.
+        examples: [ 'web', 'worker', 'scheduler', 'release' ]
+        note: >
+          This attribute is automatically provided by Heroku and is used to identify
+          the workload type. It is particularly useful for filtering telemetry data by process type.
+
+      # Release Attributes
+      - id: heroku.release.id
+        type: string
+        stability: stable
+        brief: >
+          The unique identifier of the app release.
+          This is a UUID that uniquely identifies each deployment/release of the application.
+        examples: [ 'release-afc4d88c-7d89-4bc6-b364-7658cd60ba57', 'release-3bd90b80-16a1-4f5b-9465-a61e1b7464d4' ]
+        note: >
+          This attribute is automatically provided by Heroku.
+
+      - id: heroku.release.version
+        type: string
+        stability: stable
+        brief: >
+          The version of the app release when telemetry is generated.
+          This is typically a version number or identifier for the specific release.
+        examples: [ 'v19', 'v42', 'v1.2.3' ]
+        note: >
+          This attribute is automatically provided by Heroku. It is commonly used as
+          the default value for service.version.
+


### PR DESCRIPTION
## Changes

The Heroku Telemetry Team is  looking to update the current Heroku semantic conventions to match our existing documentation for Fir generation applications. This PR aligns the semantic conventions with the official [Heroku OpenTelemetry Signals and Attributes Reference](https://devcenter.heroku.com/articles/heroku-opentelemetry-signals-and-attributes-reference).

### What we are changing 

#### **Updated Attributes to Match Official Documentation**
- **Removed non-documented attributes**: `heroku.dyno_index`, `heroku.dyno_type`, `heroku.release.creation_timestamp`, `heroku.release.commit`
- **Kept only officially documented attributes**:
  - `heroku.app.id` - unique identifier of app
  - `heroku.app.name` - name of application  
  - `heroku.release.id` - unique identifier of app release
  - `heroku.release.version` - version of app release when telemetry is generated
  - `heroku.workload.id` - workload identifier, as defined by the process type

#### **Additional Information**
- All attributes are automatically provided by the Heroku platform
- Attributes are specific to Heroku Fir applications (not traditional Cedar dynos)
- Service-level attributes can be configured via standard OTEL environment variables (`OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`)

(Note: I'm currently going through internal process of getting CLA signed) 

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
