### PR TITLE
Add note about preserving case to database stable semconv migration doc

### DIFF
--- a/docs/non-normative/db-migration.md
+++ b/docs/non-normative/db-migration.md
@@ -43,7 +43,7 @@ to
 
 ### Database client span attributes
 
-<!-- prettier-ignore-start -->
+<!-- markdownlint-disable-file MD060 -->
 | Change                                              | Comments                                                                                                    |
 |-----------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
 | `db.connection_string`                              | Removed                                                                                                     |
@@ -69,7 +69,6 @@ to
 | New: `db.operation.parameter.<key>`                 | _Not marked stable yet_                                                                                     |
 | New: `db.query.parameter.<key>`                     | _Not marked stable yet_                                                                                     |
 | New: `db.response.returned_rows`                    | _Not marked stable yet_                                                                                     |
-<!-- prettier-ignore-end -->
 
 References:
 


### PR DESCRIPTION
Noticed this while updating Java database instrumentations.