### PR TITLE
[system] Mark `cpu.logical_number` attribute as opt-in

### DIFF
--- a/.chloggen/mark-cpu-number-opt-in.yaml
+++ b/.chloggen/mark-cpu-number-opt-in.yaml
@@ -1,0 +1,17 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: system
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark `cpu.logical_number` attribute as opt-in for `system.cpu.time` and `system.cpu.utilization` metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2932]

--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -163,8 +163,8 @@ This metric is [recommended][MetricRecommended].
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`cpu.logical_number`](/docs/registry/attributes/cpu.md) | int | The logical CPU number [0..n-1] | `1` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`cpu.mode`](/docs/registry/attributes/cpu.md) | string | The mode of the CPU [1] | `user`; `system` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`cpu.logical_number`](/docs/registry/attributes/cpu.md) | int | The logical CPU number [0..n-1] | `1` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 **[1] `cpu.mode`:** Following states SHOULD be used: `user`, `system`, `nice`, `idle`, `iowait`, `interrupt`, `steal`
 
@@ -229,8 +229,8 @@ This metric is [opt-in][MetricOptIn].
 
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
-| [`cpu.logical_number`](/docs/registry/attributes/cpu.md) | int | The logical CPU number [0..n-1] | `1` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
 | [`cpu.mode`](/docs/registry/attributes/cpu.md) | string | The mode of the CPU [1] | `user`; `system` | `Recommended` | ![Development](https://img.shields.io/badge/-development-blue) |
+| [`cpu.logical_number`](/docs/registry/attributes/cpu.md) | int | The logical CPU number [0..n-1] | `1` | `Opt-In` | ![Development](https://img.shields.io/badge/-development-blue) |
 
 **[1] `cpu.mode`:** Following modes SHOULD be used: `user`, `system`, `nice`, `idle`, `iowait`, `interrupt`, `steal`
 

--- a/model/system/metrics.yaml
+++ b/model/system/metrics.yaml
@@ -61,6 +61,7 @@ groups:
       - ref: cpu.mode
         note: "Following states SHOULD be used: `user`, `system`, `nice`, `idle`, `iowait`, `interrupt`, `steal`"
       - ref: cpu.logical_number
+        requirement_level: opt_in
     entity_associations:
       - host
 
@@ -78,6 +79,7 @@ groups:
       - ref: cpu.mode
         note: "Following modes SHOULD be used: `user`, `system`, `nice`, `idle`, `iowait`, `interrupt`, `steal`"
       - ref: cpu.logical_number
+        requirement_level: opt_in
     entity_associations:
       - host
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/2932

## Changes

As discussed during the latest System SemConv SIG call, the `cpu.logical_number` attribute should be marked as opt-in for `system.cpu.time`, `system.cpu.utilization` CPU metrics.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
  - Will be introduced in collector once https://github.com/open-telemetry/opentelemetry-collector/pull/13900 is merged
