### PR TITLE
[chore] Fix link title

### DIFF
--- a/docs/system/openshift-metrics.md
+++ b/docs/system/openshift-metrics.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: Kubernetes
+linkTitle: OpenShift
 --->
 
 # Semantic conventions for OpenShift metrics


### PR DESCRIPTION
## Changes

The link to OpenShift docs is now named OpenShift as opposed to Kubernetes. This removes confusion by having 2 links named Kubernetes in the same folder.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
