### PR TITLE
[chore] Add writers of decentralized conventions as users requiring changelog entries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,6 +240,7 @@ Keep in mind the following types of users (not limited to):
 1. Those who are consuming the data following these conventions (e.g., in alerts, dashboards, queries)
 2. Those who are using the conventions in instrumentations (e.g., library authors)
 3. Those who are using the conventions to derive heuristics, predictions and automatic analyses (e.g., observability products/back-ends)
+4. Those who define their own conventions (e.g., vendor-specific conventions, private registries)
 
 If a changelog entry is not required (e.g. editorial or trivial changes),
 a maintainer or approver will add the `Skip Changelog` label to the pull request.


### PR DESCRIPTION
## Changes

Following the PR discussion https://github.com/open-telemetry/semantic-conventions/pull/3240#issuecomment-3787695848 we:
* add writers of decentralized semantic conventions to the CONTRIBUTING `When to add a changelog entry` user list.

PR discussion:

> > > Is there a reason not to include a changelog entry?
> > > #2232 was listed as a doc enhancement.
> >
> > good question. In my view changelog is a summary of things that have changed that's relevant to consumers. This doc does not change any conventions and users don't need to be notified. In this sense, it's similar to CI fixes and internal docs updates. As you noticed we're not consistent and some PRs include changelog even when they don't change anything for consumers.
>
> I feel that we could count writers of decentralized semantic conventions as consumers.
> Any enhancement to the how-to-write-conventions would be of interest to them.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry). → NA
  * If your PR does not need a change log, start the PR title with `[chore]`
* Links to the prototypes or existing instrumentations (when adding or changing conventions) → NA
