### PR TITLE
[chore] fix location of status metric doc

### DIFF
--- a/docs/how-to-write-conventions/status-metrics.md
+++ b/docs/how-to-write-conventions/status-metrics.md
@@ -49,7 +49,7 @@ The metric is
 rather than a `Gauge`. This is a deliberate choice, as it is a reasonable use
 case to count objects that are in a particular state. Since the metric value is
 either `0` or `1` for a given state attribute value, this means you can do a
-simplesum aggregation to count instances of particular states.
+simple sum aggregation to count instances of particular states.
 
 ### Should it be an Entity Attribute?
 
@@ -76,7 +76,7 @@ The general recommendation is to use the word "state" for the attribute and
 "status" for the metric. This is derived from common turns of phrase for each
 word, respectively:
 
-"What **state** is X in?"  
+"What **state** is X in?"
 "What is the **current status** of X?"
 
 The english-language semantics of this are heavily debatable, thus for the sake


### PR DESCRIPTION
## Changes

This moves status metric doc to be with other how to write docs.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
