### PR TITLE
Provide attribute roles for Cloud Foundry entities

### DIFF
--- a/.chloggen/cf_entities_attribute_roles.yaml
+++ b/.chloggen/cf_entities_attribute_roles.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: cloudfoundry
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Define roles for cloudfoundry entities' attributes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [3086]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/entities/cloudfoundry.md
+++ b/docs/registry/entities/cloudfoundry.md
@@ -13,16 +13,12 @@
 
 **Description:** The application which is monitored.
 
-> :warning: This entity definition contains attributes without a role.
-> Stable Entities MUST NOT have attributes without a defined role.
-
 **Attributes:**
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`cloudfoundry.app.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The guid of the application. [1] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
-| Other | [`cloudfoundry.app.name`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the application. [2] | `my-app-name` |
-
+| Identity | [`cloudfoundry.app.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The guid of the application. [1] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
+| Description | [`cloudfoundry.app.name`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the application. [2] | `my-app-name` |
 
 **[1] `cloudfoundry.app.id`:** Application instrumentation should use the value from environment
 variable `VCAP_APPLICATION.application_id`. This is the same value as
@@ -40,16 +36,12 @@ as reported by `cf apps`.
 
 **Description:** The organization of the application which is monitored.
 
-> :warning: This entity definition contains attributes without a role.
-> Stable Entities MUST NOT have attributes without a defined role.
-
 **Attributes:**
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`cloudfoundry.org.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The guid of the CloudFoundry org the application is running in. [3] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
-| Other | [`cloudfoundry.org.name`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the CloudFoundry organization the app is running in. [4] | `my-org-name` |
-
+| Identity | [`cloudfoundry.org.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The guid of the CloudFoundry org the application is running in. [3] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
+| Description | [`cloudfoundry.org.name`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the CloudFoundry organization the app is running in. [4] | `my-org-name` |
 
 **[3] `cloudfoundry.org.id`:** Application instrumentation should use the value from environment
 variable `VCAP_APPLICATION.org_id`. This is the same value as
@@ -67,16 +59,12 @@ reported by `cf orgs`.
 
 **Description:** The process of the application which is monitored.
 
-> :warning: This entity definition contains attributes without a role.
-> Stable Entities MUST NOT have attributes without a defined role.
-
 **Attributes:**
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`cloudfoundry.process.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The UID identifying the process. [5] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
-| Other | [`cloudfoundry.process.type`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The type of process. [6] | `web` |
-
+| Identity | [`cloudfoundry.process.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The UID identifying the process. [5] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
+| Description | [`cloudfoundry.process.type`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The type of process. [6] | `web` |
 
 **[5] `cloudfoundry.process.id`:** Application instrumentation should use the value from environment
 variable `VCAP_APPLICATION.process_id`. It is supposed to be equal to
@@ -95,16 +83,12 @@ tasks or side-cars with different process types.
 
 **Description:** The space of the application which is monitored.
 
-> :warning: This entity definition contains attributes without a role.
-> Stable Entities MUST NOT have attributes without a defined role.
-
 **Attributes:**
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`cloudfoundry.space.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The guid of the CloudFoundry space the application is running in. [7] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
-| Other | [`cloudfoundry.space.name`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the CloudFoundry space the application is running in. [8] | `my-space-name` |
-
+| Identity | [`cloudfoundry.space.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The guid of the CloudFoundry space the application is running in. [7] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
+| Description | [`cloudfoundry.space.name`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the CloudFoundry space the application is running in. [8] | `my-space-name` |
 
 **[7] `cloudfoundry.space.id`:** Application instrumentation should use the value from environment
 variable `VCAP_APPLICATION.space_id`. This is the same value as
@@ -122,18 +106,22 @@ reported by `cf spaces`.
 
 **Description:** The system component which is monitored.
 
-> :warning: This entity definition contains attributes without a role.
-> Stable Entities MUST NOT have attributes without a defined role.
-
 **Attributes:**
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`cloudfoundry.system.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A guid or another name describing the event source. [9] | `cf/gorouter` |
-| Other | [`cloudfoundry.system.instance.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A guid describing the concrete instance of the event source. [10] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
+| Identity | [`cloudfoundry.system.instance.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A guid describing the concrete instance of the event source. [9] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
+| Description | [`cloudfoundry.system.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A guid or another name describing the event source. [10] | `cf/gorouter` |
 
+**[9] `cloudfoundry.system.instance.id`:** CloudFoundry defines the `instance_id` in the [Loggregator v2 envelope](https://github.com/cloudfoundry/loggregator-api#v2-envelope).
+It is used for logs and metrics emitted by CloudFoundry. It is
+supposed to contain the vm id for CloudFoundry components.
 
-**[9] `cloudfoundry.system.id`:** CloudFoundry defines the `source_id` in the [Loggregator v2 envelope](https://github.com/cloudfoundry/loggregator-api#v2-envelope).
+When system components are instrumented, values from the
+[Bosh spec](https://bosh.io/docs/jobs/#properties-spec)
+should be used. The `system.instance.id` should be set to `spec.id`.
+
+**[10] `cloudfoundry.system.id`:** CloudFoundry defines the `source_id` in the [Loggregator v2 envelope](https://github.com/cloudfoundry/loggregator-api#v2-envelope).
 It is used for logs and metrics emitted by CloudFoundry. It is
 supposed to contain the component name, e.g. "gorouter", for
 CloudFoundry components.
@@ -142,13 +130,5 @@ When system components are instrumented, values from the
 [Bosh spec](https://bosh.io/docs/jobs/#properties-spec)
 should be used. The `system.id` should be set to
 `spec.deployment/spec.name`.
-
-**[10] `cloudfoundry.system.instance.id`:** CloudFoundry defines the `instance_id` in the [Loggregator v2 envelope](https://github.com/cloudfoundry/loggregator-api#v2-envelope).
-It is used for logs and metrics emitted by CloudFoundry. It is
-supposed to contain the vm id for CloudFoundry components.
-
-When system components are instrumented, values from the
-[Bosh spec](https://bosh.io/docs/jobs/#properties-spec)
-should be used. The `system.instance.id` should be set to `spec.id`.
 
 <!-- markdownlint-restore -->

--- a/docs/resource/cloudfoundry.md
+++ b/docs/resource/cloudfoundry.md
@@ -35,16 +35,12 @@ They align with the Bosh deployment tool of CloudFoundry.
 
 **Description:** The organization of the application which is monitored.
 
-> :warning: This entity definition contains attributes without a role.
-> Stable Entities MUST NOT have attributes without a defined role.
-
 **Attributes:**
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`cloudfoundry.org.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The guid of the CloudFoundry org the application is running in. [1] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
-| Other | [`cloudfoundry.org.name`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the CloudFoundry organization the app is running in. [2] | `my-org-name` |
-
+| Identity | [`cloudfoundry.org.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The guid of the CloudFoundry org the application is running in. [1] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
+| Description | [`cloudfoundry.org.name`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the CloudFoundry organization the app is running in. [2] | `my-org-name` |
 
 **[1] `cloudfoundry.org.id`:** Application instrumentation should use the value from environment
 variable `VCAP_APPLICATION.org_id`. This is the same value as
@@ -73,16 +69,12 @@ reported by `cf orgs`.
 
 **Description:** The space of the application which is monitored.
 
-> :warning: This entity definition contains attributes without a role.
-> Stable Entities MUST NOT have attributes without a defined role.
-
 **Attributes:**
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`cloudfoundry.space.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The guid of the CloudFoundry space the application is running in. [1] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
-| Other | [`cloudfoundry.space.name`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the CloudFoundry space the application is running in. [2] | `my-space-name` |
-
+| Identity | [`cloudfoundry.space.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The guid of the CloudFoundry space the application is running in. [1] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
+| Description | [`cloudfoundry.space.name`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the CloudFoundry space the application is running in. [2] | `my-space-name` |
 
 **[1] `cloudfoundry.space.id`:** Application instrumentation should use the value from environment
 variable `VCAP_APPLICATION.space_id`. This is the same value as
@@ -111,16 +103,12 @@ reported by `cf spaces`.
 
 **Description:** The application which is monitored.
 
-> :warning: This entity definition contains attributes without a role.
-> Stable Entities MUST NOT have attributes without a defined role.
-
 **Attributes:**
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`cloudfoundry.app.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The guid of the application. [1] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
-| Other | [`cloudfoundry.app.name`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the application. [2] | `my-app-name` |
-
+| Identity | [`cloudfoundry.app.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The guid of the application. [1] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
+| Description | [`cloudfoundry.app.name`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the application. [2] | `my-app-name` |
 
 **[1] `cloudfoundry.app.id`:** Application instrumentation should use the value from environment
 variable `VCAP_APPLICATION.application_id`. This is the same value as
@@ -149,16 +137,12 @@ as reported by `cf apps`.
 
 **Description:** The process of the application which is monitored.
 
-> :warning: This entity definition contains attributes without a role.
-> Stable Entities MUST NOT have attributes without a defined role.
-
 **Attributes:**
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`cloudfoundry.process.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The UID identifying the process. [1] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
-| Other | [`cloudfoundry.process.type`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The type of process. [2] | `web` |
-
+| Identity | [`cloudfoundry.process.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The UID identifying the process. [1] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
+| Description | [`cloudfoundry.process.type`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The type of process. [2] | `web` |
 
 **[1] `cloudfoundry.process.id`:** Application instrumentation should use the value from environment
 variable `VCAP_APPLICATION.process_id`. It is supposed to be equal to
@@ -188,18 +172,22 @@ tasks or side-cars with different process types.
 
 **Description:** The system component which is monitored.
 
-> :warning: This entity definition contains attributes without a role.
-> Stable Entities MUST NOT have attributes without a defined role.
-
 **Attributes:**
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 |---|---|---|---|---|---|---|
-| Other | [`cloudfoundry.system.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A guid or another name describing the event source. [1] | `cf/gorouter` |
-| Other | [`cloudfoundry.system.instance.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A guid describing the concrete instance of the event source. [2] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
+| Identity | [`cloudfoundry.system.instance.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A guid describing the concrete instance of the event source. [1] | `218fc5a9-a5f1-4b54-aa05-46717d0ab26d` |
+| Description | [`cloudfoundry.system.id`](/docs/registry/attributes/cloudfoundry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A guid or another name describing the event source. [2] | `cf/gorouter` |
 
+**[1] `cloudfoundry.system.instance.id`:** CloudFoundry defines the `instance_id` in the [Loggregator v2 envelope](https://github.com/cloudfoundry/loggregator-api#v2-envelope).
+It is used for logs and metrics emitted by CloudFoundry. It is
+supposed to contain the vm id for CloudFoundry components.
 
-**[1] `cloudfoundry.system.id`:** CloudFoundry defines the `source_id` in the [Loggregator v2 envelope](https://github.com/cloudfoundry/loggregator-api#v2-envelope).
+When system components are instrumented, values from the
+[Bosh spec](https://bosh.io/docs/jobs/#properties-spec)
+should be used. The `system.instance.id` should be set to `spec.id`.
+
+**[2] `cloudfoundry.system.id`:** CloudFoundry defines the `source_id` in the [Loggregator v2 envelope](https://github.com/cloudfoundry/loggregator-api#v2-envelope).
 It is used for logs and metrics emitted by CloudFoundry. It is
 supposed to contain the component name, e.g. "gorouter", for
 CloudFoundry components.
@@ -208,14 +196,6 @@ When system components are instrumented, values from the
 [Bosh spec](https://bosh.io/docs/jobs/#properties-spec)
 should be used. The `system.id` should be set to
 `spec.deployment/spec.name`.
-
-**[2] `cloudfoundry.system.instance.id`:** CloudFoundry defines the `instance_id` in the [Loggregator v2 envelope](https://github.com/cloudfoundry/loggregator-api#v2-envelope).
-It is used for logs and metrics emitted by CloudFoundry. It is
-supposed to contain the vm id for CloudFoundry components.
-
-When system components are instrumented, values from the
-[Bosh spec](https://bosh.io/docs/jobs/#properties-spec)
-should be used. The `system.instance.id` should be set to `spec.id`.
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
 <!-- END AUTOGENERATED TEXT -->

--- a/model/cloudfoundry/entities.yaml
+++ b/model/cloudfoundry/entities.yaml
@@ -7,7 +7,9 @@ groups:
       The system component which is monitored.
     attributes:
       - ref: cloudfoundry.system.id
+        role: descriptive
       - ref: cloudfoundry.system.instance.id
+        role: identifying
   - id: entity.cloudfoundry.app
     type: entity
     stability: development
@@ -16,7 +18,9 @@ groups:
       The application which is monitored.
     attributes:
       - ref: cloudfoundry.app.id
+        role: identifying
       - ref: cloudfoundry.app.name
+        role: descriptive
   - id: entity.cloudfoundry.space
     type: entity
     stability: development
@@ -25,7 +29,9 @@ groups:
       The space of the application which is monitored.
     attributes:
       - ref: cloudfoundry.space.id
+        role: identifying
       - ref: cloudfoundry.space.name
+        role: descriptive
   - id: entity.cloudfoundry.org
     type: entity
     stability: development
@@ -34,7 +40,9 @@ groups:
       The organization of the application which is monitored.
     attributes:
       - ref: cloudfoundry.org.id
+        role: identifying
       - ref: cloudfoundry.org.name
+        role: descriptive
   - id: entity.cloudfoundry.process
     type: entity
     stability: development
@@ -43,4 +51,6 @@ groups:
       The process of the application which is monitored.
     attributes:
       - ref: cloudfoundry.process.id
+        role: identifying
       - ref: cloudfoundry.process.type
+        role: descriptive


### PR DESCRIPTION
Fixes #3086 

## Changes

Provides proper roles for the attributes of the Cloud Foundry entities. All ids are UUIDs identifying the underlying entity uniquely and stable over the lifetime of the resource. The PR addresses the missing roles for the existing attributes. 

This PR does not introduce is-an-relationships which are under heavy discussion. It defines the minimal set of attribute roles.


> [!IMPORTANT]
## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
