### PR TITLE
Clarify role for tool_call_response message parts

### DIFF
--- a/model/gen-ai/registry.yaml
+++ b/model/gen-ai/registry.yaml
@@ -233,7 +233,19 @@ groups:
         type: string
         brief: Name of the tool utilized by the agent.
         examples: ["Flights"]
+        +## Tool call responses
+        +
+        +When a message part has `type: "tool_call_response"`, the message `role` MUST be `"tool"`.
+        +
+        +This ensures that:
+        +- Tool outputs are clearly distinguished from model-generated content
+        +- SDKs and collectors can reliably parse tool execution boundaries
+        +- Redaction and telemetry pipelines correctly classify tool results
+        +
+        +The `tool_call_response` part represents the result of a tool execution initiated by the model.
+        +It is not user input and not model output — it is tool output.
 
+        
       - id: gen_ai.tool.call.id
         stability: development
         type: string
@@ -517,12 +529,18 @@ groups:
                   ]
                 },
                 {
-                  "role": "tool",
-                  "parts": [
-                    {
-                      "type": "tool_call_response",
-                      "id": " call_VSPygqKTWdrhaFErNvMV18Yl",
-                      "result": "rainy, 57°F"
+                   {
+                     -  "role": "assistant",
+                     +  "role": "tool",
+                     "  parts": [
+                         {
+                           "type": "tool_call_response",
+                           "id": "call_VSPygKTWdrhaFErNvMV18Y1",
+                            "response": "rainy, 57°F"
+                          }
+                        ]
+                    }
+
                     }
                   ]
                 }


### PR DESCRIPTION
Document that messages containing tool_call_response parts MUST use role "tool" and align examples accordingly.

Fixes #

## Changes

Please provide a brief description of the changes here.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
