### PR TITLE
[chore] MongoDB: remove network.* attributes from example

### DIFF
--- a/docs/db/mongodb.md
+++ b/docs/db/mongodb.md
@@ -95,9 +95,6 @@ and SHOULD be provided **at span creation time** (if provided at all):
 | `db.system.name`       | `"mongodb"`                |
 | `server.address`       | `"mongodb0.example.com"`   |
 | `server.port`          | `27017`                    |
-| `network.peer.address` | `"192.0.2.14"`             |
-| `network.peer.port`    | `27017`                    |
-| `network.transport`    | `"tcp"`                    |
 | `db.collection.name`   | `"products"`               |
 | `db.namespace`         | `"shopDb"`                 |
 | `db.query.text`        | not set                    |


### PR DESCRIPTION
`Network.`* attributes are not mentioned in the formal MongoDB span definition, but appear in the example.

Removing them to avoid any confusion, e.g. here https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/4791#discussion_r2715932620