### PR TITLE
[chore] Update Renovate configuration to best practices

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "docker:pinDigests",
+    "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "postUpdateOptions" : [


### PR DESCRIPTION
## Changes

This upgrades the renovate preset to follow the best practices rather than just the recommended as outlined in https://docs.renovatebot.com/upgrade-best-practices/

The difference is the addition of the following profiles/rule-sets:

- docker:pinDigests which we previously opted in to
- helpers:pinGitHubActionDigests which we already override
- :configMigration
- :pinDevDependencies
- abandonments:recommended

In effect this gives us insight packages which have been abandoned ie misspell (as seen in https://github.com/open-telemetry/opentelemetry-specification/issues/4507), allows for automatic migration of legacy config options and also rules for dev dependencies.

This also aligns the settings with what the spec repo uses https://github.com/open-telemetry/opentelemetry-specification/blob/main/.github/renovate.json.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
