### PR TITLE
Reduce scope of semconv-http-approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,6 @@
 /docs/http/                            @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
 /docs/url/                             @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
 /model/http/                           @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
-/model/error/                          @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
 /model/client/                         @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers
 /model/network/                        @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers @open-telemetry/semconv-system-approvers @open-telemetry/semconv-security-approvers
 /model/server/                         @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-http-approvers


### PR DESCRIPTION
Follow-up from https://github.com/open-telemetry/semantic-conventions/pull/3057#discussion_r2538270070