### PR TITLE
Stabilize `otel.event.name`

### DIFF
--- a/.chloggen/stabilize-otel-event-name.yaml
+++ b/.chloggen/stabilize-otel-event-name.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: otel
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Stabilize the `otel.event.name` attribute.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [2913]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/otel.md
+++ b/docs/registry/attributes/otel.md
@@ -110,7 +110,7 @@ Attributes used by non-OTLP exporters to represent OpenTelemetry Event's concept
 
 | Key | Stability | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- |
-| <a id="otel-event-name" href="#otel-event-name">`otel.event.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Identifies the class / type of event. [3] | `browser.mouse.click`; `device.app.lifecycle` |
+| <a id="otel-event-name" href="#otel-event-name">`otel.event.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | Identifies the class / type of event. [3] | `browser.mouse.click`; `device.app.lifecycle` |
 
 **[3] `otel.event.name`:** This attribute SHOULD be used by non-OTLP exporters when destination does not support `EventName` or equivalent field. This attribute MAY be used by applications using existing logging libraries so that it can be used to set the `EventName` field by Collector or SDK components.
 

--- a/model/otel/registry.yaml
+++ b/model/otel/registry.yaml
@@ -83,7 +83,7 @@ groups:
     attributes:
       - id: otel.event.name
         type: string
-        stability: development
+        stability: stable
         brief: >
           Identifies the class / type of event.
         note: >


### PR DESCRIPTION
Fixes #2913

I believe we have necessary prototypes now:

- Log4j - https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16220
- Logback - https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16220
- Go (log processor) - https://pkg.go.dev/go.opentelemetry.io/otel/sdk/log#example-Processor-EventName
