### PR TITLE
Define declarative configuration path for known_methods

### DIFF
--- a/.chloggen/http-known-methods-declarative-config.yaml
+++ b/.chloggen/http-known-methods-declarative-config.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: http
+note: Defined declarative configuration for overriding known HTTP methods.
+issues: [3394]

--- a/docs/db/elasticsearch.md
+++ b/docs/db/elasticsearch.md
@@ -66,8 +66,11 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -100,8 +100,11 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
@@ -227,8 +230,11 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
@@ -307,8 +313,11 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
@@ -442,8 +451,11 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
@@ -582,8 +594,11 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
@@ -696,8 +711,11 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
@@ -810,8 +828,11 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
@@ -1016,8 +1037,11 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -179,8 +179,11 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
@@ -482,8 +485,11 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.

--- a/docs/registry/attributes/http.md
+++ b/docs/registry/attributes/http.md
@@ -53,8 +53,11 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
 Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.

--- a/model/http/registry.yaml
+++ b/model/http/registry.yaml
@@ -96,8 +96,11 @@ groups:
 
           If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
           the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-          OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-          (this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+          OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+          If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
+          (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+          `.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+          it is not a list of known methods in addition to the defaults.
 
           HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
           Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.


### PR DESCRIPTION
Resurrection of
- https://github.com/open-telemetry/semantic-conventions/pull/2504

In order to unblock adding it to the declarative configuration schema.

Until we have a dedicated place for defining declarative configuration in semconv, I'd like to see if it's acceptable to add it freeform in the `notes:` similar to how we've defined environment variables so far.

cc @jack-berg @lmolkova @zeitlinger 