### PR TITLE
Replace system.paging.type and process.paging.fault_type with system.paging.fault.type

### DIFF
--- a/.chloggen/fix_paging_fault_type.yaml
+++ b/.chloggen/fix_paging_fault_type.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: system
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Replace `system.paging.type` and `process.paging.fault_type` with `system.paging.fault.type`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [1803]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/non-normative/k8s-migration.md
+++ b/docs/non-normative/k8s-migration.md
@@ -437,10 +437,10 @@ The changes in these metrics are the following:
 
 <!-- prettier-ignore-start -->
 
-| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New                                                                 |
-|------------------------------------------------------------------------------------|---------------------------------------------------------------------|
-| `k8s.pod.memory.page_faults`                                                         | `k8s.pod.memory.paging.faults` with attribute `system.paging.type` set to `minor` |
-| `k8s.pod.memory.major_page_faults`                                                   | `k8s.pod.memory.paging.faults` with attribute `system.paging.type` set to `major` |
+| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New                                                                                     |
+|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| `k8s.pod.memory.page_faults`                                                         | `k8s.pod.memory.paging.faults` with attribute `system.paging.fault.type` set to `minor` |
+| `k8s.pod.memory.major_page_faults`                                                   | `k8s.pod.memory.paging.faults` with attribute `system.paging.fault.type` set to `major` |
 
 <!-- prettier-ignore-end -->
 
@@ -455,10 +455,10 @@ The changes in these metrics are the following:
 
 <!-- prettier-ignore-start -->
 
-| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New                                                                                           |
-|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
-| `container.memory.page_faults`                                                     | `container.memory.paging.faults` with attribute `system.paging.type` set to `minor` |
-| `container.memory.major_page_faults`                                                 | `container.memory.paging.faults` with attribute `system.paging.type` set to `major` |
+| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New                                                                                       |
+|------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| `container.memory.page_faults`                                                     | `container.memory.paging.faults` with attribute `system.paging.fault.type` set to `minor` |
+| `container.memory.major_page_faults`                                                 | `container.memory.paging.faults` with attribute `system.paging.fault.type` set to `major` |
 
 <!-- prettier-ignore-end -->
 

