### PR TITLE
[chore] Fix weaver registry link

### DIFF
--- a/model/README.md
+++ b/model/README.md
@@ -57,5 +57,5 @@ See also:
 
 * [Markdown Templates](../templates/registry/markdown)
 * [Weaver Template Documentation](https://github.com/open-telemetry/weaver/blob/main/crates/weaver_forge/README.md)
-* [Weaver Usage Documentation](https://github.com/open-telemetry/weaver/blob/main/docs/usage.md#registry-generate)
+* [Weaver Usage Documentation](https://github.com/open-telemetry/weaver/blob/main/docs/usage.md#weaver-registry-generate)
 * [Code Generator Documentation](../docs/non-normative/code-generation.md)


### PR DESCRIPTION
Looks like this change in the Weaver docs broke our link check https://github.com/open-telemetry/weaver/commit/f05fa9c81819fc53a3c7084d8d062355c5e5bafc. 

Wonder if we should point to the fragment or just to the general usage.md page. 

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
