### PR TITLE
Update naming.md to clarify 'duration' definition

### DIFF
--- a/docs/general/naming.md
+++ b/docs/general/naming.md
@@ -315,6 +315,14 @@ be confusing in delta backends.
   defined as the difference in `system.cpu.time` measurements divided by the
   elapsed time and number of CPUs.
 
+- **duration** - an instrument that measures elapsed time for individual occurrences 
+  of an event should be called `entity.duration`.
+  For example, `http.server.request.duration` for the time taken to process each HTTP request.
+  These instruments are typically histograms, allowing measurement of both the rate of events
+  and the distribution of their durations.
+  The difference with `time` is that `time` is used to measure monotonically increasing total time,
+  whereas `duration` captures the time of each discrete occurrence.
+
 - **io** - an instrument that measures bidirectional data flow should be
   called `entity.io` and have attributes for direction. For example,
   `system.network.io`.

--- a/docs/general/naming.md
+++ b/docs/general/naming.md
@@ -315,13 +315,11 @@ be confusing in delta backends.
   defined as the difference in `system.cpu.time` measurements divided by the
   elapsed time and number of CPUs.
 
-- **duration** - an instrument that measures elapsed time for individual occurrences 
-  of an event should be called `entity.duration`.
+- **duration** - a histogram that measures operation duration
+  of an event should be called `{operation name}.duration`.
   For example, `http.server.request.duration` for the time taken to process each HTTP request.
-  These instruments are typically histograms, allowing measurement of both the rate of events
-  and the distribution of their durations.
   The difference with `time` is that `time` is used to measure monotonically increasing total time,
-  whereas `duration` captures the time of each discrete occurrence.
+  whereas `duration` captures the aggregated elapsed time.
 
 - **io** - an instrument that measures bidirectional data flow should be
   called `entity.io` and have attributes for direction. For example,

--- a/docs/general/naming.md
+++ b/docs/general/naming.md
@@ -316,7 +316,7 @@ be confusing in delta backends.
   elapsed time and number of CPUs.
 
 - **duration** - a histogram that measures operation duration
-  should be called `{operation name}.duration`.
+  of an event should be called `{operation name}.duration`.
   For example, `http.server.request.duration` for the time taken to process each HTTP request.
   The difference with `time` is that `time` is used to measure monotonically increasing total time,
   whereas `duration` captures the aggregated elapsed time.

--- a/docs/general/naming.md
+++ b/docs/general/naming.md
@@ -316,7 +316,7 @@ be confusing in delta backends.
   elapsed time and number of CPUs.
 
 - **duration** - a histogram that measures operation duration
-  of an event should be called `{operation name}.duration`.
+  should be called `{operation name}.duration`.
   For example, `http.server.request.duration` for the time taken to process each HTTP request.
   The difference with `time` is that `time` is used to measure monotonically increasing total time,
   whereas `duration` captures the aggregated elapsed time.

--- a/docs/general/naming.md
+++ b/docs/general/naming.md
@@ -319,7 +319,7 @@ be confusing in delta backends.
   should be called `{operation name}.duration`.
   For example, `http.server.request.duration` for the time taken to process each HTTP request.
   The difference with `time` is that `time` is used to measure monotonically increasing total time,
-  whereas `duration` captures the elapsed time of discrete operations
+  whereas `duration` captures the elapsed time of discrete operations.
 
 - **io** - an instrument that measures bidirectional data flow should be
   called `entity.io` and have attributes for direction. For example,

--- a/docs/general/naming.md
+++ b/docs/general/naming.md
@@ -319,7 +319,7 @@ be confusing in delta backends.
   should be called `{operation name}.duration`.
   For example, `http.server.request.duration` for the time taken to process each HTTP request.
   The difference with `time` is that `time` is used to measure monotonically increasing total time,
-  whereas `duration` captures the aggregated elapsed time.
+  whereas `duration` captures the elapsed time of discrete operations
 
 - **io** - an instrument that measures bidirectional data flow should be
   called `entity.io` and have attributes for direction. For example,


### PR DESCRIPTION
Part of https://github.com/open-telemetry/semantic-conventions/issues/816

## Changes

**time** and **duration** are close but slightly different ways to instrument times.

There are plenty of examples in this doc with **duration** yet it wasn't defined in the instrument naming section.

@jack-berg explained in [this comment](https://github.com/open-telemetry/semantic-conventions/issues/816#issuecomment-2018164514) clearly the difference between **time** and **duration**.

This attempts to update the documentation to persist this information by documenting **duration** and explaining when to use it compared to **time**.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [x] Links to the prototypes or existing instrumentations (when adding or changing conventions)
