### PR TITLE
Fix markdown formatting

### DIFF
--- a/docs/system/system-metrics.md
+++ b/docs/system/system-metrics.md
@@ -14,7 +14,7 @@ instruments not explicitly defined in the specification.
 The `system.*` namespace SHOULD be exclusively used to report hosts' metrics.
 The `system.*` namespace SHOULD only be used when the metrics are collected from within the target system. (physical servers, virtual machines etc).
 Metrics collected from technology-specific, well-defined APIs (e.g. Kubelet's API or container runtimes)
-should be reported under their respective namespace (e.g. k8s.*, container.*).
+should be reported under their respective namespace (e.g. `k8s.*`, `container.*`).
 Resource attributes related to a host, SHOULD be reported under the `host.*` namespace.
 
 <!-- toc -->


### PR DESCRIPTION
Currently rendering as italics.

Noticed when reviewing #3010