### PR TITLE
Clarify case-sensitivity of declarative config `known_methods`

### DIFF
--- a/docs/db/elasticsearch.md
+++ b/docs/db/elasticsearch.md
@@ -70,7 +70,7 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 ![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+(an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
 `.instrumentation/development.general.http.server`.
 
 In either case, this list MUST be a full override of the default known methods,

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -102,7 +102,7 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 ![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+(an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
 `.instrumentation/development.general.http.server`.
 
 In either case, this list MUST be a full override of the default known methods,
@@ -236,7 +236,7 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 ![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+(an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
 `.instrumentation/development.general.http.server`.
 
 In either case, this list MUST be a full override of the default known methods,
@@ -323,7 +323,7 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 ![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+(an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
 `.instrumentation/development.general.http.server`.
 
 In either case, this list MUST be a full override of the default known methods,
@@ -465,7 +465,7 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 ![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+(an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
 `.instrumentation/development.general.http.server`.
 
 In either case, this list MUST be a full override of the default known methods,
@@ -610,7 +610,7 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 ![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+(an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
 `.instrumentation/development.general.http.server`.
 
 In either case, this list MUST be a full override of the default known methods,
@@ -731,7 +731,7 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 ![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+(an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
 `.instrumentation/development.general.http.server`.
 
 In either case, this list MUST be a full override of the default known methods,
@@ -852,7 +852,7 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 ![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+(an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
 `.instrumentation/development.general.http.server`.
 
 In either case, this list MUST be a full override of the default known methods,
@@ -1063,7 +1063,7 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 ![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+(an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
 `.instrumentation/development.general.http.server`.
 
 In either case, this list MUST be a full override of the default known methods,

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -183,7 +183,7 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 ![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+(an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
 `.instrumentation/development.general.http.server`.
 
 In either case, this list MUST be a full override of the default known methods,
@@ -493,7 +493,7 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 ![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+(an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
 `.instrumentation/development.general.http.server`.
 
 In either case, this list MUST be a full override of the default known methods,

--- a/docs/registry/attributes/http.md
+++ b/docs/registry/attributes/http.md
@@ -57,7 +57,7 @@ OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of ca
 
 ![Development](https://img.shields.io/badge/-development-blue)
 If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-(an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+(an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
 `.instrumentation/development.general.http.server`.
 
 In either case, this list MUST be a full override of the default known methods,

--- a/model/http/registry.yaml
+++ b/model/http/registry.yaml
@@ -100,7 +100,7 @@ groups:
 
           ![Development](https://img.shields.io/badge/-development-blue)
           If this override is done via declarative configuration, then the list MUST be configurable via the `known_methods` property
-          (an array of strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
+          (an array of case-sensitive strings with minimum items 0) under `.instrumentation/development.general.http.client` and/or
           `.instrumentation/development.general.http.server`.
 
           In either case, this list MUST be a full override of the default known methods,


### PR DESCRIPTION
I forgot to carry it over from the env var definition (though can be inferred by statement below as well).