### PR TITLE
Add service.owner entity

### DIFF
--- a/.chloggen/service_owner_entity.yaml
+++ b/.chloggen/service_owner_entity.yaml
@@ -1,0 +1,24 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: "service"
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add service.owner entity with service.owner.name, service.owner.url, and service.owner.contact attributes"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [3101]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The new entity enables users to annotate services with organizational ownership information,
+  supporting automation for notifications, incident response, and diagnostics.

--- a/docs/registry/attributes/service.md
+++ b/docs/registry/attributes/service.md
@@ -14,6 +14,9 @@ A service instance.
 | <a id="service-instance-id" href="#service-instance-id">`service.instance.id`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The string ID of the service instance. [1] | `627cc493-f310-47de-96bd-71410b7dec09` |
 | <a id="service-name" href="#service-name">`service.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | Logical name of the service. [2] | `shoppingcart` |
 | <a id="service-namespace" href="#service-namespace">`service.namespace`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | A namespace for `service.name`. [3] | `Shop` |
+| <a id="service-owner-contact" href="#service-owner-contact">`service.owner.contact`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The contact point or communication channel for the team responsible for the service. [4] | `https://example.slack.com/channels/checkout-team`; `#checkout-team`; `checkout-team@example.com` |
+| <a id="service-owner-name" href="#service-owner-name">`service.owner.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the team or individual responsible for the service. [5] | `Checkout Team`; `Platform Infrastructure`; `john.doe` |
+| <a id="service-owner-url" href="#service-owner-url">`service.owner.url`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | A URL or identifier pointing to the service's source code repository or documentation. [6] | `https://github.com/example/checkout-service`; `https://gitlab.example.com/platform/infra` |
 | <a id="service-version" href="#service-version">`service.version`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The version string of the service component. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` |
 
 **[1] `service.instance.id`:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words
@@ -46,3 +49,15 @@ port.
 **[2] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
 
 **[3] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+
+**[4] `service.owner.contact`:** This attribute provides a way to reach the team or individual responsible for the service.
+The value can be a chat channel URL, email address, or other contact information.
+When using chat channels, the full URL is preferred for easy navigation.
+
+**[5] `service.owner.name`:** This attribute is used to identify the organizational owner of a service,
+enabling automation for notifications, incident response, and diagnostics.
+The value SHOULD be a human-readable name such as a team name.
+
+**[6] `service.owner.url`:** This attribute is typically used to link a service to its source control management system,
+allowing developers and operators to quickly navigate to the relevant codebase.
+The value SHOULD be a fully qualified URL when possible.

--- a/docs/registry/entities/README.md
+++ b/docs/registry/entities/README.md
@@ -90,6 +90,7 @@ Currently, the following namespaces exist:
 | | [service](service.md#service) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | | [service.instance](service.md#service-instance) | ![Development](https://img.shields.io/badge/-development-blue) |
 | | [service.namespace](service.md#service-namespace) | ![Development](https://img.shields.io/badge/-development-blue) |
+| | [service.owner](service.md#service-owner) | ![Development](https://img.shields.io/badge/-development-blue) |
 | Telemetry | | |
 | | [telemetry.distro](telemetry.md#telemetry-distro) | ![Development](https://img.shields.io/badge/-development-blue) |
 | | [telemetry.sdk](telemetry.md#telemetry-sdk) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |

--- a/docs/registry/entities/service.md
+++ b/docs/registry/entities/service.md
@@ -76,3 +76,31 @@ port.
 | Identity | [`service.namespace`](/docs/registry/attributes/service.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Required` | string | A namespace for `service.name`. [3] | `Shop` |
 
 **[3] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+
