### PR TITLE
[otel] add otel.event.name attribute

### DIFF
--- a/.chloggen/2913.yaml
+++ b/.chloggen/2913.yaml
@@ -1,0 +1,8 @@
+change_type: enhancement
+component: otel
+note: "Add `otel.event.name` attribute for use by non-OTLP exporters and logging libraries."
+issues: [2913]
+subtext: |
+  The `otel.event.name` attribute can be used by:
+  - Non-OTLP exporters to emit the `EventName`
+  - Applications using existing logging libraries to add event name information that can be used to set the `EventName` field by Collector or SDK components

--- a/docs/registry/attributes/otel.md
+++ b/docs/registry/attributes/otel.md
@@ -5,6 +5,7 @@
 
 - [OTel Attributes](#otel-attributes)
 - [OTel Component Attributes](#otel-component-attributes)
+- [OTel Event Attributes](#otel-event-attributes)
 - [OTel Scope Attributes](#otel-scope-attributes)
 - [Deprecated OTel Library Attributes](#deprecated-otel-library-attributes)
 
@@ -100,6 +101,18 @@ E.g. for Java the fully qualified classname SHOULD be used in this case.
 | `simple_log_processor` | The builtin SDK simple log record processor | ![Development](https://img.shields.io/badge/-development-blue) |
 | `simple_span_processor` | The builtin SDK simple span processor | ![Development](https://img.shields.io/badge/-development-blue) |
 | `zipkin_http_span_exporter` | Zipkin span exporter over HTTP | ![Development](https://img.shields.io/badge/-development-blue) |
+
+## OTel Event Attributes
+
+Attributes used by non-OTLP exporters to represent OpenTelemetry Event's concepts.
+
+**Attributes:**
+
+| Key | Stability | Value Type | Description | Example Values |
+|---|---|---|---|---|
+| <a id="otel-event-name" href="#otel-event-name">`otel.event.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Identifies the class / type of event. [3] | `browser.mouse.click`; `device.app.lifecycle` |
+
+**[3] `otel.event.name`:** This attribute SHOULD be used by non-OTLP exporters when destination does not support `EventName` or equivalent field. This attribute MAY be used by applications using existing logging libraries so that it can be used to set the `EventName` field by Collector or SDK components.
 
 ## OTel Scope Attributes
 

--- a/model/otel/registry.yaml
+++ b/model/otel/registry.yaml
@@ -76,6 +76,23 @@ groups:
         brief: The schema URL of the instrumentation scope.
         examples: ['https://opentelemetry.io/schemas/1.31.0']
         stability: development
+  - id: registry.otel.event
+    type: attribute_group
+    display_name: OTel Event Attributes
+    brief: Attributes used by non-OTLP exporters to represent OpenTelemetry Event's concepts.
+    attributes:
+      - id: otel.event.name
+        type: string
+        stability: development
+        brief: >
+          Identifies the class / type of event.
+        note: >
+          This attribute SHOULD be used by non-OTLP exporters
+          when destination does not support `EventName` or equivalent field.
+          This attribute MAY be used by applications using existing logging
+          libraries so that it can be used to set the `EventName` field by
+          Collector or SDK components.
+        examples: ["browser.mouse.click", "device.app.lifecycle"]
   - id: registry.otel.component
     type: attribute_group
     display_name: OTel Component Attributes


### PR DESCRIPTION
Fixes #2913

This PR introduces the `otel.event.name` attribute for use by non-OTLP exporters and logging libraries.

The `otel.event.name` attribute can be used by:
- Non-OTLP exporters to emit the `EventName` when the destination does not support `EventName` or an equivalent field
- Applications using existing logging libraries to add event name information that can be used to set the `EventName` field by Collector or SDK components

This follows a similar pattern to #2715, but uses the `otel.*` namespace instead of `event.*` to properly represent OpenTelemetry-specific concepts used for bridging between formats.

Example from OTel Go:
- https://github.com/open-telemetry/opentelemetry-go/pull/7568