### PR TITLE
[process] Rename process.context_switch_type to process.context_switch.type

### DIFF
--- a/.chloggen/rename_process_context_switch_type.yaml
+++ b/.chloggen/rename_process_context_switch_type.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: process
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Renames process.context_switch_type to process.context_switch.type
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1501]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/process.md
+++ b/docs/registry/attributes/process.md
@@ -17,7 +17,7 @@ An operating system process.
 | <a id="process-command" href="#process-command">`process.command`</a> | string | The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`. | `cmd/otelcol` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-command-args" href="#process-command-args">`process.command_args`</a> | string[] | All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`. SHOULD NOT be collected by default unless there is sanitization that excludes sensitive data. | `["cmd/otecol", "--config=config.yaml"]` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-command-line" href="#process-command-line">`process.command_line`</a> | string | The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead. SHOULD NOT be collected by default unless there is sanitization that excludes sensitive data. | `C:\cmd\otecol --config="my directory\config.yaml"` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="process-context-switch-type" href="#process-context-switch-type">`process.context_switch_type`</a> | string | Specifies whether the context switches for this data point were voluntary or involuntary. | `voluntary`; `involuntary` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="process-context-switch-type" href="#process-context-switch-type">`process.context_switch.type`</a> | string | Specifies whether the context switches for this data point were voluntary or involuntary. | `voluntary`; `involuntary` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-creation-time" href="#process-creation-time">`process.creation.time`</a> | string | The date and time the process was created, in ISO 8601 format. | `2023-11-21T09:25:34.853Z` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-environment-variable" href="#process-environment-variable">`process.environment_variable.<key>`</a> | string | Process environment variables, `<key>` being the environment variable name, the value being the environment variable value. [2] | `ubuntu`; `/usr/local/bin:/usr/bin` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-executable-build-id-gnu" href="#process-executable-build-id-gnu">`process.executable.build_id.gnu`</a> | string | The GNU build ID as found in the `.note.gnu.build-id` ELF section (hex string). | `c89b11207f6479603b0d49bf291c092c2b719293` | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -64,7 +64,7 @@ with value `"/usr/local/bin:/usr/bin"`.
 
 ---
 
-`process.context_switch_type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`process.context_switch.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|
@@ -96,8 +96,18 @@ Deprecated process attributes.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
+| <a id="process-context-switch-type" href="#process-context-switch-type">`process.context_switch_type`</a> | string | "Deprecated, use `process.context_switch.type` instead." | `voluntary`; `involuntary` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `process.context_switch.type`. |
 | <a id="process-cpu-state" href="#process-cpu-state">`process.cpu.state`</a> | string | Deprecated, use `cpu.mode` instead. | `system`; `user`; `wait` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `cpu.mode`. |
 | <a id="process-executable-build-id-profiling" href="#process-executable-build-id-profiling">`process.executable.build_id.profiling`</a> | string | "Deprecated, use `process.executable.build_id.htlhash` instead." | `600DCAFE4A110000F2BF38C493F5FB92` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `process.executable.build_id.htlhash`. |
+
+---
+
+`process.context_switch_type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `involuntary` | involuntary | ![Development](https://img.shields.io/badge/-development-blue) |
+| `voluntary` | voluntary | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 

--- a/docs/system/process-metrics.md
+++ b/docs/system/process-metrics.md
@@ -289,11 +289,11 @@ This metric is [recommended][MetricRecommended].
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`process.context_switch_type`](/docs/registry/attributes/process.md) | string | Specifies whether the context switches for this data point were voluntary or involuntary. | `voluntary`; `involuntary` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`process.context_switch.type`](/docs/registry/attributes/process.md) | string | Specifies whether the context switches for this data point were voluntary or involuntary. | `voluntary`; `involuntary` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
-`process.context_switch_type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`process.context_switch.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/model/process/deprecated/registry-deprecated.yaml
+++ b/model/process/deprecated/registry-deprecated.yaml
@@ -30,3 +30,21 @@ groups:
         brief: >
           "Deprecated, use `process.executable.build_id.htlhash` instead."
         examples: ['600DCAFE4A110000F2BF38C493F5FB92']
+      - id: process.context_switch_type
+        brief: >
+          "Deprecated, use `process.context_switch.type` instead."
+        deprecated:
+          reason: renamed
+          renamed_to: process.context_switch.type
+        annotations:
+          code_generation:
+            exclude: true
+        type:
+          members:
+            - id: voluntary
+              value: 'voluntary'
+              stability: development
+            - id: involuntary
+              value: 'involuntary'
+              stability: development
+        stability: development

--- a/model/process/metrics.yaml
+++ b/model/process/metrics.yaml
@@ -134,7 +134,7 @@ groups:
     instrument: counter
     unit: "{context_switch}"
     attributes:
-      - ref: process.context_switch_type
+      - ref: process.context_switch.type
     entity_associations:
       - process
 

--- a/model/process/registry.yaml
+++ b/model/process/registry.yaml
@@ -217,7 +217,7 @@ groups:
         brief: >
           The working directory of the process.
         examples: ["/root"]
-      - id: process.context_switch_type
+      - id: process.context_switch.type
         brief: "Specifies whether the context switches for this data point were voluntary or involuntary."
         type:
           members:


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/1501

## Changes

This PR renames `process.context_switch_type` to `process.context_switch.type`.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