+## Service Owner
+
+**Status:** ![Development](https://img.shields.io/badge/-development-blue)
+
+**type:** `service.owner`
+
+**Description:** Identifies the team or individual responsible for a service.
+
+**Attributes:**
+
+| Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
+| --- | --- | --- | --- | --- | --- | --- |
+| Description | [`service.owner.contact`](/docs/registry/attributes/service.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The contact point or communication channel for the team responsible for the service. [4] | `https://example.slack.com/channels/checkout-team`; `#checkout-team`; `checkout-team@example.com` |
+| Description | [`service.owner.name`](/docs/registry/attributes/service.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the team or individual responsible for the service. [5] | `Checkout Team`; `Platform Infrastructure`; `john.doe` |
+| Description | [`service.owner.url`](/docs/registry/attributes/service.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A URL or identifier pointing to the service's source code repository or documentation. [6] | `https://github.com/example/checkout-service`; `https://gitlab.example.com/platform/infra` |
+
+**[4] `service.owner.contact`:** This attribute provides a way to reach the team or individual responsible for the service.
+The value can be a chat channel URL, email address, or other contact information.
+When using chat channels, the full URL is preferred for easy navigation.
+
+**[5] `service.owner.name`:** This attribute is used to identify the organizational owner of a service,
+enabling automation for notifications, incident response, and diagnostics.
+The value SHOULD be a human-readable name such as a team name.
+
+**[6] `service.owner.url`:** This attribute is typically used to link a service to its source control management system,
+allowing developers and operators to quickly navigate to the relevant codebase.
+The value SHOULD be a fully qualified URL when possible.

--- a/model/service/entities.yaml
+++ b/model/service/entities.yaml
@@ -41,3 +41,21 @@ groups:
       - ref: service.namespace
         role: identifying
         requirement_level: required
+  - id: entity.service.owner
+    type: entity
+    name: service.owner
+    brief: >
+      Identifies the team or individual responsible for a service.
+    note: >
+      A `service.owner` provides organizational ownership information for a service,
+      enabling automation for notifications, incident response, and diagnostics.
+      While `service.namespace` groups services logically, `service.owner` explicitly
+      conveys who is responsible for the service and how to contact them.
+    stability: development
+    attributes:
+      - ref: service.owner.name
+        role: descriptive
+      - ref: service.owner.url
+        role: descriptive
+      - ref: service.owner.contact
+        role: descriptive

--- a/model/service/registry.yaml
+++ b/model/service/registry.yaml
@@ -69,3 +69,33 @@ groups:
           for that telemetry. This is typically the case for scraping receivers, as they know the target address and
           port.
         examples: ["627cc493-f310-47de-96bd-71410b7dec09"]
+      - id: service.owner.name
+        type: string
+        stability: development
+        brief: >
+          The name of the team or individual responsible for the service.
+        note: |
+          This attribute is used to identify the organizational owner of a service,
+          enabling automation for notifications, incident response, and diagnostics.
+          The value SHOULD be a human-readable name such as a team name.
+        examples: ["Checkout Team", "Platform Infrastructure", "john.doe"]
+      - id: service.owner.url
+        type: string
+        stability: development
+        brief: >
+          A URL or identifier pointing to the service's source code repository or documentation.
+        note: |
+          This attribute is typically used to link a service to its source control management system,
+          allowing developers and operators to quickly navigate to the relevant codebase.
+          The value SHOULD be a fully qualified URL when possible.
+        examples: ["https://github.com/example/checkout-service", "https://gitlab.example.com/platform/infra"]
+      - id: service.owner.contact
+        type: string
+        stability: development
+        brief: >
+          The contact point or communication channel for the team responsible for the service.
+        note: |
+          This attribute provides a way to reach the team or individual responsible for the service.
+          The value can be a chat channel URL, email address, or other contact information.
+          When using chat channels, the full URL is preferred for easy navigation.
+        examples: ["https://example.slack.com/channels/checkout-team", "#checkout-team", "checkout-team@example.com"]


### PR DESCRIPTION
## Changes

Implements the `service.owner` entity as proposed in #3101, adding semantic conventions for service ownership information.

This enables users to annotate services with organizational ownership details, supporting automation for notifications, incident response, and diagnostics.

### New Attributes

| Attribute | Type | Description |
|-----------|------|-------------|
| `service.owner.name` | string | Name of the team or individual responsible for the service |
| `service.owner.url` | string | URL to the service's source code repository or documentation |
| `service.owner.contact` | string | Contact point or communication channel (e.g., Slack, email) |

### New Entity

- **`service.owner`** - Identifies the team or individual responsible for a service
  - `service.owner.name` as identifying attribute (required)
  - `service.owner.url` and `service.owner.contact` as descriptive attributes

### Stability

All new attributes and the entity are introduced at `development` stability.

### Relationship to Existing Conventions

While `service.namespace` groups services logically, `service.owner` explicitly conveys organizational ownership and contact details - addressing a common pattern observed in production environments.

Closes #3101

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)

