### PR TITLE
Indicate that `exception.message` attribute may contain sensitive information

### DIFF
--- a/.chloggen/exception-message-sensitive.yaml
+++ b/.chloggen/exception-message-sensitive.yaml
@@ -1,4 +1,4 @@
 change_type: enhancement
 component: exception
 note: Indicate that `exception.message` attribute may contain sensitive information.
-issues: [2967, TODO]
+issues: [2967, 3310]

--- a/docs/exceptions/exceptions-logs.md
+++ b/docs/exceptions/exceptions-logs.md
@@ -54,7 +54,7 @@ The table below indicates which attributes should be added to the
 
 > [!WARNING]
 >
-> This attribute contains sensitive (PII, secrets) information
+> This attribute may contain sensitive information.
 
 **[3] `exception.type`:** Required if `exception.message` is not set, recommended otherwise.
 

--- a/docs/exceptions/exceptions-spans.md
+++ b/docs/exceptions/exceptions-spans.md
@@ -44,7 +44,7 @@ This event describes a single exception.
 
 > [!WARNING]
 >
-> This attribute contains sensitive (PII, secrets) information
+> This attribute may contain sensitive information.
 
 **[3] `exception.type`:** Required if `exception.message` is not set, recommended otherwise.
 

--- a/docs/registry/attributes/exception.md
+++ b/docs/registry/attributes/exception.md
@@ -22,7 +22,7 @@ This document defines the shared attributes used to report a single exception as
 
 > [!WARNING]
 >
-> This attribute contains sensitive (PII, secrets) information
+> This attribute may contain sensitive information.
 
 ## Deprecated Exception Attributes
 

--- a/model/exceptions/registry.yaml
+++ b/model/exceptions/registry.yaml
@@ -23,7 +23,7 @@ groups:
         note: |
           > [!WARNING]
           >
-          > This attribute contains sensitive (PII, secrets) information
+          > This attribute may contain sensitive information.
       - id: exception.stacktrace
         type: string
         stability: stable


### PR DESCRIPTION
Towards #2967

`exception.message` is recorded by default on span-events (for now) and logs. It's stable and too useful.
At the same time, there are known cases when exception message contains things like connection strings or user_ids. 

It is not recommended to include sensitive information in exception messages.

In many cases, exceptions are thrown and recorded as telemetry by  different components. As a result, it may not be possible for  instrumentation to prevent sensitive information from being recorded.

Additional processing in the telemetry pipeline may be necessary to remove sensitive information.

So adding sensitivity warning on the attribute. https://github.com/open-telemetry/semantic-conventions/issues/1594 would improve this story (by making sensitivity note machine readable).
