### PR TITLE
[chore] clarify reason for deprecation of event.name

### DIFF
--- a/docs/registry/attributes/event.md
+++ b/docs/registry/attributes/event.md
@@ -9,4 +9,4 @@ Attributes for Events represented using Log Records.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
-| <a id="event-name" href="#event-name">`event.name`</a> | string | Identifies the class / type of event. | `browser.mouse.click`; `device.app.lifecycle` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Replaced by EventName top-level field on the LogRecord. |
+| <a id="event-name" href="#event-name">`event.name`</a> | string | Identifies the class / type of event. | `browser.mouse.click`; `device.app.lifecycle` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>The value of this attribute MUST now be set as the value of the EventName field on the LogRecord to indicate that the LogRecord represents an Event. |

--- a/model/event/deprecated/registry-deprecated.yaml
+++ b/model/event/deprecated/registry-deprecated.yaml
@@ -11,7 +11,7 @@ groups:
         deprecated:
           reason: uncategorized
           note: >
-            Replaced by EventName top-level field on the LogRecord.
+            The value of this attribute MUST now be set as the value of the EventName field on the LogRecord to indicate that the LogRecord represents an Event.
         brief: >
           Identifies the class / type of event.
         examples: ["browser.mouse.click", "device.app.lifecycle"]


### PR DESCRIPTION
Fixes #2904

## Changes

Makes it clearer why event.name was deprecated and what to do with the value.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
