### PR TITLE
[chore] fix bug in validate-area-ownership action when area has no owners

### DIFF
--- a/.github/scripts/triage/utils.ts
+++ b/.github/scripts/triage/utils.ts
@@ -8,7 +8,7 @@ export interface Owner {
 
 export interface Area {
     name: string
-    owner: Owner[]
+    owner?: Owner[]
     project: string
     board: string
     labels: string[]
@@ -30,7 +30,7 @@ export function getActiveAreasWithCodeOwners(areas: Area[]): Map<string, Set<str
             }
             // add all owners - an area can be owned by multiple teams
             // as well as a team own many areas.
-            area.owner.forEach((owner) => {
+            area.owner?.forEach((owner) => {
                 areaOwnersMap.get(labelWithoutPrefix)!.add(owner.github);
             });
         });


### PR DESCRIPTION
## Changes

The workflow can fail if an area in `areas.yaml` doesn't have any owners, for example https://github.com/open-telemetry/semantic-conventions/actions/runs/18696230217/job/53314344981?pr=2953#logs

<details><summary>Some areas have no owners 
</summary>
<p>

https://github.com/open-telemetry/semantic-conventions/blob/8b4f210f43136e57c1f6f47292eb6d38e3bf30bb/areas.yaml#L219-L236

</p>
</details> 


## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
