### PR TITLE
Mark `known_methods` declarative config property as development status

### DIFF
--- a/docs/db/elasticsearch.md
+++ b/docs/db/elasticsearch.md
@@ -67,9 +67,13 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
 (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+`.instrumentation/development.general.http.server`.
+
+In either case, this list MUST be a full override of the default known methods,
 it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -101,9 +101,13 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
 (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+`.instrumentation/development.general.http.server`.
+
+In either case, this list MUST be a full override of the default known methods,
 it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
@@ -231,9 +235,13 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
 (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+`.instrumentation/development.general.http.server`.
+
+In either case, this list MUST be a full override of the default known methods,
 it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
@@ -314,9 +322,13 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
 (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+`.instrumentation/development.general.http.server`.
+
+In either case, this list MUST be a full override of the default known methods,
 it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
@@ -452,9 +464,13 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
 (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+`.instrumentation/development.general.http.server`.
+
+In either case, this list MUST be a full override of the default known methods,
 it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
@@ -595,9 +611,13 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
 (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+`.instrumentation/development.general.http.server`.
+
+In either case, this list MUST be a full override of the default known methods,
 it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
@@ -712,9 +732,13 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
 (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+`.instrumentation/development.general.http.server`.
+
+In either case, this list MUST be a full override of the default known methods,
 it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
@@ -829,9 +853,13 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
 (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+`.instrumentation/development.general.http.server`.
+
+In either case, this list MUST be a full override of the default known methods,
 it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
@@ -1038,9 +1066,13 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
 (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+`.instrumentation/development.general.http.server`.
+
+In either case, this list MUST be a full override of the default known methods,
 it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -180,9 +180,13 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
 (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+`.instrumentation/development.general.http.server`.
+
+In either case, this list MUST be a full override of the default known methods,
 it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
@@ -486,9 +490,13 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
 (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+`.instrumentation/development.general.http.server`.
+
+In either case, this list MUST be a full override of the default known methods,
 it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.

--- a/docs/registry/attributes/http.md
+++ b/docs/registry/attributes/http.md
@@ -54,9 +54,13 @@ If the HTTP request method is not known to instrumentation, it MUST set the `htt
 If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
 (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-`.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+`.instrumentation/development.general.http.server`.
+
+In either case, this list MUST be a full override of the default known methods,
 it is not a list of known methods in addition to the defaults.
 
 HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.

--- a/model/http/registry.yaml
+++ b/model/http/registry.yaml
@@ -97,9 +97,13 @@ groups:
           If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
           the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
           OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods.
+
+          ![Development](https://img.shields.io/badge/-development-blue)
           If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
           (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
-          `.instrumentation/development.general.http.server`. In either case, this list MUST be a full override of the default known methods,
+          `.instrumentation/development.general.http.server`.
+
+          In either case, this list MUST be a full override of the default known methods,
           it is not a list of known methods in addition to the defaults.
 
           HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.


### PR DESCRIPTION
To make it clear that this property is in development still (along with the rest of declarative configuration).

Follow-up to the just merged
- #3394 

cc @jack-berg @lmolkova @zeitlinger 