### PR TITLE
Update GraphQL Recommended vs Opt-In requirements

### DIFF
--- a/.chloggen/abernix_graphql-spec-requirements.yaml
+++ b/.chloggen/abernix_graphql-spec-requirements.yaml
@@ -4,7 +4,7 @@
 # your pull request title with [chore] or use the "Skip Changelog" label.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
 component: graphql

--- a/.chloggen/abernix_graphql-spec-requirements.yaml
+++ b/.chloggen/abernix_graphql-spec-requirements.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: graphql
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Change `graphql.document` attribute requirement level from Recommended to Opt-In due to sensitive data, cardinality, and size concerns"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2985]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `graphql.document` attribute contains user-inputted data that is often sensitive,
+  potentially unbounded in length, and high-cardinality. Moving from Recommended to Opt-In
+  ensures operators make an informed decision before enabling this attribute.
+  Also updated the note to use SHOULD for stronger normative language regarding sanitization.

--- a/docs/graphql/graphql-spans.md
+++ b/docs/graphql/graphql-spans.md
@@ -36,11 +36,11 @@ the span SHOULD be named `GraphQL Operation`.
 
 | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- |
-| [`graphql.document`](/docs/registry/attributes/graphql.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The GraphQL document being executed. [1] | `query findBookById { bookById(id: ?) { name } }` |
 | [`graphql.operation.name`](/docs/registry/attributes/graphql.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the operation being executed. | `findBookById` |
 | [`graphql.operation.type`](/docs/registry/attributes/graphql.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The type of the operation being executed. | `query`; `mutation`; `subscription` |
+| [`graphql.document`](/docs/registry/attributes/graphql.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The GraphQL document being executed. [1] | `query findBookById { bookById(id: ?) { name } }` |
 
-**[1] `graphql.document`:** The value may be sanitized to exclude sensitive information.
+**[1] `graphql.document`:** The value SHOULD be sanitized to exclude sensitive information.
 
 ---
 

--- a/docs/graphql/graphql-spans.md
+++ b/docs/graphql/graphql-spans.md
@@ -40,7 +40,7 @@ the span SHOULD be named `GraphQL Operation`.
 | [`graphql.operation.type`](/docs/registry/attributes/graphql.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The type of the operation being executed. | `query`; `mutation`; `subscription` |
 | [`graphql.document`](/docs/registry/attributes/graphql.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The GraphQL document being executed. [1] | `query findBookById { bookById(id: ?) { name } }` |
 
-**[1] `graphql.document`:** The value SHOULD be sanitized to exclude sensitive information.
+**[1] `graphql.document`:** If instrumentation can reliably identify and redact sensitive information it SHOULD do it.
 
 ---
 

--- a/docs/registry/attributes/graphql.md
+++ b/docs/registry/attributes/graphql.md
@@ -15,7 +15,7 @@ This document defines attributes for GraphQL.
 | <a id="graphql-operation-name" href="#graphql-operation-name">`graphql.operation.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the operation being executed. | `findBookById` |
 | <a id="graphql-operation-type" href="#graphql-operation-type">`graphql.operation.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The type of the operation being executed. | `query`; `mutation`; `subscription` |
 
-**[1] `graphql.document`:** The value may be sanitized to exclude sensitive information.
+**[1] `graphql.document`:** The value SHOULD be sanitized to exclude sensitive information.
 
 ---
 

--- a/docs/registry/attributes/graphql.md
+++ b/docs/registry/attributes/graphql.md
@@ -15,7 +15,7 @@ This document defines attributes for GraphQL.
 | <a id="graphql-operation-name" href="#graphql-operation-name">`graphql.operation.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the operation being executed. | `findBookById` |
 | <a id="graphql-operation-type" href="#graphql-operation-type">`graphql.operation.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The type of the operation being executed. | `query`; `mutation`; `subscription` |
 
-**[1] `graphql.document`:** The value SHOULD be sanitized to exclude sensitive information.
+**[1] `graphql.document`:** If instrumentation can reliably identify and redact sensitive information it SHOULD do it.
 
 ---
 

--- a/model/graphql/registry.yaml
+++ b/model/graphql/registry.yaml
@@ -31,5 +31,5 @@ groups:
         brief: "The GraphQL document being executed."
         type: string
         stability: development
-        note: The value may be sanitized to exclude sensitive information.
+        note: The value SHOULD be sanitized to exclude sensitive information.
         examples: 'query findBookById { bookById(id: ?) { name } }'

--- a/model/graphql/registry.yaml
+++ b/model/graphql/registry.yaml
@@ -31,5 +31,5 @@ groups:
         brief: "The GraphQL document being executed."
         type: string
         stability: development
-        note: The value SHOULD be sanitized to exclude sensitive information.
+        note: If instrumentation can reliably identify and redact sensitive information it SHOULD do it.
         examples: 'query findBookById { bookById(id: ?) { name } }'

--- a/model/graphql/spans.yml
+++ b/model/graphql/spans.yml
@@ -24,4 +24,4 @@ groups:
       - ref: graphql.operation.type
         requirement_level: recommended
       - ref: graphql.document
-        requirement_level: recommended
+        requirement_level: opt_in


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/2985

## Changes

Changes the firmness for `graphql.document` from `Recommended` to `Opt-In`.

## Context

The `graphql.document` is user-inputted, often contains sensitive information, is potentially unbounded in length and is also high-cardinality in the same way as the existing `graphql.operation.name` (which is already warned about).

Put another way, `graphql.document` is a general liability to have listed as `Recommended` without serious infrastructure considerations and needs.  This makes it a better candidate for being an `Opt-In` attribute.  In our customer adoption of OpenTelemetry and GraphQL, we've found GraphQL customers following this configuration/instruction purely based on its naming in this (still, experimental) specification and not understanding the implications (or just not thinking them through).

In most all cases, the lesser liability of `graphql.operation.name` (The actual operation name) is sufficient, as in many GraphQL deployments there is a link between the two which can be correlated out of band (e.g., client code-bases, operation manifests, etc.).  While the operation name isn't without its risk, but it's more likely to be dozens of *bytes* of a limited character set rather than dozens, hundreds or potentially thousands of *kilobytes*.  In that regard, it's reasonable that `graphql.operation.name` be left as `Recommended` for user experience (though the argument could easily be made that it should also be `Opt-In`).

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] Links to the prototypes or existing instrumentations (when adding or changing conventions)
