### PR TITLE
nfs/metrics.yaml: nfs.server.net.count: add missing network.transport attribute

### DIFF
--- a/model/nfs/metrics.yaml
+++ b/model/nfs/metrics.yaml
@@ -147,6 +147,8 @@ groups:
     note: |
       Linux: this metric is taken from the Linux kernel's svc_stat.nettcpcnt and svc_stat.netudpcnt
     instrument: counter
+    attributes:
+      - ref: network.transport
     unit: "{record}"
     entity_associations:
       - host


### PR DESCRIPTION
## Changes

nfs/metrics.yaml: nfs.server.net.count: add missing network.transport attribute

This makes it equivalent to nfs.server.net.count. See: https://android.googlesource.com/kernel/common/+/11a083724be9/net/sunrpc/stats.c#39 

Implementation https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40134 not merged yet, so no breaking changes.

## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [N/A] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [N/A] Links to the prototypes or existing instrumentations (when adding or changing conventions)

