### PR TITLE
[chore] Add retry_wait_time to lychee link checker config

### DIFF
--- a/.github/scripts/lychee-config.toml
+++ b/.github/scripts/lychee-config.toml
@@ -26,6 +26,9 @@ exclude = [
 # better to be safe and avoid failures
 max_retries = 6
 
+# wait between retries to avoid 429 rate limiting from GitHub
+retry_wait_time = 5
+
 # better to be safe and avoid failures
 timeout = 60
 


### PR DESCRIPTION
## Summary

The `link-check` CI job frequently fails with HTTP 429 (Too Many Requests) from GitHub due to rate limiting. The config already has `max_retries=6` but retries happen immediately without any backoff, hitting the same rate limit repeatedly.

### Change

Added `retry_wait_time = 5` to `.github/scripts/lychee-config.toml`, which ensures a 5-second minimum wait between retries. This gives GitHub's rate limiter time to reset before the next attempt.

### Evidence

Example failures (all 429s on GitHub URLs):
- [PR #3250 run](https://github.com/open-telemetry/semantic-conventions/actions/runs/22977247715/job/66708766647)
- These are transient rate limits, not broken links

### References

- [lychee rate limits docs](https://lychee.cli.rs/troubleshooting/rate-limits/)
- [lychee config docs](https://lychee.cli.rs/guides/config/)