### PR TITLE
Update missed locations from rpc.system to rpc.system.name

### DIFF
--- a/docs/rpc/connect-rpc.md
+++ b/docs/rpc/connect-rpc.md
@@ -21,7 +21,7 @@ described on this page.
 
 This span represents an outgoing Remote Procedure Call (RPC).
 
-`rpc.system` MUST be set to `"connect_rpc"` and SHOULD be provided **at span creation time.**
+`rpc.system.name` MUST be set to `"connect_rpc"` and SHOULD be provided **at span creation time.**
 
 **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 
@@ -131,7 +131,7 @@ the `rpc.response.metadata.my-custom-key` attribute with value `["attribute_valu
 
 This span represents an incoming Remote Procedure Call (RPC).
 
-`rpc.system` MUST be set to `"connect_rpc"` and SHOULD be provided **at span creation time.**
+`rpc.system.name` MUST be set to `"connect_rpc"` and SHOULD be provided **at span creation time.**
 
 **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 

--- a/docs/rpc/grpc.md
+++ b/docs/rpc/grpc.md
@@ -21,7 +21,7 @@ described on this page.
 
 This span represents an outgoing Remote Procedure Call (RPC).
 
-`rpc.system` MUST be set to `"grpc"` and SHOULD be provided **at span creation time.**
+`rpc.system.name` MUST be set to `"grpc"` and SHOULD be provided **at span creation time.**
 
 **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 
@@ -132,7 +132,7 @@ the `rpc.response.metadata.my-custom-key` attribute with value `["attribute_valu
 
 This span represents an incoming Remote Procedure Call (RPC).
 
-`rpc.system` MUST be set to `"grpc"` and SHOULD be provided **at span creation time.**
+`rpc.system.name` MUST be set to `"grpc"` and SHOULD be provided **at span creation time.**
 
 **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 

--- a/docs/rpc/json-rpc.md
+++ b/docs/rpc/json-rpc.md
@@ -21,7 +21,7 @@ described on this page.
 
 This span represents an outgoing Remote Procedure Call (RPC).
 
-`rpc.system` MUST be set to `"jsonrpc"` and SHOULD be provided **at span creation time.**
+`rpc.system.name` MUST be set to `"jsonrpc"` and SHOULD be provided **at span creation time.**
 
 **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 
@@ -121,7 +121,7 @@ different processes could be listening on TCP port 12345 and UDP port 12345.
 
 This span represents an incoming Remote Procedure Call (RPC).
 
-`rpc.system` MUST be set to `"jsonrpc"` and SHOULD be provided **at span creation time.**
+`rpc.system.name` MUST be set to `"jsonrpc"` and SHOULD be provided **at span creation time.**
 
 **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 

--- a/model/rpc/spans.yaml
+++ b/model/rpc/spans.yaml
@@ -92,7 +92,7 @@ groups:
     stability: development
     brief: This span represents an outgoing Remote Procedure Call (RPC).
     note: |
-      `rpc.system` MUST be set to `"connect_rpc"` and SHOULD be provided **at span creation time.**
+      `rpc.system.name` MUST be set to `"connect_rpc"` and SHOULD be provided **at span creation time.**
 
       **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 
@@ -122,7 +122,7 @@ groups:
     span_kind: server
     brief: This span represents an incoming Remote Procedure Call (RPC).
     note: |
-      `rpc.system` MUST be set to `"connect_rpc"` and SHOULD be provided **at span creation time.**
+      `rpc.system.name` MUST be set to `"connect_rpc"` and SHOULD be provided **at span creation time.**
 
       **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 
@@ -154,7 +154,7 @@ groups:
     stability: development
     brief: This span represents an outgoing Remote Procedure Call (RPC).
     note: |
-      `rpc.system` MUST be set to `"grpc"` and SHOULD be provided **at span creation time.**
+      `rpc.system.name` MUST be set to `"grpc"` and SHOULD be provided **at span creation time.**
 
       **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 
@@ -189,7 +189,7 @@ groups:
     span_kind: server
     brief: This span represents an incoming Remote Procedure Call (RPC).
     note: |
-      `rpc.system` MUST be set to `"grpc"` and SHOULD be provided **at span creation time.**
+      `rpc.system.name` MUST be set to `"grpc"` and SHOULD be provided **at span creation time.**
 
       **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 
@@ -224,7 +224,7 @@ groups:
     stability: development
     brief: This span represents an outgoing Remote Procedure Call (RPC).
     note: |
-      `rpc.system` MUST be set to `"jsonrpc"` and SHOULD be provided **at span creation time.**
+      `rpc.system.name` MUST be set to `"jsonrpc"` and SHOULD be provided **at span creation time.**
 
       **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 
@@ -260,7 +260,7 @@ groups:
     span_kind: server
     brief: This span represents an incoming Remote Procedure Call (RPC).
     note: |
-      `rpc.system` MUST be set to `"jsonrpc"` and SHOULD be provided **at span creation time.**
+      `rpc.system.name` MUST be set to `"jsonrpc"` and SHOULD be provided **at span creation time.**
 
       **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 


### PR DESCRIPTION
Follow-up to #3176

I'm thinking no changelog entry needed since #3176 hasn't been released yet, but can add one if anyone prefers.