### PR TITLE
Introduce `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN`

### DIFF
--- a/.chloggen/exception-signal-opt-in.yaml
+++ b/.chloggen/exception-signal-opt-in.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: exceptions
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Introduce `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN` environment variable for transitioning exception recording from span events to logs.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [3363]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/exceptions/README.md
+++ b/docs/exceptions/README.md
@@ -6,9 +6,27 @@ linkTitle: Exceptions
 
 **Status**: [Stable][DocumentStatus]
 
+> [!IMPORTANT]
+>
+> Existing instrumentations that record exceptions as span events:
+>
+> * SHOULD introduce an environment variable `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN`
+>   supporting the following values:
+>   * `logs` - emit exceptions as logs only.
+>   * `logs/dup` - emit both span events and logs, allowing for a phased rollout.
+>   * The default behavior (in the absence of one of these values) is to continue
+>     emitting exceptions as span events (existing behavior).
+> * SHOULD maintain (security patching at a minimum) their existing major version
+>   for at least six months after it starts emitting both sets of conventions.
+> * MAY drop the environment variable in their next major version and emit exceptions
+>   as logs only.
+>
+> Even after instrumentations start emitting exceptions only as logs, users will
+> still have the option to route those to span events at the SDK layer.
+
 Semantic conventions for Exceptions are defined for the following signals:
 
-* [Exceptions on spans](exceptions-spans.md): Semantic Conventions for Exceptions associated with *spans*.
+* [Exceptions on spans](exceptions-spans.md): Semantic Conventions for Exceptions recorded on *spans* (deprecated).
 * [Exceptions in logs](exceptions-logs.md): Semantic Conventions for Exceptions recorded in *logs*.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/exceptions/exceptions-logs.md
+++ b/docs/exceptions/exceptions-logs.md
@@ -18,6 +18,24 @@ emitted through the [Logger API](https://github.com/open-telemetry/opentelemetry
 
 <!-- tocstop -->
 
+> [!IMPORTANT]
+>
+> Existing instrumentations that record exceptions as span events:
+>
+> * SHOULD introduce an environment variable `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN`
+>   supporting the following values:
+>   * `logs` - emit exceptions as logs only.
+>   * `logs/dup` - emit both span events and logs, allowing for a phased rollout.
+>   * The default behavior (in the absence of one of these values) is to continue
+>     emitting exceptions as span events (existing behavior).
+> * SHOULD maintain (security patching at a minimum) their existing major version
+>   for at least six months after it starts emitting both sets of conventions.
+> * MAY drop the environment variable in their next major version and emit exceptions
+>   as logs only.
+>
+> Even after instrumentations start emitting exceptions only as logs, users will
+> still have the option to route those to span events at the SDK layer.
+
 ## Recording an exception
 
 Exceptions SHOULD be recorded as attributes on the

--- a/docs/exceptions/exceptions-spans.md
+++ b/docs/exceptions/exceptions-spans.md
@@ -17,6 +17,24 @@ exceptions associated with spans.
 
 <!-- tocstop -->
 
+> [!IMPORTANT]
+>
+> Existing instrumentations that record exceptions as span events:
+>
+> * SHOULD introduce an environment variable `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN`
+>   supporting the following values:
+>   * `logs` - emit exceptions as logs only.
+>   * `logs/dup` - emit both span events and logs, allowing for a phased rollout.
+>   * The default behavior (in the absence of one of these values) is to continue
+>     emitting exceptions as span events (existing behavior).
+> * SHOULD maintain (security patching at a minimum) their existing major version
+>   for at least six months after it starts emitting both sets of conventions.
+> * MAY drop the environment variable in their next major version and emit exceptions
+>   as logs only.
+>
+> Even after instrumentations start emitting exceptions only as logs, users will
+> still have the option to route those to span events at the SDK layer.
+
 ## Exception event
 
 <!-- semconv event.exception -->


### PR DESCRIPTION
Fixes #3363

Introduces environment variable `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN`, defined as

> Existing instrumentations that record exceptions as span events:
>
> * SHOULD introduce an environment variable `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN` supporting the following values:
>   * `logs` - emit exceptions as logs only.
>   * `logs/dup` - emit both span events and logs, allowing for a phased rollout.
>   * The default behavior (in the absence of one of these values) is to continue emitting exceptions as span events (existing behavior).
> * SHOULD maintain (security patching at a minimum) their existing major version for at least six months after it starts emitting both sets of conventions.
> * MAY drop the environment variable in their next major version and emit exceptions as logs only.

Prototype at https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16049