### PR TITLE
[chore] Add OpenSSF Scorecard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Specification Version](https://img.shields.io/badge/OTel_specification_version-v1.50.0-blue?logo=opentelemetry&color=f5a800)](https://github.com/open-telemetry/opentelemetry-specification/releases/tag/v1.50.0)
 [![Slack](https://img.shields.io/badge/Slack-otel_semantic_conventions-purple)](https://cloud-native.slack.com/archives/C041APFBYQP)
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/open-telemetry/semantic-conventions/badge)](https://scorecard.dev/viewer/?uri=github.com/open-telemetry/semantic-conventions)
+
 Semantic Conventions define a common set of (semantic) attributes which
 provide meaning to data when collecting, producing and consuming it.
 


### PR DESCRIPTION
## Changes

Adds the openssf scorecard to the project readme. The best practise should be done by a maintainer as it requires registering project which can be done via https://www.bestpractices.dev/en/projects/new

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
