### PR TITLE
[chore] RPC: Update references to `connectrpc` value for `rpc.system.name`

### DIFF
--- a/model/rpc/spans.yaml
+++ b/model/rpc/spans.yaml
@@ -90,7 +90,7 @@ groups:
     stability: development
     brief: This span represents an outgoing Remote Procedure Call (RPC).
     note: |
-      `rpc.system.name` MUST be set to `"connect_rpc"` and SHOULD be provided **at span creation time.**
+      `rpc.system.name` MUST be set to `"connectrpc"` and SHOULD be provided **at span creation time.**
 
       **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 
@@ -119,7 +119,7 @@ groups:
     span_kind: server
     brief: This span represents an incoming Remote Procedure Call (RPC).
     note: |
-      `rpc.system.name` MUST be set to `"connect_rpc"` and SHOULD be provided **at span creation time.**
+      `rpc.system.name` MUST be set to `"connectrpc"` and SHOULD be provided **at span creation time.**
 
       **Span name:** refer to the [Span Name](/docs/rpc/rpc-spans.md#span-name) section.
 


### PR DESCRIPTION
## Changes

Update notes on RPC spans to use recently renamed enum value. [`connect_rpc` was renamed to `connectrpc`](https://github.com/open-telemetry/semantic-conventions/commit/18db3e4428b6a162838dbe10f129e992a2e121de).

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
