### PR TITLE
[chore] Fix the error.type table nested in the note

### DIFF
--- a/docs/dotnet/dotnet-kestrel-metrics.md
+++ b/docs/dotnet/dotnet-kestrel-metrics.md
@@ -127,8 +127,8 @@ of `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
 **[1] `error.type`:** Starting from .NET 9, Kestrel `kestrel.connection.duration` metric reports
 the following errors types when a corresponding error occurs:
 
-| Value  | Description | Stability |
-|---|---|---|
+| Value  | Description |
+| --- | --- |
 | `aborted_by_app` | The HTTP/1.1 connection was aborted when app code aborted an HTTP request with `HttpContext.Abort()`. |
 | `app_shutdown_timeout` | The connection was aborted during app shutdown. During shutdown, the server stops accepting new connections and HTTP requests, and it is given time for active requests to complete. If the app shutdown timeout is exceeded, all remaining connections are aborted. |
 | `closed_critical_stream` | A critical control stream for an HTTP/3 connection was closed. |

--- a/model/kestrel/metrics.yaml
+++ b/model/kestrel/metrics.yaml
@@ -55,8 +55,8 @@ groups:
           Starting from .NET 9, Kestrel `kestrel.connection.duration` metric reports
           the following errors types when a corresponding error occurs:
 
-          | Value  | Description | Stability |
-          |---|---|---|
+          | Value  | Description |
+          | --- | --- |
           | `aborted_by_app` | The HTTP/1.1 connection was aborted when app code aborted an HTTP request with `HttpContext.Abort()`. |
           | `app_shutdown_timeout` | The connection was aborted during app shutdown. During shutdown, the server stops accepting new connections and HTTP requests, and it is given time for active requests to complete. If the app shutdown timeout is exceeded, all remaining connections are aborted. |
           | `closed_critical_stream` | A critical control stream for an HTTP/3 connection was closed. |


### PR DESCRIPTION
## Changes

This corrects the error.type enum value table which is nested in the note which by extension enables linting.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
