### PR TITLE
[chore] Use generic/ficticious example for conditionaly required attributes

### DIFF
--- a/docs/general/attribute-requirement-level.md
+++ b/docs/general/attribute-requirement-level.md
@@ -82,13 +82,11 @@ the `Opt-In` requirement level on the attribute.
 
 <!-- TODO(jsuereth) - make examples not break on changes to semconv -->
 
-For example, `example.attribute1` is `Conditionally Required` by a convention
-when available.
-If only `example.attribute2` is available instead, which may require an expensive
-operation (e.g., a lookup or computation) to retrieve, instrumentation can
-use `example.attribute2` to populate `example.attribute1`. However, this
-should only be done if the user explicitly enables the instrumentation to
-perform such operations, considering the potential performance impact.
+For example, `server.address` is `Conditionally Required` by a convention. When
+server IP address is available instead, instrumentation can do a DNS
+lookup, cache and populate `server.address`, but only if the user explicitly
+enables the instrumentation to do so, considering the performance issues that
+DNS lookups introduce.
 
 ## Recommended
 


### PR DESCRIPTION
Fixes #1508

## Changes

I tried finding an example, but wasn't very successful + I think it's better to keep it ficticious to avoid it "breaking" again. I think it still serves the purpose that it initially had. 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
