### PR TITLE
[chore] Fix white-spacing linting issue

### DIFF
--- a/docs/registry/entities/android.md
+++ b/docs/registry/entities/android.md
@@ -13,7 +13,7 @@
 
 **Description:** The Android platform on which the Android application is running.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/app.md
+++ b/docs/registry/entities/app.md
@@ -13,7 +13,7 @@
 
 **Description:** An app used directly by end users — like mobile, web, or desktop.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/aws.md
+++ b/docs/registry/entities/aws.md
@@ -13,7 +13,7 @@
 
 **Description:** Entities used by AWS Elastic Container Service (ECS).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -49,7 +49,7 @@
 
 **Description:** Entities used by AWS Elastic Kubernetes Service (EKS).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -67,7 +67,7 @@
 
 **Description:** Entities specific to Amazon Web Services.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/browser.md
+++ b/docs/registry/entities/browser.md
@@ -13,7 +13,7 @@
 
 **Description:** The web browser in which the application represented by the resource is running. The `browser.*` attributes MUST be used only for resources that represent applications running in a web browser (regardless of whether running on a mobile or desktop device).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/cicd.md
+++ b/docs/registry/entities/cicd.md
@@ -13,7 +13,7 @@
 
 **Description:** A pipeline is a series of automated steps that helps software teams deliver code.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -31,7 +31,7 @@
 
 **Description:** A pipeline run is a singular execution of a given pipeline's tasks.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -52,7 +52,7 @@
 A single pipeline run may be distributed across multiple workers. Any OpenTelemetry signal associated with a worker should be associated to the worker that performed the corresponding work.
 For example, when a pipeline run involves several workers, its task run spans may reference the different `cicd.worker` resources corresponding to the workers that executed each task run. The pipeline run's parent span may instead reference the CICD controller as the `cicd.worker` resource.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/cloud.md
+++ b/docs/registry/entities/cloud.md
@@ -13,7 +13,7 @@
 
 **Description:** A cloud environment (e.g. GCP, Azure, AWS)
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/cloudfoundry.md
+++ b/docs/registry/entities/cloudfoundry.md
@@ -13,7 +13,7 @@
 
 **Description:** The application which is monitored.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -41,7 +41,7 @@ as reported by `cf apps`.
 
 **Description:** The organization of the application which is monitored.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -69,7 +69,7 @@ reported by `cf orgs`.
 
 **Description:** The process of the application which is monitored.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -98,7 +98,7 @@ tasks or side-cars with different process types.
 
 **Description:** The space of the application which is monitored.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -126,7 +126,7 @@ reported by `cf spaces`.
 
 **Description:** The system component which is monitored.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/container.md
