### PR TITLE
[chore] Add prettier to cicd

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,8 +14,11 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - run: npm run check:format
+      - name: check out code
+        uses: actions/checkout@v5
+
+      - name: run prettier
+        run: npm run check:format
 
   markdownlint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ yamllint:
 .PHONY: prettier
 prettier:
 	@if ! npm ls prettier; then npm install; fi
-	npx --no -- prettier --check . || (echo '[help] Run: npm run format'; )
+	npm run fix:format
 
 # Generate markdown tables from YAML definitions
 .PHONY: table-generation


### PR DESCRIPTION
Fixes #189 

## Changes

Prettier now runs as part of cicd pipeline to ensure compliancy of new docs and changes.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
