### PR TITLE
[chore] Mark package.lock.json as linguist generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 
 *.cmd text eol=crlf
 *.bat text eol=crlf
+
+**/package.lock.json linguist-generated

--- a/.github/scripts/triage/package-lock.json
+++ b/.github/scripts/triage/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "triage",
       "dependencies": {
         "@octokit/action": "^8.0.2",
         "yaml": "^2.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "semantic-conventions",
       "devDependencies": {
         "markdown-toc": "1.2.0",
         "markdownlint-cli": "0.46.0",


### PR DESCRIPTION
## Changes

This sets the package.lock.json as linguist-generated so that the changes to the file are collapsed by default in pr's. See https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github for more details and sample below.

<img width="1170" height="194" alt="image" src="https://github.com/user-attachments/assets/48f8b0c7-7309-4285-b5db-1a59e1020496" />


> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