--- a/docs/registry/attributes/process.md
+++ b/docs/registry/attributes/process.md
@@ -30,7 +30,6 @@ An operating system process.
 | <a id="process-group-leader-pid" href="#process-group-leader-pid">`process.group_leader.pid`</a> | int | The PID of the process's group leader. This is also the process group ID (PGID) of the process. | `23` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-interactive" href="#process-interactive">`process.interactive`</a> | boolean | Whether the process is connected to an interactive shell. |  | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-owner" href="#process-owner">`process.owner`</a> | string | The username of the user that owns the process. | `root` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="process-paging-fault-type" href="#process-paging-fault-type">`process.paging.fault_type`</a> | string | The type of page fault for this data point. Type `major` is for major/hard page faults, and `minor` is for minor/soft page faults. | `major`; `minor` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-parent-pid" href="#process-parent-pid">`process.parent_pid`</a> | int | Parent Process identifier (PPID). | `111` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-pid" href="#process-pid">`process.pid`</a> | int | Process identifier (PID). | `1234` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="process-real-user-id" href="#process-real-user-id">`process.real_user.id`</a> | int | The real user ID (RUID) of the process. | `1000` | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -71,15 +70,6 @@ with value `"/usr/local/bin:/usr/bin"`.
 | `involuntary` | involuntary | ![Development](https://img.shields.io/badge/-development-blue) |
 | `voluntary` | voluntary | ![Development](https://img.shields.io/badge/-development-blue) |
 
----
-
-`process.paging.fault_type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
-
-| Value  | Description | Stability |
-|---|---|---|
-| `major` | major | ![Development](https://img.shields.io/badge/-development-blue) |
-| `minor` | minor | ![Development](https://img.shields.io/badge/-development-blue) |
-
 ## Process Linux Attributes
 
 Describes Linux Process attributes
@@ -99,6 +89,7 @@ Deprecated process attributes.
 | <a id="process-context-switch-type" href="#process-context-switch-type">`process.context_switch_type`</a> | string | "Deprecated, use `process.context_switch.type` instead." | `voluntary`; `involuntary` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `process.context_switch.type`. |
 | <a id="process-cpu-state" href="#process-cpu-state">`process.cpu.state`</a> | string | Deprecated, use `cpu.mode` instead. | `system`; `user`; `wait` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `cpu.mode`. |
 | <a id="process-executable-build-id-profiling" href="#process-executable-build-id-profiling">`process.executable.build_id.profiling`</a> | string | "Deprecated, use `process.executable.build_id.htlhash` instead." | `600DCAFE4A110000F2BF38C493F5FB92` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `process.executable.build_id.htlhash`. |
+| <a id="process-paging-fault-type" href="#process-paging-fault-type">`process.paging.fault_type`</a> | string | Deprecated, use `system.paging.fault.type` instead. | `major`; `minor` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `system.paging.fault.type`. |
 
 ---
 
@@ -118,3 +109,12 @@ Deprecated process attributes.
 | `system` | system | ![Development](https://img.shields.io/badge/-development-blue) |
 | `user` | user | ![Development](https://img.shields.io/badge/-development-blue) |
 | `wait` | wait | ![Development](https://img.shields.io/badge/-development-blue) |
+
+---
+
+`process.paging.fault_type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `major` | major | ![Development](https://img.shields.io/badge/-development-blue) |
+| `minor` | minor | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/registry/attributes/system.md
+++ b/docs/registry/attributes/system.md
@@ -80,8 +80,8 @@ Describes System Memory Paging attributes
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
 | <a id="system-paging-direction" href="#system-paging-direction">`system.paging.direction`</a> | string | The paging access direction | `in` | ![Development](https://img.shields.io/badge/-development-blue) |
+| <a id="system-paging-fault-type" href="#system-paging-fault-type">`system.paging.fault.type`</a> | string | The memory paging type | `minor` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="system-paging-state" href="#system-paging-state">`system.paging.state`</a> | string | The memory paging state | `free` | ![Development](https://img.shields.io/badge/-development-blue) |
-| <a id="system-paging-type" href="#system-paging-type">`system.paging.type`</a> | string | The memory paging type | `minor` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
@@ -94,21 +94,21 @@ Describes System Memory Paging attributes
 
 ---
 
+`system.paging.fault.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `major` | major | ![Development](https://img.shields.io/badge/-development-blue) |
+| `minor` | minor | ![Development](https://img.shields.io/badge/-development-blue) |
+
+---
+
 `system.paging.state` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|
 | `free` | free | ![Development](https://img.shields.io/badge/-development-blue) |
 | `used` | used | ![Development](https://img.shields.io/badge/-development-blue) |
-
----
-
-`system.paging.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
-
-| Value  | Description | Stability |
-|---|---|---|
-| `major` | major | ![Development](https://img.shields.io/badge/-development-blue) |
-| `minor` | minor | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ## System Process Attributes
 
@@ -138,6 +138,7 @@ Deprecated system attributes.
 | <a id="system-cpu-logical-number" href="#system-cpu-logical-number">`system.cpu.logical_number`</a> | int | Deprecated, use `cpu.logical_number` instead. | `1` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `cpu.logical_number`. |
 | <a id="system-cpu-state" href="#system-cpu-state">`system.cpu.state`</a> | string | Deprecated, use `cpu.mode` instead. | `idle`; `interrupt` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `cpu.mode`. |
 | <a id="system-network-state" href="#system-network-state">`system.network.state`</a> | string | Deprecated, use `network.connection.state` instead. | `close_wait` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `network.connection.state`. |
+| <a id="system-paging-type" href="#system-paging-type">`system.paging.type`</a> | string | Deprecated, use `system.paging.fault.type` instead. | `minor` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `system.paging.fault.type`. |
 | <a id="system-processes-status" href="#system-processes-status">`system.processes.status`</a> | string | Deprecated, use `system.process.status` instead. | `running` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by `system.process.status`. |
 
 ---
@@ -172,6 +173,15 @@ Deprecated system attributes.
 | `syn_recv` | syn_recv | ![Development](https://img.shields.io/badge/-development-blue) |
 | `syn_sent` | syn_sent | ![Development](https://img.shields.io/badge/-development-blue) |
 | `time_wait` | time_wait | ![Development](https://img.shields.io/badge/-development-blue) |
+
+---
+
+`system.paging.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `major` | major | ![Development](https://img.shields.io/badge/-development-blue) |
+| `minor` | minor | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -255,11 +255,11 @@ In K8s, this metric is derived from the [MemoryStats.PageFaults](https://pkg.go.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`system.paging.type`](/docs/registry/attributes/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`system.paging.fault.type`](/docs/registry/attributes/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
-`system.paging.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`system.paging.fault.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/docs/system/k8s-metrics.md
+++ b/docs/system/k8s-metrics.md
@@ -395,11 +395,11 @@ This metric is derived from the [MemoryStats.PageFaults](https://pkg.go.dev/k8s.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`system.paging.type`](/docs/registry/attributes/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`system.paging.fault.type`](/docs/registry/attributes/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
-`system.paging.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`system.paging.fault.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|
@@ -1226,11 +1226,11 @@ This metric is derived from the [MemoryStats.PageFaults](https://pkg.go.dev/k8s.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`system.paging.type`](/docs/registry/attributes/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`system.paging.fault.type`](/docs/registry/attributes/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
-`system.paging.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`system.paging.fault.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/docs/system/process-metrics.md
+++ b/docs/system/process-metrics.md
@@ -322,11 +322,11 @@ This metric is [recommended][MetricRecommended].
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`process.paging.fault_type`](/docs/registry/attributes/process.md) | string | The type of page fault for this data point. Type `major` is for major/hard page faults, and `minor` is for minor/soft page faults. | `major`; `minor` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`system.paging.fault.type`](/docs/registry/attributes/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
-`process.paging.fault_type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`system.paging.fault.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -465,11 +465,11 @@ This metric is [recommended][MetricRecommended].
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`system.paging.type`](/docs/registry/attributes/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`system.paging.fault.type`](/docs/registry/attributes/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
-`system.paging.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`system.paging.fault.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|
@@ -499,7 +499,7 @@ This metric is [recommended][MetricRecommended].
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | [`system.paging.direction`](/docs/registry/attributes/system.md) | string | The paging access direction | `in` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
-| [`system.paging.type`](/docs/registry/attributes/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`system.paging.fault.type`](/docs/registry/attributes/system.md) | string | The memory paging type | `minor` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
@@ -512,7 +512,7 @@ This metric is [recommended][MetricRecommended].
 
 ---
 
-`system.paging.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+`system.paging.fault.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
 | Value  | Description | Stability |
 |---|---|---|

--- a/model/container/metrics.yaml
+++ b/model/container/metrics.yaml
@@ -143,7 +143,7 @@ groups:
       - container
     brief: "Container memory paging faults."
     attributes:
-      - ref: system.paging.type
+      - ref: system.paging.fault.type
     note: >
       In general, this metric can be derived from
       [cadvisor](https://github.com/google/cadvisor/blob/v0.53.0/docs/storage/prometheus.md#prometheus-container-metrics)

--- a/model/k8s/metrics.yaml
+++ b/model/k8s/metrics.yaml
@@ -167,7 +167,7 @@ groups:
     entity_associations:
       - k8s.pod
     attributes:
-      - ref: system.paging.type
+      - ref: system.paging.fault.type
     note: >
       Cumulative number of major/minor page faults.
 
@@ -698,7 +698,7 @@ groups:
     entity_associations:
       - k8s.node
     attributes:
-      - ref: system.paging.type
+      - ref: system.paging.fault.type
     note: >
       Cumulative number of major/minor page faults.
 

--- a/model/process/deprecated/registry-deprecated.yaml
+++ b/model/process/deprecated/registry-deprecated.yaml
@@ -48,3 +48,17 @@ groups:
               value: 'involuntary'
               stability: development
         stability: development
+      - id: process.paging.fault_type
+        brief: "Deprecated, use `system.paging.fault.type` instead."
+        deprecated:
+          reason: renamed
+          renamed_to: system.paging.fault.type
+        type:
+          members:
+            - id: major
+              value: 'major'
+              stability: development
+            - id: minor
+              value: 'minor'
+              stability: development
+        stability: development

--- a/model/process/metrics.yaml
+++ b/model/process/metrics.yaml
@@ -149,7 +149,7 @@ groups:
     instrument: counter
     unit: "{fault}"
     attributes:
-      - ref: process.paging.fault_type
+      - ref: system.paging.fault.type
     entity_associations:
       - process
 

--- a/model/process/registry.yaml
+++ b/model/process/registry.yaml
@@ -228,19 +228,6 @@ groups:
               value: 'involuntary'
               stability: development
         stability: development
-      - id: process.paging.fault_type
-        brief: >
-          The type of page fault for this data point. Type `major` is for major/hard page faults, and `minor`
-          is for minor/soft page faults.
-        type:
-          members:
-            - id: major
-              value: 'major'
-              stability: development
-            - id: minor
-              value: 'minor'
-              stability: development
-        stability: development
       - id: process.environment_variable
         brief: >
           Process environment variables, `<key>` being the environment variable

--- a/model/system/deprecated/registry-deprecated.yaml
+++ b/model/system/deprecated/registry-deprecated.yaml
@@ -108,3 +108,18 @@ groups:
           reason: renamed
           renamed_to: cpu.logical_number
         examples: [1]
+      - id: system.paging.type
+        type:
+          members:
+            - id: major
+              value: 'major'
+              stability: development
+            - id: minor
+              value: 'minor'
+              stability: development
+        stability: development
+        deprecated:
+          reason: renamed
+          renamed_to: system.paging.fault.type
+        brief: "Deprecated, use `system.paging.fault.type` instead."
+        examples: [ "minor" ]

--- a/model/system/metrics.yaml
+++ b/model/system/metrics.yaml
@@ -205,7 +205,7 @@ groups:
     instrument: counter
     unit: "{fault}"
     attributes:
-      - ref: system.paging.type
+      - ref: system.paging.fault.type
     entity_associations:
       - host
 
@@ -220,7 +220,7 @@ groups:
     instrument: counter
     unit: "{operation}"
     attributes:
-      - ref: system.paging.type
+      - ref: system.paging.fault.type
       - ref: system.paging.direction
     entity_associations:
       - host

--- a/model/system/registry.yaml
+++ b/model/system/registry.yaml
@@ -65,7 +65,7 @@ groups:
         stability: development
         brief: "The memory paging state"
         examples: ["free"]
-      - id: system.paging.type
+      - id: system.paging.fault.type
         type:
           members:
             - id: major


### PR DESCRIPTION
Part of https://github.com/open-telemetry/semantic-conventions/issues/1803

## Changes

This PR replaces `system.paging.type` and `process.paging.fault_type` with `system.paging.fault.type` based on the what was suggested at https://github.com/open-telemetry/semantic-conventions/issues/1803 and https://github.com/open-telemetry/semantic-conventions/issues/1501 (`_type` should be `.type`).

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