+++ b/docs/registry/entities/container.md
@@ -13,7 +13,7 @@
 
 **Description:** A container instance.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -45,7 +45,7 @@ An example can be found in [Example Image Manifest](https://github.com/openconta
 
 **Description:** The image used for the container.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/deployment.md
+++ b/docs/registry/entities/deployment.md
@@ -13,7 +13,7 @@
 
 **Description:** The software deployment.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/device.md
+++ b/docs/registry/entities/device.md
@@ -13,7 +13,7 @@
 
 **Description:** The device on which the process represented by this resource is running.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/faas.md
+++ b/docs/registry/entities/faas.md
@@ -13,7 +13,7 @@
 
 **Description:** A serverless instance.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/gcp.md
+++ b/docs/registry/entities/gcp.md
@@ -13,7 +13,7 @@
 
 **Description:** Attributes denoting data from an Application in AppHub. See [AppHub overview](https://cloud.google.com/app-hub/docs/overview).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -33,7 +33,7 @@
 
 **Description:** Attributes denoting data from a Service in AppHub. See [AppHub overview](https://cloud.google.com/app-hub/docs/overview).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -80,7 +80,7 @@
 
 **Description:** Attributes denoting data from a Workload in AppHub. See [AppHub overview](https://cloud.google.com/app-hub/docs/overview).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -127,7 +127,7 @@
 
 **Description:** Resource used by Google Cloud Run.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -146,7 +146,7 @@
 
 **Description:** Resources used by Google Compute Engine (GCE).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/heroku.md
+++ b/docs/registry/entities/heroku.md
@@ -13,7 +13,7 @@
 
 **Description:** [Heroku dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata)
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/host.md
+++ b/docs/registry/entities/host.md
@@ -13,7 +13,7 @@
 
 **Description:** A host is defined as a computing instance. For example, physical servers, virtual machines, switches or disk array.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -85,7 +85,7 @@ privileged lookup of `host.id` is required, the value should be injected via the
 
 **Description:** A host's CPU information
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/k8s.md
+++ b/docs/registry/entities/k8s.md
@@ -51,7 +51,7 @@ conflict.
 
 **Description:** A container in a [PodTemplate](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -219,7 +219,7 @@ conflict.
 
 **Description:** A Kubernetes Namespace.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/os.md
+++ b/docs/registry/entities/os.md
@@ -13,7 +13,7 @@
 
 **Description:** The operating system (OS) on which the process represented by this resource is running.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/otel.md
+++ b/docs/registry/entities/otel.md
@@ -13,7 +13,7 @@
 
 **Description:** Attributes used by non-OTLP exporters to represent OpenTelemetry Scope's concepts.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/telemetry.md
+++ b/docs/registry/entities/telemetry.md
@@ -13,7 +13,7 @@
 
 **Description:** The distribution of telemetry SDK used to capture data recorded by the instrumentation libraries.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/vcs.md
+++ b/docs/registry/entities/vcs.md
@@ -13,7 +13,7 @@
 
 **Description:** A reference to a specific version in the Version Control System.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -58,7 +58,7 @@ revision based on the VCS system and situational context.
 
 **Description:** A repository in the Version Control System.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/webengine.md
+++ b/docs/registry/entities/webengine.md
@@ -13,7 +13,7 @@
 
 **Description:** Resource describing the packaged software running the application code. Web engines are typically executed using process.runtime.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/registry/entities/zos.md
+++ b/docs/registry/entities/zos.md
@@ -13,7 +13,7 @@
 
 **Description:** A software resource running on a z/OS system.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -206,7 +206,7 @@ All custom identifiers SHOULD be stable across different versions of an implemen
 
 **Description:** The distribution of telemetry SDK used to capture data recorded by the instrumentation libraries.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/android.md
+++ b/docs/resource/android.md
@@ -13,7 +13,7 @@
 
 **Description:** The Android platform on which the Android application is running.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/browser.md
+++ b/docs/resource/browser.md
@@ -13,7 +13,7 @@
 
 **Description:** The web browser in which the application represented by the resource is running. The `browser.*` attributes MUST be used only for resources that represent applications running in a web browser (regardless of whether running on a mobile or desktop device).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/cicd.md
+++ b/docs/resource/cicd.md
@@ -37,7 +37,7 @@ See also:
 
 **Description:** A pipeline is a series of automated steps that helps software teams deliver code.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -72,7 +72,7 @@ Using the CICD pipeline run resource with metrics inherently causes high cardina
 
 **Description:** A pipeline run is a singular execution of a given pipeline's tasks.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -104,7 +104,7 @@ Using the CICD pipeline run resource with metrics inherently causes high cardina
 A single pipeline run may be distributed across multiple workers. Any OpenTelemetry signal associated with a worker should be associated to the worker that performed the corresponding work.
 For example, when a pipeline run involves several workers, its task run spans may reference the different `cicd.worker` resources corresponding to the workers that executed each task run. The pipeline run's parent span may instead reference the CICD controller as the `cicd.worker` resource.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -137,7 +137,7 @@ For example, when a pipeline run involves several workers, its task run spans ma
 
 **Description:** A repository in the Version Control System.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -175,7 +175,7 @@ the `.git` extension.
 
 **Description:** A reference to a specific version in the Version Control System.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/cloud-provider/aws/ecs.md
+++ b/docs/resource/cloud-provider/aws/ecs.md
@@ -18,7 +18,7 @@ linkTitle: ECS
 
 **Description:** Entities used by AWS Elastic Container Service (ECS).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/cloud-provider/aws/eks.md
+++ b/docs/resource/cloud-provider/aws/eks.md
@@ -17,7 +17,7 @@ linkTitle: EKS
 
 **Description:** Entities used by AWS Elastic Kubernetes Service (EKS).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/cloud-provider/aws/logs.md
+++ b/docs/resource/cloud-provider/aws/logs.md
@@ -17,7 +17,7 @@ linkTitle: Logs
 
 **Description:** Entities specific to Amazon Web Services.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/cloud-provider/gcp/apphub.md
+++ b/docs/resource/cloud-provider/gcp/apphub.md
@@ -30,7 +30,7 @@ See [Supported Resources](https://cloud.google.com/app-hub/docs/supported-resour
 
 **Description:** Attributes denoting data from an Application in AppHub. See [AppHub overview](https://cloud.google.com/app-hub/docs/overview).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -61,7 +61,7 @@ See [Supported Resources](https://cloud.google.com/app-hub/docs/supported-resour
 
 **Description:** Attributes denoting data from a Service in AppHub. See [AppHub overview](https://cloud.google.com/app-hub/docs/overview).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -119,7 +119,7 @@ See [Supported Resources](https://cloud.google.com/app-hub/docs/supported-resour
 
 **Description:** Attributes denoting data from a Workload in AppHub. See [AppHub overview](https://cloud.google.com/app-hub/docs/overview).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/cloud-provider/gcp/cloud-run.md
+++ b/docs/resource/cloud-provider/gcp/cloud-run.md
@@ -17,7 +17,7 @@ These conventions are recommended for resources running on Cloud Run.
 
 **Description:** Resource used by Google Cloud Run.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/cloud-provider/gcp/gce.md
+++ b/docs/resource/cloud-provider/gcp/gce.md
@@ -13,7 +13,7 @@
 
 **Description:** Resources used by Google Compute Engine (GCE).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/cloud-provider/heroku.md
+++ b/docs/resource/cloud-provider/heroku.md
@@ -13,7 +13,7 @@
 
 **Description:** [Heroku dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata)
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/cloud.md
+++ b/docs/resource/cloud.md
@@ -13,7 +13,7 @@
 
 **Description:** A cloud environment (e.g. GCP, Azure, AWS)
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/cloudfoundry.md
+++ b/docs/resource/cloudfoundry.md
@@ -35,7 +35,7 @@ They align with the Bosh deployment tool of CloudFoundry.
 
 **Description:** The organization of the application which is monitored.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -74,7 +74,7 @@ reported by `cf orgs`.
 
 **Description:** The space of the application which is monitored.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -113,7 +113,7 @@ reported by `cf spaces`.
 
 **Description:** The application which is monitored.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -152,7 +152,7 @@ as reported by `cf apps`.
 
 **Description:** The process of the application which is monitored.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -192,7 +192,7 @@ tasks or side-cars with different process types.
 
 **Description:** The system component which is monitored.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/container.md
+++ b/docs/resource/container.md
@@ -13,7 +13,7 @@
 
 **Description:** A container instance.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/deployment-environment.md
+++ b/docs/resource/deployment-environment.md
@@ -13,7 +13,7 @@
 
 **Description:** The software deployment.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/device.md
+++ b/docs/resource/device.md
@@ -13,7 +13,7 @@
 
 **Description:** The device on which the process represented by this resource is running.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/faas.md
+++ b/docs/resource/faas.md
@@ -24,7 +24,7 @@ See also:
 
 **Description:** A serverless instance.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/host.md
+++ b/docs/resource/host.md
@@ -17,7 +17,7 @@ To report host metrics, the `system.*` namespace SHOULD be used.
 
 **Description:** A host is defined as a computing instance. For example, physical servers, virtual machines, switches or disk array.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -101,7 +101,7 @@ privileged lookup of `host.id` is required, the value should be injected via the
 
 **Description:** A host's CPU information
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/k8s/README.md
+++ b/docs/resource/k8s/README.md
@@ -124,7 +124,7 @@ a namespace, but not across namespaces.
 
 **Description:** A Kubernetes Namespace.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 
@@ -226,7 +226,7 @@ to a running container.
 
 **Description:** A container in a [PodTemplate](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/os.md
+++ b/docs/resource/os.md
@@ -15,7 +15,7 @@ In case of virtualized environments, this is the operating system as it is obser
 
 **Description:** The operating system (OS) on which the process represented by this resource is running.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/webengine.md
+++ b/docs/resource/webengine.md
@@ -13,7 +13,7 @@
 
 **Description:** Resource describing the packaged software running the application code. Web engines are typically executed using process.runtime.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/docs/resource/zos.md
+++ b/docs/resource/zos.md
@@ -15,7 +15,7 @@ This document defines z/OS software entity and documents how to populate other e
 
 **Description:** A software resource running on a z/OS system.
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 

--- a/templates/registry/markdown/entity_macros.j2
+++ b/templates/registry/markdown/entity_macros.j2
@@ -43,7 +43,7 @@
 {%- set misc_attrs = e.attributes | rejectattr("role", "defined") -%}
 {%- if misc_attrs | length > 0 %}
 
-> [!warning] 
+> [!warning]
 > This entity definition contains attributes without a role.
 > Stable Entities MUST NOT have attributes without a defined role.
 {% endif %}


### PR DESCRIPTION
## Changes

This trims a left over whitespace from switching to gfm alerts. Wasn't detected earlier due to markdown linting suppression in effect.

All changes to markdown has been a result of updating the jinja template.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
