### PR TITLE
[chore] Align stale behaviour and stale comment

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -19,12 +19,12 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: >
             This PR has been labeled as stale due to lack of activity.
-            It will be automatically closed if there is no further activity over the next 14 days.
+            It will be automatically closed if there is no further activity over the next 7 days.
           exempt-pr-labels: 'never stale'
           # opt out of defaults to avoid marking issues as stale
           days-before-stale: -1
           days-before-close: -1
           # overrides the above only for pull requests
           days-before-pr-stale: 14
-          days-before-pr-close: 14
+          days-before-pr-close: 7
           operations-per-run: 1000


### PR DESCRIPTION
## Changes 

With https://github.com/open-telemetry/semantic-conventions/commit/b0ee8f8d7c8ffdb42640bac43f178b779fc68804 the message for stale pr's was changed to 14 days however that change in duration was not intended. This brings the message back in alignment with the behaviour.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
