### PR TITLE
Add host.cpu.core.id and host.cpu.socket.id attributes

### DIFF
--- a/.chloggen/add-cpu-topology-attributes.yaml
+++ b/.chloggen/add-cpu-topology-attributes.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: 'cpu'
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'Added `core` and `socket` attributes to the CPU model'
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [39333]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/model/cpu/registry.yaml
+++ b/model/cpu/registry.yaml
@@ -4,6 +4,11 @@ groups:
     brief: Attributes specific to a cpu instance.
     display_name: CPU Attributes
     attributes:
+      - id: cpu.core
+        type: string
+        stability: development
+        brief: "Core number of the CPU."
+        examples: ["0", "1"]
       - id: cpu.mode
         brief: "The mode of the CPU"
         type:
@@ -48,3 +53,8 @@ groups:
         stability: development
         brief: "The logical CPU number [0..n-1]"
         examples: [1]
+      - id: cpu.socket
+        type: string
+        stability: development
+        brief: "Socket number of the CPU."
+        examples: ["0", "1"]

--- a/model/system/metrics.yaml
+++ b/model/system/metrics.yaml
@@ -62,6 +62,10 @@ groups:
         note: "Following states SHOULD be used: `user`, `system`, `nice`, `idle`, `iowait`, `interrupt`, `steal`"
       - ref: cpu.logical_number
         requirement_level: opt_in
+      - ref: cpu.socket
+        requirement_level: recommended
+      - ref: cpu.core
+        requirement_level: recommended
     entity_associations:
       - host
 
@@ -80,6 +84,10 @@ groups:
         note: "Following modes SHOULD be used: `user`, `system`, `nice`, `idle`, `iowait`, `interrupt`, `steal`"
       - ref: cpu.logical_number
         requirement_level: opt_in
+      - ref: cpu.socket
+        requirement_level: recommended
+      - ref: cpu.core
+        requirement_level: recommended
     entity_associations:
       - host
 
@@ -95,6 +103,10 @@ groups:
     unit: "Hz"
     attributes:
       - ref: cpu.logical_number
+      - ref: cpu.socket
+        requirement_level: recommended
+      - ref: cpu.core
+        requirement_level: recommended
     entity_associations:
       - host
 


### PR DESCRIPTION
## Changes

Update semantic conventions with new attributes, added by this PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46332

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] Links to the prototypes or existing instrumentations (when adding or changing conventions)
