### PR TITLE
[Chore] update CODEOWNERS for oracle-cloud areas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -176,3 +176,7 @@
 /docs/rpc                         @open-telemetry/semconv-rpc-approvers @open-telemetry/specs-semconv-approvers
 /model/rpc                        @open-telemetry/semconv-rpc-approvers @open-telemetry/specs-semconv-approvers
 /model/jsonrpc                    @open-telemetry/semconv-rpc-approvers @open-telemetry/specs-semconv-approvers
+
+# Oracle Cloud Infrastructure semantic conventions
+/docs/oracle-cloud                @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-oracle-cloud-approvers
+/model/oracle-cloud               @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-oracle-cloud-approvers


### PR DESCRIPTION
Add `oracle-cloud` areas to codeowners with appropriate approvers groups.

See https://github.com/open-telemetry/semantic-conventions/issues/3214 for further context.

cc @lmolkova 