### PR TITLE
docs: replace deprecated `attribute-registry-generation` command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ the respective markdown files.
 If you want to update existing tables, just run the following commands:
 
 ```bash
-make table-generation attribute-registry-generation
+make table-generation registry-generation
 ```
 
 When defining new telemetry signals (spans, metrics, events, resources) in YAML,
@@ -187,7 +187,7 @@ code-snippet into the markdown file:
 Then run markdown generation commands:
 
 ```bash
-make table-generation attribute-registry-generation
+make table-generation registry-generation
 ```
 
 #### Hugo frontmatter


### PR DESCRIPTION
## Changes

replace deprecated `attribute-registry-generation` command with `registry-generation` in CONTRIBUTING.md

https://github.com/open-telemetry/semantic-conventions/blob/ee434970ad400c279f382a891c84bbaf0e087647/Makefile#L169-L171

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
