### PR TITLE
[chore] Remove type info from resource pages #929

### DIFF
--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -77,8 +77,6 @@ as specified in the [Resource SDK specification](https://github.com/open-telemet
 
 **Status:** ![Mixed](https://img.shields.io/badge/-mixed-yellow)
 
-**type:** `service`
-
 **Description:** A service instance.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -150,8 +148,6 @@ service.name = Shop.shoppingcart
 
 **Status:** ![Stable](https://img.shields.io/badge/-stable-lightgreen)
 
-**type:** `telemetry.sdk`
-
 **Description:** The telemetry SDK used to capture data recorded by the instrumentation libraries.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -202,8 +198,6 @@ All custom identifiers SHOULD be stable across different versions of an implemen
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `telemetry.distro`
 
 **Description:** The distribution of telemetry SDK used to capture data recorded by the instrumentation libraries.
 

--- a/docs/resource/android.md
+++ b/docs/resource/android.md
@@ -10,8 +10,6 @@
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `android`
-
 **Description:** The Android platform on which the Android application is running.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/browser.md
+++ b/docs/resource/browser.md
@@ -10,8 +10,6 @@
 
 **Status:** ![Mixed](https://img.shields.io/badge/-mixed-yellow)
 
-**type:** `browser`
-
 **Description:** The web browser in which the application represented by the resource is running. The `browser.*` attributes MUST be used only for resources that represent applications running in a web browser (regardless of whether running on a mobile or desktop device).
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/cicd.md
+++ b/docs/resource/cicd.md
@@ -34,8 +34,6 @@ See also:
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `cicd.pipeline`
-
 **Description:** A pipeline is a series of automated steps that helps software teams deliver code.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -65,8 +63,6 @@ Using the CICD pipeline run resource with metrics inherently causes high cardina
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `cicd.pipeline.run`
-
 **Description:** A pipeline run is a singular execution of a given pipeline's tasks.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -90,8 +86,6 @@ Using the CICD pipeline run resource with metrics inherently causes high cardina
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `cicd.worker`
 
 **Description:** A CICD worker is a component of the CICD system that performs work (eg. running pipeline tasks or performing sync).
 A single pipeline run may be distributed across multiple workers. Any OpenTelemetry signal associated with a worker should be associated to the worker that performed the corresponding work.
@@ -121,8 +115,6 @@ For example, when a pipeline run involves several workers, its task run spans ma
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `vcs.repo`
 
 **Description:** A repository in the Version Control System.
 
@@ -154,8 +146,6 @@ the `.git` extension.
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `vcs.ref`
 
 **Description:** A reference to a specific version in the Version Control System.
 

--- a/docs/resource/cloud-provider/aws/ecs.md
+++ b/docs/resource/cloud-provider/aws/ecs.md
@@ -14,8 +14,6 @@ linkTitle: ECS
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `aws.ecs`
-
 **Description:** Entities used by AWS Elastic Container Service (ECS).
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/cloud-provider/aws/eks.md
+++ b/docs/resource/cloud-provider/aws/eks.md
@@ -14,8 +14,6 @@ linkTitle: EKS
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `aws.eks`
-
 **Description:** Entities used by AWS Elastic Kubernetes Service (EKS).
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/cloud-provider/aws/logs.md
+++ b/docs/resource/cloud-provider/aws/logs.md
@@ -14,8 +14,6 @@ linkTitle: Logs
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `aws.log`
-
 **Description:** Entities specific to Amazon Web Services.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/cloud-provider/gcp/apphub.md
+++ b/docs/resource/cloud-provider/gcp/apphub.md
@@ -27,8 +27,6 @@ See [Supported Resources](https://cloud.google.com/app-hub/docs/supported-resour
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `gcp.apphub.application`
-
 **Description:** Attributes denoting data from an Application in AppHub. See [AppHub overview](https://cloud.google.com/app-hub/docs/overview).
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -53,8 +51,6 @@ See [Supported Resources](https://cloud.google.com/app-hub/docs/supported-resour
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `gcp.apphub.service`
 
 **Description:** Attributes denoting data from a Service in AppHub. See [AppHub overview](https://cloud.google.com/app-hub/docs/overview).
 
@@ -106,8 +102,6 @@ See [Supported Resources](https://cloud.google.com/app-hub/docs/supported-resour
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `gcp.apphub.workload`
 
 **Description:** Attributes denoting data from a Workload in AppHub. See [AppHub overview](https://cloud.google.com/app-hub/docs/overview).
 

--- a/docs/resource/cloud-provider/gcp/cloud-run.md
+++ b/docs/resource/cloud-provider/gcp/cloud-run.md
@@ -14,8 +14,6 @@ These conventions are recommended for resources running on Cloud Run.
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `gcp.cloud_run`
-
 **Description:** Resource used by Google Cloud Run.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/cloud-provider/gcp/gce.md
+++ b/docs/resource/cloud-provider/gcp/gce.md
@@ -10,8 +10,6 @@
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `gcp.gce`
-
 **Description:** Resources used by Google Compute Engine (GCE).
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/cloud-provider/heroku.md
+++ b/docs/resource/cloud-provider/heroku.md
@@ -10,8 +10,6 @@
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `heroku`
-
 **Description:** [Heroku dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata)
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/cloud.md
+++ b/docs/resource/cloud.md
@@ -10,8 +10,6 @@
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `cloud`
-
 **Description:** A cloud environment (e.g. GCP, Azure, AWS)
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/cloudfoundry.md
+++ b/docs/resource/cloudfoundry.md
@@ -32,8 +32,6 @@ They align with the Bosh deployment tool of CloudFoundry.
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `cloudfoundry.org`
-
 **Description:** The organization of the application which is monitored.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -65,8 +63,6 @@ reported by `cf orgs`.
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `cloudfoundry.space`
 
 **Description:** The space of the application which is monitored.
 
@@ -100,8 +96,6 @@ reported by `cf spaces`.
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `cloudfoundry.app`
-
 **Description:** The application which is monitored.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -133,8 +127,6 @@ as reported by `cf apps`.
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `cloudfoundry.process`
 
 **Description:** The process of the application which is monitored.
 
@@ -168,8 +160,6 @@ tasks or side-cars with different process types.
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `cloudfoundry.system`
 
 **Description:** The system component which is monitored.
 

--- a/docs/resource/container.md
+++ b/docs/resource/container.md
@@ -10,8 +10,6 @@
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `container`
-
 **Description:** A container instance.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/deployment-environment.md
+++ b/docs/resource/deployment-environment.md
@@ -10,8 +10,6 @@
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `deployment`
-
 **Description:** The software deployment.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/device.md
+++ b/docs/resource/device.md
@@ -10,8 +10,6 @@
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `device`
-
 **Description:** The device on which the process represented by this resource is running.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/faas.md
+++ b/docs/resource/faas.md
@@ -21,8 +21,6 @@ See also:
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `faas`
-
 **Description:** A serverless instance.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/host.md
+++ b/docs/resource/host.md
@@ -13,8 +13,6 @@ To report host metrics, the `system.*` namespace SHOULD be used.
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `host`
-
 **Description:** A host is defined as a computing instance. For example, physical servers, virtual machines, switches or disk array.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -90,8 +88,6 @@ privileged lookup of `host.id` is required, the value should be injected via the
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `host.cpu`
 
 **Description:** A host's CPU information
 

--- a/docs/resource/k8s.md
+++ b/docs/resource/k8s.md
@@ -27,8 +27,6 @@ Kubernetes object, but "name" is usually more user friendly so can be also set.
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `k8s.cluster`
-
 **Description:** A Kubernetes Cluster.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -76,8 +74,6 @@ conflict.
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `k8s.node`
-
 **Description:** A Kubernetes Node object.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -121,8 +117,6 @@ a namespace, but not across namespaces.
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `k8s.namespace`
-
 **Description:** A Kubernetes Namespace.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -164,8 +158,6 @@ containers on your cluster.
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `k8s.pod`
 
 **Description:** A Kubernetes Pod object.
 
@@ -218,8 +210,6 @@ to a running container.
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `k8s.container`
-
 **Description:** A container in a [PodTemplate](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -244,8 +234,6 @@ to a running container.
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `k8s.replicaset`
 
 **Description:** A Kubernetes ReplicaSet object.
 
@@ -291,8 +279,6 @@ distributed among the nodes of a cluster.
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `k8s.deployment`
-
 **Description:** A Kubernetes Deployment object.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -336,8 +322,6 @@ about the ordering and uniqueness of these Pods.
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `k8s.statefulset`
-
 **Description:** A Kubernetes StatefulSet object.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -379,8 +363,6 @@ A DaemonSet ensures that all (or some) Nodes run a copy of a Pod.
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `k8s.daemonset`
 
 **Description:** A Kubernetes DaemonSet object.
 
@@ -425,8 +407,6 @@ successfully terminate.
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `k8s.job`
-
 **Description:** A Kubernetes Job object.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -468,8 +448,6 @@ A CronJob creates Jobs on a repeating schedule.
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `k8s.cronjob`
 
 **Description:** A Kubernetes CronJob object.
 
@@ -513,8 +491,6 @@ A ReplicationController ensures that a specified number of pod replicas are runn
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `k8s.replicationcontroller`
-
 **Description:** A Kubernetes ReplicationController object.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -541,8 +517,6 @@ A HorizontalPodAutoscaler (HPA for short) automatically updates a workload resou
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `k8s.hpa`
 
 **Description:** A Kubernetes HorizontalPodAutoscaler object.
 
@@ -578,8 +552,6 @@ A ResourceQuota provides constraints that limit aggregate resource consumption p
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `k8s.resourcequota`
 
 **Description:** A Kubernetes ResourceQuota object.
 

--- a/docs/resource/os.md
+++ b/docs/resource/os.md
@@ -12,8 +12,6 @@ In case of virtualized environments, this is the operating system as it is obser
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `os`
-
 **Description:** The operating system (OS) on which the process represented by this resource is running.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/process.md
+++ b/docs/resource/process.md
@@ -33,8 +33,6 @@ linkTitle: Process
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `process`
-
 **Description:** An operating system process.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
@@ -91,8 +89,6 @@ On Windows and other systems where the native format of process commands is a si
 
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
-
-**type:** `process.runtime`
 
 **Description:** The single (language) runtime instance which is monitored.
 

--- a/docs/resource/webengine.md
+++ b/docs/resource/webengine.md
@@ -10,8 +10,6 @@
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `webengine`
-
 **Description:** Resource describing the packaged software running the application code. Web engines are typically executed using process.runtime.
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/docs/resource/zos.md
+++ b/docs/resource/zos.md
@@ -13,8 +13,6 @@ This document defines z/OS software entity and documents how to populate other e
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-**type:** `zos.software`
-
 **Description:** A software resource running on a z/OS system.
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|

--- a/templates/registry/markdown/resource_macros.j2
+++ b/templates/registry/markdown/resource_macros.j2
@@ -10,7 +10,5 @@
 {% macro header(resource) %}
 **Status:** {{ real_stability(resource) | trim }}
 
-**type:** `{{ resource.name }}`
-
 **Description:** {{ resource.brief }}
 {% endmacro %}


### PR DESCRIPTION
Fixes #929

## Changes

This removes the type field from resource documents as type is a concept for entities for which we have a dedicated registry documenting them.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
