### PR TITLE
introduce: log.type

### DIFF
--- a/model/log/common.yaml
+++ b/model/log/common.yaml
@@ -4,6 +4,8 @@ groups:
     brief: >
       The attributes described in this section are rather generic. They may be used in any Log Record they apply to.
     attributes:
+      - ref: log.type
+        requirement_level: opt_in
       - ref: log.record.uid
         requirement_level: opt_in
       - ref: log.record.original

--- a/model/log/registry.yaml
+++ b/model/log/registry.yaml
@@ -5,6 +5,22 @@ groups:
     brief: >
       This document defines log attributes
     attributes:
+      - id: log.type
+        stability: development
+        brief: >
+          The type or category of the log record. See below for a list of well-known values.
+        type:
+          members:
+            - id: audit
+              value: 'audit'
+              brief: >
+                Audit log recording security-relevant activities for compliance and forensics. When log.type='audit', the log record MUST not get lost and body not changed.
+              stability: development
+            - id: application
+              value: 'app'
+              brief: 'Default regular application log - everything which is NOT audit relevant'
+              stability: development
+
       - id: log.iostream
         stability: development
         brief: >


### PR DESCRIPTION
value: 'audit'

Audit log recording security-relevant activities for compliance and forensics. When log.type='audit', the log record MUST not get lost and body not changed.

