### PR TITLE
Make scorecard happy

### DIFF
--- a/.github/workflows/check-changes-ownership.yml
+++ b/.github/workflows/check-changes-ownership.yml
@@ -5,8 +5,11 @@ on:
     branches: [ 'main' ]
     paths:
       - 'model/**'
-jobs:
 
+permissions:
+  contents: read
+
+jobs:
   get-changed-files:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
See https://scorecard.dev/viewer/?uri=github.com/open-telemetry/semantic-conventions

and https://github.com/ossf/scorecard/blob/c22063e786c11f9dd714d777a687ff7c4599b600/docs/checks.md#token-permissions

> The highest score is awarded when the permissions definitions in each workflow's yaml file are set as read-only at the [top level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions) and the required write permissions are declared at the [run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions).