### PR TITLE
[chore] Bump markdownlint-cli package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "markdown-toc": "1.2.0",
-    "markdownlint-cli": "0.45.0",
+    "markdownlint-cli": "0.46.0",
     "prettier": "3.6.2"
   },
   "prettier": {


### PR DESCRIPTION
## Changes

This package was stuck in the pending status state of the renovate dashboard but has now dis-appeared. This issue will fail until the violations are fixed for which the pr's already exist. Ie #3083

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
