### PR TITLE
Update contributing.md to clarify which conventions belong in this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ Examples of conventions that should not be hosted in this repository:
 Want to define your own conventions outside this repo while building on OTel’s?
 Come help us [decentralize semantic conventions](https://github.com/open-telemetry/weaver/issues/215).
 
-<!-- TODO add link to decentralized conventions docs and examples -->
+<!-- TODO add link to decentralized conventions docs and examples - https://github.com/open-telemetry/semantic-conventions/issues/3456 -->
 
 ### Suggesting conventions for a new area
 


### PR DESCRIPTION
Our current contributing.md suggests to contribute everything in OTel to this repo. 

I believe this is not what we recommend anymore - we've been suggesting to host conventions specific to instrumentation outside of otel semconv.

While there is a lot to figure out (https://github.com/open-telemetry/opentelemetry-specification/pull/4815, specific docs and examples of decentralization), I think we can already outline the principle and update contrib.md