### PR TITLE
[editorial] Use canonical link to AI Foundary model inference API

### DIFF
--- a/docs/gen-ai/azure-ai-inference.md
+++ b/docs/gen-ai/azure-ai-inference.md
@@ -53,7 +53,7 @@ The Semantic Conventions for [Azure AI Inference](https://learn.microsoft.com/az
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-Semantic Conventions for [Azure AI Inference](https://learn.microsoft.com/azure/ai-studio/reference/reference-model-inference-api) client spans extend and override the semantic conventions for [Gen AI Spans](gen-ai-spans.md).
+Semantic Conventions for [Azure AI Inference](https://learn.microsoft.com/rest/api/aifoundry/modelinference/) client spans extend and override the semantic conventions for [Gen AI Spans](gen-ai-spans.md).
 
 `gen_ai.provider.name` MUST be set to `"azure.ai.inference"` and SHOULD be provided **at span creation time**.
 

--- a/model/gen-ai/spans.yaml
+++ b/model/gen-ai/spans.yaml
@@ -174,7 +174,7 @@ groups:
     type: span
     span_kind: client
     brief: >
-      Semantic Conventions for [Azure AI Inference](https://learn.microsoft.com/azure/ai-studio/reference/reference-model-inference-api)
+      Semantic Conventions for [Azure AI Inference](https://learn.microsoft.com/rest/api/aifoundry/modelinference/)
       client spans extend and override the semantic conventions for [Gen AI Spans](gen-ai-spans.md).
     note: |
       `gen_ai.provider.name` MUST be set to `"azure.ai.inference"` and SHOULD be provided **at span creation time**.


### PR DESCRIPTION
- Changes URL to AI Foundary model inference API to be the locale-neutral canonical link
- Issue found while working on https://github.com/open-telemetry/opentelemetry.io/pull/8095

Here are the redirects from the old URL:

```
location: /en-us/azure/ai-studio/reference/reference-model-inference-api
location: /en-us/azure/ai-foundry/model-inference/reference/reference-model-inference-api
location: /en-us/rest/api/aifoundry/modelinference
location: /en-us/rest/api/aifoundry/modelinference/
```