### PR TITLE
[chore] Additional test case cases for SQL sanitisation and summary

### DIFF
--- a/docs/non-normative/database-test-cases/db-sql-test-cases.json
+++ b/docs/non-normative/database-test-cases/db-sql-test-cases.json
@@ -294,7 +294,8 @@
         },
         "expected": {
             "db.query.text": [
-                "ALTER  TABLE MyTable ADD Name varchar(?)"
+                "ALTER  TABLE MyTable ADD Name varchar(?)",
+                "ALTER  TABLE MyTable ADD Name varchar(255)"
             ],
             "db.query.summary": "ALTER TABLE MyTable"
         }
@@ -311,5 +312,864 @@
             ],
             "db.query.summary": "DROP TABLE MyTable"
         }
+    },
+    {
+    "name": "keyword_prefix_for_target",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM SelectedData"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM SelectedData"
+      ],
+      "db.query.summary": "SELECT SelectedData"
     }
+  },
+  {
+    "name": "summary_truncated",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM Vecnzotjejucwitzgrfifscuevittljlnrlpbruvkezeptqciyvbjhsytmbucbhwttidayecnthaztxbyppbyztcqccedeirgkxzrfezjxfwbtuqxeusroqgbvulgmsvnelovkxqsaqmlogomkhtjuirzhaocxlrmerihnmwaelullionarkmxwdamhduwrbooknqsnilurutgyerxphokeqnnoumbpcfjtmqrbpukjllofiwaltyoawkp o, OrderDetails od"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM Vecnzotjejucwitzgrfifscuevittljlnrlpbruvkezeptqciyvbjhsytmbucbhwttidayecnthaztxbyppbyztcqccedeirgkxzrfezjxfwbtuqxeusroqgbvulgmsvnelovkxqsaqmlogomkhtjuirzhaocxlrmerihnmwaelullionarkmxwdamhduwrbooknqsnilurutgyerxphokeqnnoumbpcfjtmqrbpukjllofiwaltyoawkp o, OrderDetails od"
+      ],
+      "db.query.summary": "SELECT"
+    }
+  },
+  {
+    "name": "create_unique_clustered_index",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE UNIQUE CLUSTERED INDEX IX_Employee_Email ON Employees (Email);"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE UNIQUE CLUSTERED INDEX IX_Employee_Email ON Employees (Email);"
+      ],
+      "db.query.summary": "CREATE INDEX IX_Employee_Email"
+    }
+  },
+  {
+    "name": "create_unique_index",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE UNIQUE INDEX IX_Employee_Email ON Employees (Email);"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE UNIQUE INDEX IX_Employee_Email ON Employees (Email);"
+      ],
+      "db.query.summary": "CREATE INDEX IX_Employee_Email"
+    }
+  },
+  {
+    "name": "select_distinct",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT DISTINCT Country FROM Countries"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT DISTINCT Country FROM Countries"
+      ],
+      "db.query.summary": "SELECT Countries"
+    }
+  },
+  {
+    "name": "select_distinct_with_join",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT DISTINCT o.Id FROM Orders o JOIN Customers c ON o.CustomerId = c.Id"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT DISTINCT o.Id FROM Orders o JOIN Customers c ON o.CustomerId = c.Id"
+      ],
+      "db.query.summary": "SELECT Orders Customers"
+    }
+  },
+  {
+    "name": "create_table_with_if_not_exists",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE TABLE IF NOT EXISTS Users (Id INT PRIMARY KEY, Name NVARCHAR(100));"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE TABLE IF NOT EXISTS Users (Id INT PRIMARY KEY, Name NVARCHAR(?));",
+        "CREATE TABLE IF NOT EXISTS Users (Id INT PRIMARY KEY, Name NVARCHAR(100));"
+      ],
+      "db.query.summary": "CREATE TABLE Users"
+    }
+  },
+  {
+    "name": "create_view_with_select",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE VIEW ActiveUsers AS SELECT * FROM Users WHERE IsActive = 1;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE VIEW ActiveUsers AS SELECT * FROM Users WHERE IsActive = ?;"
+      ],
+      "db.query.summary": "CREATE VIEW ActiveUsers"
+    }
+  },
+  {
+    "name": "alter_table_add_column",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER TABLE Orders ADD COLUMN OrderStatus NVARCHAR(50);"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER TABLE Orders ADD COLUMN OrderStatus NVARCHAR(?);",
+        "ALTER TABLE Orders ADD COLUMN OrderStatus NVARCHAR(50);"
+      ],
+      "db.query.summary": "ALTER TABLE Orders"
+    }
+  },
+  {
+    "name": "alter_table_rename_column",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER TABLE Orders RENAME COLUMN OldName TO NewName;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER TABLE Orders RENAME COLUMN OldName TO NewName;"
+      ],
+      "db.query.summary": "ALTER TABLE Orders"
+    }
+  },
+  {
+    "name": "create_procedure_with_params",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE PROCEDURE GetUserById @UserId INT AS SELECT * FROM Users WHERE Id = @UserId;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE PROCEDURE GetUserById @UserId INT AS SELECT * FROM Users WHERE Id = @UserId;"
+      ],
+      "db.query.summary": "CREATE PROCEDURE GetUserById"
+    }
+  },
+  {
+    "name": "alter_view_as_select",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER VIEW ActiveUsers AS SELECT * FROM Users WHERE IsActive = 1;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER VIEW ActiveUsers AS SELECT * FROM Users WHERE IsActive = ?;"
+      ],
+      "db.query.summary": "ALTER VIEW ActiveUsers"
+    }
+  },
+  {
+    "name": "create_trigger_on_table",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE TRIGGER trg_UpdateTimestamp ON Orders AFTER UPDATE AS BEGIN UPDATE Orders SET UpdatedAt = GETDATE() WHERE Id IN (SELECT Id FROM inserted); END;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE TRIGGER trg_UpdateTimestamp ON Orders AFTER UPDATE AS BEGIN UPDATE Orders SET UpdatedAt = GETDATE() WHERE Id IN (SELECT Id FROM inserted); END;"
+      ],
+      "db.query.summary": "CREATE TRIGGER trg_UpdateTimestamp"
+    }
+  },
+  {
+    "name": "alter_procedure_with_params",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER PROCEDURE UpdateUserEmail @UserId INT, @Email NVARCHAR(100) AS UPDATE Users SET Email = @Email WHERE Id = @UserId;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER PROCEDURE UpdateUserEmail @UserId INT, @Email NVARCHAR(?) AS UPDATE Users SET Email = @Email WHERE Id = @UserId;",
+        "ALTER PROCEDURE UpdateUserEmail @UserId INT, @Email NVARCHAR(100) AS UPDATE Users SET Email = @Email WHERE Id = @UserId;"
+      ],
+      "db.query.summary": "ALTER PROCEDURE UpdateUserEmail"
+    }
+  },
+  {
+    "name": "create_index_with_include",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE INDEX IX_Orders_CustomerId ON Orders (CustomerId) INCLUDE (OrderDate, TotalAmount);"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE INDEX IX_Orders_CustomerId ON Orders (CustomerId) INCLUDE (OrderDate, TotalAmount);"
+      ],
+      "db.query.summary": "CREATE INDEX IX_Orders_CustomerId"
+    }
+  },
+  {
+    "name": "alter_table_drop_column",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER TABLE Orders DROP COLUMN TempColumn;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER TABLE Orders DROP COLUMN TempColumn;"
+      ],
+      "db.query.summary": "ALTER TABLE Orders"
+    }
+  },
+  {
+    "name": "drop_trigger",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP TRIGGER IF EXISTS trg_AfterInsert;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP TRIGGER IF EXISTS trg_AfterInsert;"
+      ],
+      "db.query.summary": "DROP TRIGGER trg_AfterInsert"
+    }
+  },
+  {
+    "name": "alter_trigger",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER TRIGGER trg_AfterInsert ON Employees AFTER INSERT AS BEGIN INSERT INTO AuditLog (EmployeeId, Action) SELECT Id, 'INSERT' FROM inserted; END;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER TRIGGER trg_AfterInsert ON Employees AFTER INSERT AS BEGIN INSERT INTO AuditLog (EmployeeId, Action) SELECT Id, ? FROM inserted; END;"
+      ],
+      "db.query.summary": "ALTER TRIGGER trg_AfterInsert"
+    }
+  },
+  {
+    "name": "create_procedure_with_multiple_params",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE PROCEDURE AddEmployee @Name NVARCHAR(100), @Email NVARCHAR(100) AS INSERT INTO Employees (Name, Email) VALUES (@Name, @Email);"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE PROCEDURE AddEmployee @Name NVARCHAR(?), @Email NVARCHAR(?) AS INSERT INTO Employees (Name, Email) VALUES (@Name, @Email);",
+        "CREATE PROCEDURE AddEmployee @Name NVARCHAR(100), @Email NVARCHAR(100) AS INSERT INTO Employees (Name, Email) VALUES (@Name, @Email);"
+      ],
+      "db.query.summary": "CREATE PROCEDURE AddEmployee"
+    }
+  },
+  {
+    "name": "drop_procedure",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP PROCEDURE IF EXISTS RemoveEmployee;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP PROCEDURE IF EXISTS RemoveEmployee;"
+      ],
+      "db.query.summary": "DROP PROCEDURE RemoveEmployee"
+    }
+  },
+  {
+    "name": "alter_procedure_add_param",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER PROCEDURE UpdateEmployeeEmail @EmployeeId INT, @Email NVARCHAR(100) AS UPDATE Employees SET Email = @Email WHERE Id = @EmployeeId;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER PROCEDURE UpdateEmployeeEmail @EmployeeId INT, @Email NVARCHAR(?) AS UPDATE Employees SET Email = @Email WHERE Id = @EmployeeId;",
+        "ALTER PROCEDURE UpdateEmployeeEmail @EmployeeId INT, @Email NVARCHAR(100) AS UPDATE Employees SET Email = @Email WHERE Id = @EmployeeId;"
+      ],
+      "db.query.summary": "ALTER PROCEDURE UpdateEmployeeEmail"
+    }
+  },
+  {
+    "name": "select_with_multiple_joins_and_group_by",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT o.Id, c.Name, SUM(oi.Quantity) FROM Orders o JOIN Customers c ON o.CustomerId = c.Id JOIN OrderItems oi ON o.Id = oi.OrderId GROUP BY o.Id, c.Name;"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT o.Id, c.Name, SUM(oi.Quantity) FROM Orders o JOIN Customers c ON o.CustomerId = c.Id JOIN OrderItems oi ON o.Id = oi.OrderId GROUP BY o.Id, c.Name;"
+      ],
+      "db.query.summary": "SELECT Orders Customers OrderItems"
+    }
+  },
+  {
+    "name": "select_with_distinct_and_window_function",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT DISTINCT Department, COUNT(*) OVER (PARTITION BY Department) AS DeptCount FROM Employees;"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT DISTINCT Department, COUNT(*) OVER (PARTITION BY Department) AS DeptCount FROM Employees;"
+      ],
+      "db.query.summary": "SELECT Employees"
+    }
+  },
+  {
+    "name": "select_with_union_and_order_by",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT Id, Name FROM Customers UNION SELECT Id, Name FROM Suppliers ORDER BY Name;"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT Id, Name FROM Customers UNION SELECT Id, Name FROM Suppliers ORDER BY Name;"
+      ],
+      "db.query.summary": "SELECT Customers Suppliers"
+    }
+  },
+  {
+    "name": "create_database",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE DATABASE TestDb;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE DATABASE TestDb;"
+      ],
+      "db.query.summary": "CREATE DATABASE TestDb"
+    }
+  },
+  {
+    "name": "alter_database",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER DATABASE TestDb MODIFY NAME = NewTestDb;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER DATABASE TestDb MODIFY NAME = NewTestDb;"
+      ],
+      "db.query.summary": "ALTER DATABASE TestDb"
+    }
+  },
+  {
+    "name": "drop_database",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP DATABASE IF EXISTS TestDb;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP DATABASE IF EXISTS TestDb;"
+      ],
+      "db.query.summary": "DROP DATABASE TestDb"
+    }
+  },
+  {
+    "name": "create_schema",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE SCHEMA Reporting;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE SCHEMA Reporting;"
+      ],
+      "db.query.summary": "CREATE SCHEMA Reporting"
+    }
+  },
+  {
+    "name": "alter_schema",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER SCHEMA Reporting TRANSFER dbo.OldTable;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER SCHEMA Reporting TRANSFER dbo.OldTable;"
+      ],
+      "db.query.summary": "ALTER SCHEMA Reporting"
+    }
+  },
+  {
+    "name": "drop_schema",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP SCHEMA IF EXISTS Reporting;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP SCHEMA IF EXISTS Reporting;"
+      ],
+      "db.query.summary": "DROP SCHEMA Reporting"
+    }
+  },
+  {
+    "name": "create_sequence",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE SEQUENCE SalesSeq START WITH 1 INCREMENT BY 1;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE SEQUENCE SalesSeq START WITH ? INCREMENT BY ?;"
+      ],
+      "db.query.summary": "CREATE SEQUENCE SalesSeq"
+    }
+  },
+  {
+    "name": "alter_sequence",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER SEQUENCE SalesSeq RESTART WITH 100;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER SEQUENCE SalesSeq RESTART WITH ?;"
+      ],
+      "db.query.summary": "ALTER SEQUENCE SalesSeq"
+    }
+  },
+  {
+    "name": "drop_sequence",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP SEQUENCE SalesSeq;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP SEQUENCE SalesSeq;"
+      ],
+      "db.query.summary": "DROP SEQUENCE SalesSeq"
+    }
+  },
+  {
+    "name": "create_function_tsql",
+    "input": {
+      "db.system.name": "microsoft.sql_server",
+      "query": "CREATE FUNCTION dbo.GetTotal(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a + @b; END;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE FUNCTION dbo.GetTotal(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a + @b; END;"
+      ],
+      "db.query.summary": "CREATE FUNCTION dbo.GetTotal"
+    }
+  },
+  {
+    "name": "alter_function_tsql",
+    "input": {
+      "db.system.name": "microsoft.sql_server",
+      "query": "ALTER FUNCTION dbo.GetTotal(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a * @b; END;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER FUNCTION dbo.GetTotal(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a * @b; END;"
+      ],
+      "db.query.summary": "ALTER FUNCTION dbo.GetTotal"
+    }
+  },
+  {
+    "name": "drop_function_tsql",
+    "input": {
+      "db.system.name": "microsoft.sql_server",
+      "query": "DROP FUNCTION dbo.GetTotal;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP FUNCTION dbo.GetTotal;"
+      ],
+      "db.query.summary": "DROP FUNCTION dbo.GetTotal"
+    }
+  },
+  {
+    "name": "create_user",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE USER johndoe WITH PASSWORD = 'password';"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE USER johndoe WITH PASSWORD = ?;"
+      ],
+      "db.query.summary": "CREATE USER johndoe"
+    }
+  },
+  {
+    "name": "alter_user",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER USER johndoe WITH PASSWORD = 'newpassword';"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER USER johndoe WITH PASSWORD = ?;"
+      ],
+      "db.query.summary": "ALTER USER johndoe"
+    }
+  },
+  {
+    "name": "drop_user",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP USER IF EXISTS johndoe;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP USER IF EXISTS johndoe;"
+      ],
+      "db.query.summary": "DROP USER johndoe"
+    }
+  },
+  {
+    "name": "create_role",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE ROLE app_admin;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE ROLE app_admin;"
+      ],
+      "db.query.summary": "CREATE ROLE app_admin"
+    }
+  },
+  {
+    "name": "alter_role",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER ROLE app_admin ADD MEMBER johndoe;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER ROLE app_admin ADD MEMBER johndoe;"
+      ],
+      "db.query.summary": "ALTER ROLE app_admin"
+    }
+  },
+  {
+    "name": "drop_role",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP ROLE IF EXISTS app_admin;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP ROLE IF EXISTS app_admin;"
+      ],
+      "db.query.summary": "DROP ROLE app_admin"
+    }
+  },
+  {
+    "name": "alter_index",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER INDEX IX_Employee_Email ON Employees REBUILD;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER INDEX IX_Employee_Email ON Employees REBUILD;"
+      ],
+      "db.query.summary": "ALTER INDEX IX_Employee_Email"
+    }
+  },
+  {
+    "name": "exec_sp_rename_table_tsql",
+    "input": {
+      "db.system.name": "microsoft.sql_server",
+      "query": "EXEC sp_rename 'OldTable', 'NewTable';"
+    },
+    "expected": {
+      "db.query.text": [
+        "EXEC sp_rename ?, ?;"
+      ],
+      "db.query.summary": "EXEC sp_rename"
+    }
+  },
+  {
+    "name": "exec_stored_procedure_no_params",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "EXEC GetAllEmployees;"
+    },
+    "expected": {
+      "db.query.text": [
+        "EXEC GetAllEmployees;"
+      ],
+      "db.query.summary": "EXEC GetAllEmployees"
+    }
+  },
+  {
+    "name": "exec_stored_procedure_with_params",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "EXEC GetEmployeeById @EmployeeId = 42;"
+    },
+    "expected": {
+      "db.query.text": [
+        "EXEC GetEmployeeById @EmployeeId = ?;"
+      ],
+      "db.query.summary": "EXEC GetEmployeeById"
+    }
+  },
+  {
+    "name": "insert_values_parenthesized_number",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "INSERT INTO T (A) VALUES (123)"
+    },
+    "expected": {
+      "db.query.text": [
+        "INSERT INTO T (A) VALUES (?)"
+      ],
+      "db.query.summary": "INSERT T"
+    }
+  },
+  {
+    "name": "parenthesized_constant_select",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT (123) AS C;"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT (?) AS C;"
+      ],
+      "db.query.summary": "SELECT"
+    }
+  },
+  {
+    "name": "update_set_parenthesized_constant",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "UPDATE T SET A = (999);"
+    },
+    "expected": {
+      "db.query.text": [
+        "UPDATE T SET A = (?);"
+      ],
+      "db.query.summary": "UPDATE"
+    }
+  },
+  {
+    "name": "create_table_default_parenthesized_constant",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE TABLE T (A INT DEFAULT (123));"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE TABLE T (A INT DEFAULT (?));"
+      ],
+      "db.query.summary": "CREATE TABLE T"
+    }
+  },
+  {
+    "name": "nested_parentheses_constant_select",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT ((123)) AS C;"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT ((?)) AS C;"
+      ],
+      "db.query.summary": "SELECT"
+    }
+  },
+  {
+    "name": "function_arg_parenthesized_constant",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT ABS((123));"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT ABS((?));"
+      ],
+      "db.query.summary": "SELECT"
+    }
+  },
+  {
+    "name": "between_parenthesized_constants",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM T WHERE Amount BETWEEN (10) AND (20);"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM T WHERE Amount BETWEEN (?) AND (?);"
+      ],
+      "db.query.summary": "SELECT T"
+    }
+  },
+  {
+    "name": "coalesce_first_arg_parenthesized_constant",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM T WHERE Id = COALESCE((123), 0);"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM T WHERE Id = COALESCE((?), ?);"
+      ],
+      "db.query.summary": "SELECT T"
+    }
+  },
+  {
+    "name": "cast_parenthesized_constant",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT CAST((123) AS INT);"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT CAST((?) AS INT);"
+      ],
+      "db.query.summary": "SELECT"
+    }
+  },
+  {
+    "name": "valid_type_length_specifiers_varchar_char",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE TABLE Table (Name VARCHAR(255), Code CHAR(10));"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE TABLE Table (Name VARCHAR(?), Code CHAR(?));",
+        "CREATE TABLE Table (Name VARCHAR(255), Code CHAR(10));"
+      ],
+      "db.query.summary": "CREATE TABLE Table"
+    }
+  },
+  {
+    "name": "valid_type_length_specifiers_varbinary_datetime2_time",
+    "input": {
+      "db.system.name": "microsoft.sql_server",
+      "query": "CREATE TABLE Table (Payload VARBINARY(16), EventTime DATETIME2(7), Duration TIME(7));"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE TABLE Table (Payload VARBINARY(?), EventTime DATETIME2(?), Duration TIME(?));",
+        "CREATE TABLE Table (Payload VARBINARY(16), EventTime DATETIME2(7), Duration TIME(7));"
+      ],
+      "db.query.summary": "CREATE TABLE Table"
+    }
+  },
+  {
+    "name": "valid_top_with_parentheses",
+    "input": {
+      "db.system.name": "microsoft.sql_server",
+      "query": "SELECT TOP (10) * FROM Employees"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT TOP (?) * FROM Employees",
+        "SELECT TOP (10) * FROM Employees"
+      ],
+      "db.query.summary": "SELECT Employees"
+    }
+  },
+  {
+    "name": "sanitized_top_without_parentheses",
+    "input": {
+      "db.system.name": "microsoft.sql_server",
+      "query": "SELECT TOP 10 * FROM Employees"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT TOP ? * FROM Employees",
+        "SELECT TOP 10 * FROM Employees"
+      ],
+      "db.query.summary": "SELECT Employees"
+    }
+  },
+  {
+    "name": "in_clause_starting_with_negative_literal",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM table WHERE value IN (-123, .456, 'abc', 0.12, 1e10)"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM table WHERE value IN (?)",
+        "SELECT * FROM table WHERE value IN (?, ?, ?, ?, ?)"
+      ],
+      "db.query.summary": "SELECT table"
+    }
+  },
+  {
+    "name": "in_clause_starting_with_hex_literal",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM table WHERE value IN (0xAB, .456, 'abc', 0.12, 1e10)"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM table WHERE value IN (?)",
+        "SELECT * FROM table WHERE value IN (?, ?, ?, ?, ?)"
+      ],
+      "db.query.summary": "SELECT table"
+    }
+  },
+  {
+    "name": "in_clause_starting_with_string_literal",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM table WHERE value IN ('abc', 0xAB, .456, 0.12, 1e10)"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM table WHERE value IN (?)",
+        "SELECT * FROM table WHERE value IN (?, ?, ?, ?, ?)"
+      ],
+      "db.query.summary": "SELECT table"
+    }
+  },
+  {
+    "name": "malformed_in_clause",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM table WHERE value IN ('abc', 0xAB, .456,"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM table WHERE value IN (?, ?, ?,"
+      ],
+      "db.query.summary": "SELECT table"
+    }
+  },
+  {
+    "name": "malformed_alter_table_example_one",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER  TABLE MyTable ADD Name varchar(255) 'mypassword' 1234"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER  TABLE MyTable ADD Name varchar(255) ? ?",
+        "ALTER  TABLE MyTable ADD Name varchar(?) ? ?"
+      ],
+      "db.query.summary": "ALTER TABLE MyTable"
+    }
+  },
+  {
+    "name": "malformed_alter_table_example_two",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER  TABLE MyTable 'mypassword' ADD 123 Name varchar(255)"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER  TABLE MyTable ? ADD ? Name varchar(255)",
+        "ALTER  TABLE MyTable ? ADD ? Name varchar(?)"
+      ],
+      "db.query.summary": "ALTER TABLE MyTable"
+    }
+  }
 ]


### PR DESCRIPTION
## Changes

Adds extra test cases for SQL query text sanitisation and summary parsing to cover more scenarios.

We have used these test cases in the [.NET implementation](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3116) while refining and optimising it. 

An open area for discussion is whether it should be optional to skip numeric literal sanitisation when the value is used as part of a TOP (e.g. `SELECT TOP (10) FROM MyTable`) statement or type declaration (e.g. `ALTER TABLE Orders ADD COLUMN OrderStatus NVARCHAR(50)`). The tests currently allow this as an optional expectation. 

cc @alanwest 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] ~Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).~
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] ~Links to the prototypes or existing instrumentations (when adding or changing conventions)~