### PR TITLE
Add Christophe Kamphaus to approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ For more information about the maintainer role, see the [community repository](h
 ### Approvers
 
 - [Alexandra Konrad](https://github.com/trisch-me), Elastic
+- [Christophe Kamphaus](https://github.com/kamphaus), Independent
 - [Daniel Dyla](https://github.com/dyladan), Dynatrace
 - [Ted Young](https://github.com/tedsuo), Grafana Labs
 


### PR DESCRIPTION
I’d like to nominate @kamphaus as an OTel SemConv Approver.

Thanks a lot for all your contributions to the CI/CD SIG and other areas of semantic conventions!