### PR TITLE
ci: Run link check on open-telemetry only

### DIFF
--- a/.github/workflows/daily-link-check.yml
+++ b/.github/workflows/daily-link-check.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   link-check:
+    if: github.repository_owner == 'open-telemetry'
     uses: ./.github/workflows/reusable-link-check.yml
 
   workflow-notification:


### PR DESCRIPTION
## Changes

This is a small CI shift to stop the link check workflow from running on forks.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
