### PR TITLE
[chore] Remove no longer needed front matter properties

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,9 +197,6 @@ headers like the following:
 ```md
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: HTTP
-path_base_for_github_subdir:
-  from: content/en/docs/specs/semconv/http/_index.md
-  to: http/README.md
 --->
 ```
 


### PR DESCRIPTION
## Changes 

Removed path_base_for_github_subdir from Hugo front matter example in contributing as we stopped using it with https://github.com/open-telemetry/semantic-conventions/pull/1846

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
