### PR TITLE
genai: Add `gen_ai.token.cache` and `gen_ai.token.reasoning` attributes for detailed token metrics

### DIFF
--- a/.chloggen/genai-detailed-token-metrics.yaml
+++ b/.chloggen/genai-detailed-token-metrics.yaml
@@ -3,6 +3,8 @@ component: gen-ai
 note: "Add `gen_ai.token.cache` and `gen_ai.token.reasoning` attributes for detailed token usage metrics"
 issues: [3341]
 subtext: |
-  Add `gen_ai.token.cache` (string) and `gen_ai.token.reasoning` (boolean) attributes
-  to provide granular token usage breakdowns on the `gen_ai.client.token.usage`
-  metric while preserving backward compatibility and metric additivity.
+  Add `gen_ai.token.cache` (enum: read/creation/uncached) and `gen_ai.token.reasoning`
+  (boolean) attributes to the `gen_ai.client.token.usage` metric. When a provider
+  reports breakdowns, instrumentations partition token counts across these attribute
+  values instead of emitting overlapping totals and subsets. This is a semantic
+  correction to the metric model while the attributes are at development stability.

--- a/.chloggen/genai-detailed-token-metrics.yaml
+++ b/.chloggen/genai-detailed-token-metrics.yaml
@@ -1,8 +1,8 @@
 change_type: enhancement
 component: gen-ai
-note: "Add `gen_ai.token.usage_reason` attribute for detailed token usage metrics (cache, reasoning)"
+note: "Add `gen_ai.token.cache` and `gen_ai.token.reasoning` attributes for detailed token usage metrics"
 issues: [3341]
 subtext: |
-  Add `gen_ai.token.usage_reason` enum attribute with values `cache_read`, `cache_creation`,
-  and `reasoning` to provide granular token usage breakdowns on the `gen_ai.client.token.usage`
+  Add `gen_ai.token.cache` (string) and `gen_ai.token.reasoning` (boolean) attributes
+  to provide granular token usage breakdowns on the `gen_ai.client.token.usage`
   metric while preserving backward compatibility and metric additivity.

--- a/.chloggen/genai-detailed-token-metrics.yaml
+++ b/.chloggen/genai-detailed-token-metrics.yaml
@@ -1,0 +1,8 @@
+change_type: enhancement
+component: gen-ai
+note: "Add `gen_ai.token.usage_reason` attribute for detailed token usage metrics (cache, reasoning)"
+issues: [3341]
+subtext: |
+  Add `gen_ai.token.usage_reason` enum attribute with values `cache_read`, `cache_creation`,
+  and `reasoning` to provide granular token usage breakdowns on the `gen_ai.client.token.usage`
+  metric while preserving backward compatibility and metric additivity.

--- a/.github/scripts/lychee-config.toml
+++ b/.github/scripts/lychee-config.toml
@@ -21,6 +21,8 @@ exclude = [
   # TODO (lmolkova) treat timeout as not a failure?
   "^https://www.intersystems.com",
   "^https://gcc.gnu.org",
+  # Azure OpenAI product page was removed after Microsoft rebranding
+  "^https://azure.microsoft.com/products/ai-services/openai-service",
 ]
 
 # better to be safe and avoid failures

--- a/docs/gen-ai/gen-ai-metrics.md
+++ b/docs/gen-ai/gen-ai-metrics.md
@@ -103,19 +103,22 @@ This metric SHOULD be specified with [ExplicitBucketBoundaries] of [1, 4, 16, 64
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
 | `gen_ai.client.token.usage` | Histogram | `{token}` | Number of input and output tokens used. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
 
-**[1]:** When detailed token usage is available (e.g., cache read tokens, reasoning tokens),
-instrumentations SHOULD record additional data points with the `gen_ai.token.cache`
-or `gen_ai.token.reasoning` attributes set. These detailed data points represent
-subsets of the total `input` or `output` token counts and MUST NOT be summed with
-them to avoid double counting.
+**[1]:** When the provider reports a detailed token breakdown, instrumentations
+SHOULD partition the token count across the relevant attribute values
+instead of emitting a separate total. The partitioned data points MUST
+sum to the total token count for that token type, and a bare data point
+with only `gen_ai.token.type` set MUST NOT be emitted alongside them.
 
-For example, a response with 100 input tokens (50 cached) and 200 output tokens (150 reasoning)
-SHOULD produce:
+When no breakdown is available, a single data point with only
+`gen_ai.token.type` set SHOULD be recorded.
 
-- `gen_ai.client.token.usage{gen_ai.token.type="input"}` = 100
+For example, a response with 100 input tokens (50 cache-read, 50 uncached)
+and 200 output tokens (150 reasoning, 50 non-reasoning) SHOULD produce:
+
 - `gen_ai.client.token.usage{gen_ai.token.type="input", gen_ai.token.cache="read"}` = 50
-- `gen_ai.client.token.usage{gen_ai.token.type="output"}` = 200
+- `gen_ai.client.token.usage{gen_ai.token.type="input", gen_ai.token.cache="uncached"}` = 50
 - `gen_ai.client.token.usage{gen_ai.token.type="output", gen_ai.token.reasoning=true}` = 150
+- `gen_ai.client.token.usage{gen_ai.token.type="output", gen_ai.token.reasoning=false}` = 50
 
 **Attributes:**
 
@@ -125,7 +128,7 @@ SHOULD produce:
 | [`gen_ai.provider.name`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Required` | string | The Generative AI provider as identified by the client or server instrumentation. [2] | `openai`; `gcp.gen_ai`; `gcp.vertex_ai` |
 | [`gen_ai.token.type`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Required` | string | The type of token being counted. | `input`; `output` |
 | [`gen_ai.request.model`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Conditionally Required` If available. | string | The name of the GenAI model a request is being made to. | `gpt-4` |
-| [`gen_ai.token.cache`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Conditionally Required` [3] | string | The cache classification for input tokens. [4] | `read`; `creation` |
+| [`gen_ai.token.cache`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Conditionally Required` [3] | string | The cache classification for input tokens. [4] | `read`; `creation`; `uncached` |
 | [`gen_ai.token.reasoning`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Conditionally Required` [5] | boolean | Whether the output tokens were used for internal reasoning (e.g., chain-of-thought). [6] | |
 | [`server.port`](/docs/registry/attributes/server.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Conditionally Required` If `server.address` is set. | int | GenAI server port. [7] | `80`; `8080`; `443` |
 | [`gen_ai.response.model`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the model that generated the response. | `gpt-4-0613` |
@@ -154,19 +157,32 @@ applicable `aws.bedrock.*` attributes and are not expected to include
 
 **[3] `gen_ai.token.cache`:** when the provider reports a cache breakdown for input tokens.
 
-**[4] `gen_ai.token.cache`:** This attribute SHOULD only be set on data points where `gen_ai.token.type=input`
-and the provider reports a cache breakdown.
+**[4] `gen_ai.token.cache`:** When the provider reports a cache breakdown, instrumentations SHOULD
+partition input tokens across values of this attribute so that they
+sum to the total input token count. Instrumentations MUST NOT emit a
+bare `gen_ai.token.type=input` data point alongside cache-partitioned
+data points for the same request.
 
-When set, it represents a subset of total input tokens. Omit this attribute
-for non-cached input tokens to preserve metric additivity.
+When the provider does not report a cache breakdown, omit this
+attribute entirely and record a single `gen_ai.token.type=input`
+data point with the total count.
+
+Partition members with a value of zero MAY be omitted.
 
 **[5] `gen_ai.token.reasoning`:** when the provider reports reasoning token usage for output tokens.
 
-**[6] `gen_ai.token.reasoning`:** This attribute SHOULD only be set to `true` on data points where
-`gen_ai.token.type=output` and the provider reports a reasoning token breakdown.
+**[6] `gen_ai.token.reasoning`:** When the provider reports a reasoning token breakdown, instrumentations
+SHOULD partition output tokens by setting this attribute to `true`
+(reasoning tokens) and `false` (non-reasoning tokens) so that they
+sum to the total output token count. Instrumentations MUST NOT emit a
+bare `gen_ai.token.type=output` data point alongside reasoning-partitioned
+data points for the same request.
 
-When set, it represents a subset of total output tokens. Omit this attribute
-(or set to `false`) for non-reasoning output tokens to preserve metric additivity.
+When the provider does not report a reasoning breakdown, omit this
+attribute entirely and record a single `gen_ai.token.type=output`
+data point with the total count.
+
+Partition members with a value of zero MAY be omitted.
 
 **[7] `server.port`:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
 
@@ -224,6 +240,7 @@ When set, it represents a subset of total output tokens. Omit this attribute
 | --- | --- | --- |
 | `creation` | Input tokens written to a provider-managed cache. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `read` | Input tokens served from a provider-managed cache. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `uncached` | Input tokens neither served from nor written to a provider-managed cache. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 

--- a/docs/gen-ai/gen-ai-metrics.md
+++ b/docs/gen-ai/gen-ai-metrics.md
@@ -10,6 +10,7 @@ linkTitle: Metrics
 
 - [Generative AI client metrics](#generative-ai-client-metrics)
   - [Metric: `gen_ai.client.token.usage`](#metric-gen_aiclienttokenusage)
+    - [Detailed token usage](#detailed-token-usage)
   - [Metric: `gen_ai.client.operation.duration`](#metric-gen_aiclientoperationduration)
   - [Metric: `gen_ai.client.operation.time_to_first_chunk`](#metric-gen_aiclientoperationtime_to_first_chunk)
   - [Metric: `gen_ai.client.operation.time_per_output_chunk`](#metric-gen_aiclientoperationtime_per_output_chunk)
@@ -67,6 +68,26 @@ If instrumentation cannot efficiently obtain number of input and/or output token
 
 When systems report both used tokens and billable tokens, instrumentation MUST report billable tokens.
 
+#### Detailed token usage
+
+When providers report detailed token breakdowns (such as cached tokens or reasoning tokens),
+instrumentations SHOULD record additional data points with `gen_ai.token.usage_reason` set.
+
+These detailed data points represent **subsets** of the total `input` or `output` token counts.
+To avoid double counting, consumers MUST NOT sum detailed data points with their parent totals.
+Instead, `sum(gen_ai.client.token.usage)` where `gen_ai.token.usage_reason` is **not set** yields
+the correct total token count.
+
+For example, a response with 100 input tokens (50 cached) and 200 output tokens (150 reasoning)
+produces the following data points:
+
+| `gen_ai.token.type` | `gen_ai.token.usage_reason` | Value |
+| --- | --- | --- |
+| `input` | *(not set)* | 100 |
+| `input` | `cache_read` | 50 |
+| `output` | *(not set)* | 200 |
+| `output` | `reasoning` | 150 |
+
 This metric SHOULD be specified with [ExplicitBucketBoundaries] of [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864].
 
 <!-- semconv metric.gen_ai.client.token.usage -->
@@ -76,7 +97,21 @@ This metric SHOULD be specified with [ExplicitBucketBoundaries] of [1, 4, 16, 64
 
 | Name | Instrument Type | Unit (UCUM) | Description | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `gen_ai.client.token.usage` | Histogram | `{token}` | Number of input and output tokens used. | ![Development](https://img.shields.io/badge/-development-blue) | |
+| `gen_ai.client.token.usage` | Histogram | `{token}` | Number of input and output tokens used. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
+
+**[1]:** When detailed token usage is available (e.g., cache read tokens, reasoning tokens),
+instrumentations SHOULD record additional data points with the `gen_ai.token.cache`
+or `gen_ai.token.reasoning` attributes set. These detailed data points represent
+subsets of the total `input` or `output` token counts and MUST NOT be summed with
+them to avoid double counting.
+
+For example, a response with 100 input tokens (50 cached) and 200 output tokens (150 reasoning)
+SHOULD produce:
+
+- `gen_ai.client.token.usage{gen_ai.token.type="input"}` = 100
+- `gen_ai.client.token.usage{gen_ai.token.type="input", gen_ai.token.cache="read"}` = 50
+- `gen_ai.client.token.usage{gen_ai.token.type="output"}` = 200
+- `gen_ai.client.token.usage{gen_ai.token.type="output", gen_ai.token.reasoning=true}` = 150
 
 **Attributes:**
 
@@ -86,9 +121,11 @@ This metric SHOULD be specified with [ExplicitBucketBoundaries] of [1, 4, 16, 64
 | [`gen_ai.provider.name`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Required` | string | The Generative AI provider as identified by the client or server instrumentation. [2] | `openai`; `gcp.gen_ai`; `gcp.vertex_ai` |
 | [`gen_ai.token.type`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Required` | string | The type of token being counted. | `input`; `output` |
 | [`gen_ai.request.model`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Conditionally Required` If available. | string | The name of the GenAI model a request is being made to. | `gpt-4` |
-| [`server.port`](/docs/registry/attributes/server.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Conditionally Required` If `server.address` is set. | int | GenAI server port. [3] | `80`; `8080`; `443` |
+| [`gen_ai.token.cache`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Conditionally Required` [3] | string | The cache classification for input tokens. [4] | `read`; `creation` |
+| [`gen_ai.token.reasoning`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Conditionally Required` [5] | boolean | Whether the output tokens were used for internal reasoning (e.g., chain-of-thought). [6] | |
+| [`server.port`](/docs/registry/attributes/server.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Conditionally Required` If `server.address` is set. | int | GenAI server port. [7] | `80`; `8080`; `443` |
 | [`gen_ai.response.model`](/docs/registry/attributes/gen-ai.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the model that generated the response. | `gpt-4-0613` |
-| [`server.address`](/docs/registry/attributes/server.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | GenAI server address. [4] | `example.com`; `10.1.2.80`; `/tmp/my.sock` |
+| [`server.address`](/docs/registry/attributes/server.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | GenAI server address. [8] | `example.com`; `10.1.2.80`; `/tmp/my.sock` |
 
 **[1] `gen_ai.operation.name`:** If one of the predefined values applies, but specific system uses a different name it's RECOMMENDED to document it in the semantic conventions for specific GenAI system and use system-specific name in the instrumentation. If a different name is not documented, instrumentation libraries SHOULD use applicable predefined value.
 
@@ -111,9 +148,25 @@ should have the `gen_ai.provider.name` set to `aws.bedrock` and include
 applicable `aws.bedrock.*` attributes and are not expected to include
 `openai.*` attributes.
 
-**[3] `server.port`:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
+**[3] `gen_ai.token.cache`:** when the provider reports a cache breakdown for input tokens.
 
-**[4] `server.address`:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
+**[4] `gen_ai.token.cache`:** This attribute SHOULD only be set on data points where `gen_ai.token.type=input`
+and the provider reports a cache breakdown.
+
+When set, it represents a subset of total input tokens. Omit this attribute
+for non-cached input tokens to preserve metric additivity.
+
+**[5] `gen_ai.token.reasoning`:** when the provider reports reasoning token usage for output tokens.
+
+**[6] `gen_ai.token.reasoning`:** This attribute SHOULD only be set to `true` on data points where
+`gen_ai.token.type=output` and the provider reports a reasoning token breakdown.
+
+When set, it represents a subset of total output tokens. Omit this attribute
+(or set to `false`) for non-reasoning output tokens to preserve metric additivity.
+
+**[7] `server.port`:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
+
+**[8] `server.address`:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
 
 ---
 
@@ -143,9 +196,9 @@ applicable `aws.bedrock.*` attributes and are not expected to include
 | `azure.ai.openai` | [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cohere` | [Cohere](https://cohere.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `deepseek` | [DeepSeek](https://www.deepseek.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `gcp.gemini` | [Gemini](https://cloud.google.com/products/gemini) [5] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `gcp.gen_ai` | Any Google generative AI endpoint [6] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `gcp.vertex_ai` | [Vertex AI](https://cloud.google.com/vertex-ai) [7] | ![Development](https://img.shields.io/badge/-development-blue) |
+| `gcp.gemini` | [Gemini](https://cloud.google.com/products/gemini) [9] | ![Development](https://img.shields.io/badge/-development-blue) |
+| `gcp.gen_ai` | Any Google generative AI endpoint [10] | ![Development](https://img.shields.io/badge/-development-blue) |
+| `gcp.vertex_ai` | [Vertex AI](https://cloud.google.com/vertex-ai) [11] | ![Development](https://img.shields.io/badge/-development-blue) |
 | `groq` | [Groq](https://groq.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.watsonx.ai` | [IBM Watsonx AI](https://www.ibm.com/products/watsonx-ai) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mistral_ai` | [Mistral AI](https://mistral.ai/) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -153,11 +206,20 @@ applicable `aws.bedrock.*` attributes and are not expected to include
 | `perplexity` | [Perplexity](https://www.perplexity.ai/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `x_ai` | [xAI](https://x.ai/) | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[5]:** Used when accessing the 'generativelanguage.googleapis.com' endpoint. Also known as the AI Studio API.
+**[9]:** Used when accessing the 'generativelanguage.googleapis.com' endpoint. Also known as the AI Studio API.
 
-**[6]:** May be used when specific backend is unknown.
+**[10]:** May be used when specific backend is unknown.
 
-**[7]:** Used when accessing the 'aiplatform.googleapis.com' endpoint.
+**[11]:** Used when accessing the 'aiplatform.googleapis.com' endpoint.
+
+---
+
+`gen_ai.token.cache` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value | Description | Stability |
+| --- | --- | --- |
+| `creation` | Input tokens written to a provider-managed cache. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `read` | Input tokens served from a provider-managed cache. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 

--- a/docs/gen-ai/gen-ai-metrics.md
+++ b/docs/gen-ai/gen-ai-metrics.md
@@ -71,23 +71,26 @@ When systems report both used tokens and billable tokens, instrumentation MUST r
 #### Detailed token usage
 
 When providers report detailed token breakdowns (such as cached tokens or reasoning tokens),
-instrumentations SHOULD record additional data points with `gen_ai.token.cache`
-or `gen_ai.token.reasoning` attributes set.
+instrumentations SHOULD partition the token count across the relevant attribute values
+instead of emitting a separate total alongside subsets. The partitioned data points
+MUST sum to the total token count for that token type.
 
-These detailed data points represent **subsets** of the total `input` or `output` token counts.
-To avoid double counting, consumers MUST NOT sum detailed data points with their parent totals.
-Instead, `sum(gen_ai.client.token.usage)` where neither `gen_ai.token.cache` nor
-`gen_ai.token.reasoning` is set yields the correct total token count.
+When no breakdown is available, a single data point with only `gen_ai.token.type` set
+SHOULD be recorded. Absence of `gen_ai.token.cache` or `gen_ai.token.reasoning` means
+the provider did not report a breakdown, not that the value is a total bucket.
 
-For example, a response with 100 input tokens (50 cached) and 200 output tokens (150 reasoning)
-produces the following data points:
+To compute total tokens, aggregate across all values of `gen_ai.token.cache` or
+`gen_ai.token.reasoning` for a given `gen_ai.token.type`.
+
+For example, a response with 100 input tokens (50 cache-read, 50 uncached) and
+200 output tokens (150 reasoning, 50 non-reasoning) produces the following data points:
 
 | `gen_ai.token.type` | `gen_ai.token.cache` | `gen_ai.token.reasoning` | Value |
 | --- | --- | --- | --- |
-| `input` | *(not set)* | *(not set)* | 100 |
 | `input` | `read` | *(not set)* | 50 |
-| `output` | *(not set)* | *(not set)* | 200 |
+| `input` | `uncached` | *(not set)* | 50 |
 | `output` | *(not set)* | `true` | 150 |
+| `output` | *(not set)* | `false` | 50 |
 
 This metric SHOULD be specified with [ExplicitBucketBoundaries] of [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864].
 

--- a/docs/gen-ai/gen-ai-metrics.md
+++ b/docs/gen-ai/gen-ai-metrics.md
@@ -71,22 +71,23 @@ When systems report both used tokens and billable tokens, instrumentation MUST r
 #### Detailed token usage
 
 When providers report detailed token breakdowns (such as cached tokens or reasoning tokens),
-instrumentations SHOULD record additional data points with `gen_ai.token.usage_reason` set.
+instrumentations SHOULD record additional data points with `gen_ai.token.cache`
+or `gen_ai.token.reasoning` attributes set.
 
 These detailed data points represent **subsets** of the total `input` or `output` token counts.
 To avoid double counting, consumers MUST NOT sum detailed data points with their parent totals.
-Instead, `sum(gen_ai.client.token.usage)` where `gen_ai.token.usage_reason` is **not set** yields
-the correct total token count.
+Instead, `sum(gen_ai.client.token.usage)` where neither `gen_ai.token.cache` nor
+`gen_ai.token.reasoning` is set yields the correct total token count.
 
 For example, a response with 100 input tokens (50 cached) and 200 output tokens (150 reasoning)
 produces the following data points:
 
-| `gen_ai.token.type` | `gen_ai.token.usage_reason` | Value |
-| --- | --- | --- |
-| `input` | *(not set)* | 100 |
-| `input` | `cache_read` | 50 |
-| `output` | *(not set)* | 200 |
-| `output` | `reasoning` | 150 |
+| `gen_ai.token.type` | `gen_ai.token.cache` | `gen_ai.token.reasoning` | Value |
+| --- | --- | --- | --- |
+| `input` | *(not set)* | *(not set)* | 100 |
+| `input` | `read` | *(not set)* | 50 |
+| `output` | *(not set)* | *(not set)* | 200 |
+| `output` | *(not set)* | `true` | 150 |
 
 This metric SHOULD be specified with [ExplicitBucketBoundaries] of [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864].
 

--- a/docs/registry/attributes/gen-ai.md
+++ b/docs/registry/attributes/gen-ai.md
@@ -51,7 +51,7 @@ This document defines the attributes used to describe telemetry in the context o
 | <a id="gen-ai-retrieval-documents" href="#gen-ai-retrieval-documents">`gen_ai.retrieval.documents`</a> | ![Development](https://img.shields.io/badge/-development-blue) | any | The documents retrieved. [9] | [<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"id": "doc_123",<br>&nbsp;&nbsp;&nbsp;&nbsp;"score": 0.95<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"id": "doc_456",<br>&nbsp;&nbsp;&nbsp;&nbsp;"score": 0.87<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"id": "doc_789",<br>&nbsp;&nbsp;&nbsp;&nbsp;"score": 0.82<br>&nbsp;&nbsp;}<br>] |
 | <a id="gen-ai-retrieval-query-text" href="#gen-ai-retrieval-query-text">`gen_ai.retrieval.query.text`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The query text used for retrieval. [10] | `What is the capital of France?`; `weather in Paris` |
 | <a id="gen-ai-system-instructions" href="#gen-ai-system-instructions">`gen_ai.system_instructions`</a> | ![Development](https://img.shields.io/badge/-development-blue) | any | The system message or instructions provided to the GenAI model separately from the chat history. [11] | [<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"type": "text",<br>&nbsp;&nbsp;&nbsp;&nbsp;"content": "You are an Agent that greet users, always use greetings tool to respond"<br>&nbsp;&nbsp;}<br>]; [<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"type": "text",<br>&nbsp;&nbsp;&nbsp;&nbsp;"content": "You are a language translator."<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"type": "text",<br>&nbsp;&nbsp;&nbsp;&nbsp;"content": "Your mission is to translate text in English to French."<br>&nbsp;&nbsp;}<br>] |
-| <a id="gen-ai-token-cache" href="#gen-ai-token-cache">`gen_ai.token.cache`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The cache classification for input tokens. [12] | `read`; `creation` |
+| <a id="gen-ai-token-cache" href="#gen-ai-token-cache">`gen_ai.token.cache`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The cache classification for input tokens. [12] | `read`; `creation`; `uncached` |
 | <a id="gen-ai-token-reasoning" href="#gen-ai-token-reasoning">`gen_ai.token.reasoning`</a> | ![Development](https://img.shields.io/badge/-development-blue) | boolean | Whether the output tokens were used for internal reasoning (e.g., chain-of-thought). [13] | |
 | <a id="gen-ai-token-type" href="#gen-ai-token-type">`gen_ai.token.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The type of token being counted. | `input`; `output` |
 | <a id="gen-ai-tool-call-arguments" href="#gen-ai-tool-call-arguments">`gen_ai.tool.call.arguments`</a> | ![Development](https://img.shields.io/badge/-development-blue) | any | Parameters passed to the tool call. [14] | {<br>&nbsp;&nbsp;&nbsp;&nbsp;"location": "San Francisco?",<br>&nbsp;&nbsp;&nbsp;&nbsp;"date": "2025-10-01"<br>} |
@@ -65,8 +65,8 @@ This document defines the attributes used to describe telemetry in the context o
 | <a id="gen-ai-usage-cache-read-input-tokens" href="#gen-ai-usage-cache-read-input-tokens">`gen_ai.usage.cache_read.input_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of input tokens served from a provider-managed cache. [19] | `50` |
 | <a id="gen-ai-usage-input-tokens" href="#gen-ai-usage-input-tokens">`gen_ai.usage.input_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of tokens used in the GenAI input (prompt). [20] | `100` |
 | <a id="gen-ai-usage-output-tokens" href="#gen-ai-usage-output-tokens">`gen_ai.usage.output_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of tokens used in the GenAI response (completion). | `180` |
-| <a id="gen-ai-usage-reasoning-output-tokens" href="#gen-ai-usage-reasoning-output-tokens">`gen_ai.usage.reasoning.output_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of output tokens used for reasoning (e.g. chain-of-thought, extended thinking). [19] | `50` |
-| <a id="gen-ai-workflow-name" href="#gen-ai-workflow-name">`gen_ai.workflow.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Human-readable name of the GenAI workflow provided by the application. [20] | `multi_agent_rag`; `customer_support_pipeline` |
+| <a id="gen-ai-usage-reasoning-output-tokens" href="#gen-ai-usage-reasoning-output-tokens">`gen_ai.usage.reasoning.output_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of output tokens used for reasoning (e.g. chain-of-thought, extended thinking). [21] | `50` |
+| <a id="gen-ai-workflow-name" href="#gen-ai-workflow-name">`gen_ai.workflow.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Human-readable name of the GenAI workflow provided by the application. [22] | `multi_agent_rag`; `customer_support_pipeline` |
 
 **[1] `gen_ai.data_source.id`:** Data sources are used by AI agents and RAG applications to store grounding data. A data source may be an external database, object store, document collection, website, or any other storage system used by the GenAI agent or application. The `gen_ai.data_source.id` SHOULD match the identifier used by the GenAI system rather than a name specific to the external storage, such as a database or object store. Semantic conventions referencing `gen_ai.data_source.id` MAY also leverage additional attributes, such as `db.*`, to further identify and describe the data source.
 
@@ -168,17 +168,30 @@ system instructions.
 See [Recording content on attributes](/docs/gen-ai/gen-ai-spans.md#recording-content-on-attributes)
 section for more details.
 
-**[12] `gen_ai.token.cache`:** This attribute SHOULD only be set on data points where `gen_ai.token.type=input`
-and the provider reports a cache breakdown.
+**[12] `gen_ai.token.cache`:** When the provider reports a cache breakdown, instrumentations SHOULD
+partition input tokens across values of this attribute so that they
+sum to the total input token count. Instrumentations MUST NOT emit a
+bare `gen_ai.token.type=input` data point alongside cache-partitioned
+data points for the same request.
 
-When set, it represents a subset of total input tokens. Omit this attribute
-for non-cached input tokens to preserve metric additivity.
+When the provider does not report a cache breakdown, omit this
+attribute entirely and record a single `gen_ai.token.type=input`
+data point with the total count.
 
-**[13] `gen_ai.token.reasoning`:** This attribute SHOULD only be set to `true` on data points where
-`gen_ai.token.type=output` and the provider reports a reasoning token breakdown.
+Partition members with a value of zero MAY be omitted.
 
-When set, it represents a subset of total output tokens. Omit this attribute
-(or set to `false`) for non-reasoning output tokens to preserve metric additivity.
+**[13] `gen_ai.token.reasoning`:** When the provider reports a reasoning token breakdown, instrumentations
+SHOULD partition output tokens by setting this attribute to `true`
+(reasoning tokens) and `false` (non-reasoning tokens) so that they
+sum to the total output token count. Instrumentations MUST NOT emit a
+bare `gen_ai.token.type=output` data point alongside reasoning-partitioned
+data points for the same request.
+
+When the provider does not report a reasoning breakdown, omit this
+attribute entirely and record a single `gen_ai.token.type=output`
+data point with the total count.
+
+Partition members with a value of zero MAY be omitted.
 
 **[14] `gen_ai.tool.call.arguments`:**
 
@@ -223,9 +236,9 @@ Instrumentations SHOULD make a best effort to populate this value, using a total
 provided by the provider when available or, depending on the provider API,
 by summing different token types parsed from the provider output.
 
-**[19] `gen_ai.usage.reasoning.output_tokens`:** The value SHOULD be included in `gen_ai.usage.output_tokens`.
+**[21] `gen_ai.usage.reasoning.output_tokens`:** The value SHOULD be included in `gen_ai.usage.output_tokens`.
 
-**[20] `gen_ai.workflow.name`:** This attribute can be populated in different frameworks eg: name of the first chain in LangChain OR name of the crew in CrewAI.
+**[22] `gen_ai.workflow.name`:** This attribute can be populated in different frameworks eg: name of the first chain in LangChain OR name of the crew in CrewAI.
 
 ---
 
@@ -266,9 +279,9 @@ by summing different token types parsed from the provider output.
 | `azure.ai.openai` | [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cohere` | [Cohere](https://cohere.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `deepseek` | [DeepSeek](https://www.deepseek.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
-| `gcp.gemini` | [Gemini](https://cloud.google.com/products/gemini) [21] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `gcp.gen_ai` | Any Google generative AI endpoint [22] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `gcp.vertex_ai` | [Vertex AI](https://cloud.google.com/vertex-ai) [23] | ![Development](https://img.shields.io/badge/-development-blue) |
+| `gcp.gemini` | [Gemini](https://cloud.google.com/products/gemini) [23] | ![Development](https://img.shields.io/badge/-development-blue) |
+| `gcp.gen_ai` | Any Google generative AI endpoint [24] | ![Development](https://img.shields.io/badge/-development-blue) |
+| `gcp.vertex_ai` | [Vertex AI](https://cloud.google.com/vertex-ai) [25] | ![Development](https://img.shields.io/badge/-development-blue) |
 | `groq` | [Groq](https://groq.com/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.watsonx.ai` | [IBM Watsonx AI](https://www.ibm.com/products/watsonx-ai) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mistral_ai` | [Mistral AI](https://mistral.ai/) | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -276,11 +289,12 @@ by summing different token types parsed from the provider output.
 | `perplexity` | [Perplexity](https://www.perplexity.ai/) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `x_ai` | [xAI](https://x.ai/) | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[21]:** Used when accessing the 'generativelanguage.googleapis.com' endpoint. Also known as the AI Studio API.
+**[23]:** Used when accessing the 'generativelanguage.googleapis.com' endpoint. Also known as the AI Studio API.
 
-**[22]:** May be used when specific backend is unknown.
+**[24]:** May be used when specific backend is unknown.
 
-**[23]:** Used when accessing the 'aiplatform.googleapis.com' endpoint.
+**[25]:** Used when accessing the 'aiplatform.googleapis.com' endpoint.
+
 ---
 
 `gen_ai.token.cache` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
@@ -289,6 +303,7 @@ by summing different token types parsed from the provider output.
 | --- | --- | --- |
 | `creation` | Input tokens written to a provider-managed cache. | ![Development](https://img.shields.io/badge/-development-blue) |
 | `read` | Input tokens served from a provider-managed cache. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `uncached` | Input tokens neither served from nor written to a provider-managed cache. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 
@@ -325,9 +340,9 @@ Describes deprecated `gen_ai` attributes.
 | `azure.ai.openai` | Azure OpenAI | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cohere` | Cohere | ![Development](https://img.shields.io/badge/-development-blue) |
 | `deepseek` | DeepSeek | ![Development](https://img.shields.io/badge/-development-blue) |
-| `gcp.gemini` | Gemini [24] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `gcp.gen_ai` | Any Google generative AI endpoint [25] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `gcp.vertex_ai` | Vertex AI [26] | ![Development](https://img.shields.io/badge/-development-blue) |
+| `gcp.gemini` | Gemini [26] | ![Development](https://img.shields.io/badge/-development-blue) |
+| `gcp.gen_ai` | Any Google generative AI endpoint [27] | ![Development](https://img.shields.io/badge/-development-blue) |
+| `gcp.vertex_ai` | Vertex AI [28] | ![Development](https://img.shields.io/badge/-development-blue) |
 | `groq` | Groq | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.watsonx.ai` | IBM Watsonx AI | ![Development](https://img.shields.io/badge/-development-blue) |
 | `mistral_ai` | Mistral AI | ![Development](https://img.shields.io/badge/-development-blue) |
@@ -335,11 +350,11 @@ Describes deprecated `gen_ai` attributes.
 | `perplexity` | Perplexity | ![Development](https://img.shields.io/badge/-development-blue) |
 | `xai` | xAI | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[24]:** This refers to the 'generativelanguage.googleapis.com' endpoint. Also known as the AI Studio API. May use common attributes prefixed with 'gcp.gen_ai.'.
+**[26]:** This refers to the 'generativelanguage.googleapis.com' endpoint. Also known as the AI Studio API. May use common attributes prefixed with 'gcp.gen_ai.'.
 
-**[25]:** May be used when specific backend is unknown. May use common attributes prefixed with 'gcp.gen_ai.'.
+**[27]:** May be used when specific backend is unknown. May use common attributes prefixed with 'gcp.gen_ai.'.
 
-**[26]:** This refers to the 'aiplatform.googleapis.com' endpoint. May use common attributes prefixed with 'gcp.gen_ai.'.
+**[28]:** This refers to the 'aiplatform.googleapis.com' endpoint. May use common attributes prefixed with 'gcp.gen_ai.'.
 
 ## Deprecated OpenAI GenAI Attributes
 

--- a/docs/registry/attributes/gen-ai.md
+++ b/docs/registry/attributes/gen-ai.md
@@ -51,17 +51,19 @@ This document defines the attributes used to describe telemetry in the context o
 | <a id="gen-ai-retrieval-documents" href="#gen-ai-retrieval-documents">`gen_ai.retrieval.documents`</a> | ![Development](https://img.shields.io/badge/-development-blue) | any | The documents retrieved. [9] | [<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"id": "doc_123",<br>&nbsp;&nbsp;&nbsp;&nbsp;"score": 0.95<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"id": "doc_456",<br>&nbsp;&nbsp;&nbsp;&nbsp;"score": 0.87<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"id": "doc_789",<br>&nbsp;&nbsp;&nbsp;&nbsp;"score": 0.82<br>&nbsp;&nbsp;}<br>] |
 | <a id="gen-ai-retrieval-query-text" href="#gen-ai-retrieval-query-text">`gen_ai.retrieval.query.text`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The query text used for retrieval. [10] | `What is the capital of France?`; `weather in Paris` |
 | <a id="gen-ai-system-instructions" href="#gen-ai-system-instructions">`gen_ai.system_instructions`</a> | ![Development](https://img.shields.io/badge/-development-blue) | any | The system message or instructions provided to the GenAI model separately from the chat history. [11] | [<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"type": "text",<br>&nbsp;&nbsp;&nbsp;&nbsp;"content": "You are an Agent that greet users, always use greetings tool to respond"<br>&nbsp;&nbsp;}<br>]; [<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"type": "text",<br>&nbsp;&nbsp;&nbsp;&nbsp;"content": "You are a language translator."<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"type": "text",<br>&nbsp;&nbsp;&nbsp;&nbsp;"content": "Your mission is to translate text in English to French."<br>&nbsp;&nbsp;}<br>] |
+| <a id="gen-ai-token-cache" href="#gen-ai-token-cache">`gen_ai.token.cache`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The cache classification for input tokens. [12] | `read`; `creation` |
+| <a id="gen-ai-token-reasoning" href="#gen-ai-token-reasoning">`gen_ai.token.reasoning`</a> | ![Development](https://img.shields.io/badge/-development-blue) | boolean | Whether the output tokens were used for internal reasoning (e.g., chain-of-thought). [13] | |
 | <a id="gen-ai-token-type" href="#gen-ai-token-type">`gen_ai.token.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The type of token being counted. | `input`; `output` |
-| <a id="gen-ai-tool-call-arguments" href="#gen-ai-tool-call-arguments">`gen_ai.tool.call.arguments`</a> | ![Development](https://img.shields.io/badge/-development-blue) | any | Parameters passed to the tool call. [12] | {<br>&nbsp;&nbsp;&nbsp;&nbsp;"location": "San Francisco?",<br>&nbsp;&nbsp;&nbsp;&nbsp;"date": "2025-10-01"<br>} |
+| <a id="gen-ai-tool-call-arguments" href="#gen-ai-tool-call-arguments">`gen_ai.tool.call.arguments`</a> | ![Development](https://img.shields.io/badge/-development-blue) | any | Parameters passed to the tool call. [14] | {<br>&nbsp;&nbsp;&nbsp;&nbsp;"location": "San Francisco?",<br>&nbsp;&nbsp;&nbsp;&nbsp;"date": "2025-10-01"<br>} |
 | <a id="gen-ai-tool-call-id" href="#gen-ai-tool-call-id">`gen_ai.tool.call.id`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The tool call identifier. | `call_mszuSIzqtI65i1wAUOE8w5H4` |
-| <a id="gen-ai-tool-call-result" href="#gen-ai-tool-call-result">`gen_ai.tool.call.result`</a> | ![Development](https://img.shields.io/badge/-development-blue) | any | The result returned by the tool call (if any and if execution was successful). [13] | {<br>&nbsp;&nbsp;"temperature_range": {<br>&nbsp;&nbsp;&nbsp;&nbsp;"high": 75,<br>&nbsp;&nbsp;&nbsp;&nbsp;"low": 60<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"conditions": "sunny"<br>} |
-| <a id="gen-ai-tool-definitions" href="#gen-ai-tool-definitions">`gen_ai.tool.definitions`</a> | ![Development](https://img.shields.io/badge/-development-blue) | any | The list of tool definitions available to the GenAI agent or model. [14] | [<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"type": "function",<br>&nbsp;&nbsp;&nbsp;&nbsp;"name": "get_current_weather",<br>&nbsp;&nbsp;&nbsp;&nbsp;"description": "Get the current weather in a given location",<br>&nbsp;&nbsp;&nbsp;&nbsp;"parameters": {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"type": "object",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"properties": {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"location": {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"type": "string",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"description": "The city and state, e.g. San Francisco, CA"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"type": "string",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"enum": [<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"celsius",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"fahrenheit"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"required": [<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"location",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;}<br>] |
+| <a id="gen-ai-tool-call-result" href="#gen-ai-tool-call-result">`gen_ai.tool.call.result`</a> | ![Development](https://img.shields.io/badge/-development-blue) | any | The result returned by the tool call (if any and if execution was successful). [15] | {<br>&nbsp;&nbsp;"temperature_range": {<br>&nbsp;&nbsp;&nbsp;&nbsp;"high": 75,<br>&nbsp;&nbsp;&nbsp;&nbsp;"low": 60<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"conditions": "sunny"<br>} |
+| <a id="gen-ai-tool-definitions" href="#gen-ai-tool-definitions">`gen_ai.tool.definitions`</a> | ![Development](https://img.shields.io/badge/-development-blue) | any | The list of tool definitions available to the GenAI agent or model. [16] | [<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"type": "function",<br>&nbsp;&nbsp;&nbsp;&nbsp;"name": "get_current_weather",<br>&nbsp;&nbsp;&nbsp;&nbsp;"description": "Get the current weather in a given location",<br>&nbsp;&nbsp;&nbsp;&nbsp;"parameters": {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"type": "object",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"properties": {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"location": {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"type": "string",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"description": "The city and state, e.g. San Francisco, CA"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"type": "string",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"enum": [<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"celsius",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"fahrenheit"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"required": [<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"location",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;}<br>] |
 | <a id="gen-ai-tool-description" href="#gen-ai-tool-description">`gen_ai.tool.description`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The tool description. | `Multiply two numbers` |
 | <a id="gen-ai-tool-name" href="#gen-ai-tool-name">`gen_ai.tool.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Name of the tool utilized by the agent. | `Flights` |
-| <a id="gen-ai-tool-type" href="#gen-ai-tool-type">`gen_ai.tool.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Type of the tool utilized by the agent [15] | `function`; `extension`; `datastore` |
-| <a id="gen-ai-usage-cache-creation-input-tokens" href="#gen-ai-usage-cache-creation-input-tokens">`gen_ai.usage.cache_creation.input_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of input tokens written to a provider-managed cache. [16] | `25` |
-| <a id="gen-ai-usage-cache-read-input-tokens" href="#gen-ai-usage-cache-read-input-tokens">`gen_ai.usage.cache_read.input_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of input tokens served from a provider-managed cache. [17] | `50` |
-| <a id="gen-ai-usage-input-tokens" href="#gen-ai-usage-input-tokens">`gen_ai.usage.input_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of tokens used in the GenAI input (prompt). [18] | `100` |
+| <a id="gen-ai-tool-type" href="#gen-ai-tool-type">`gen_ai.tool.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Type of the tool utilized by the agent [17] | `function`; `extension`; `datastore` |
+| <a id="gen-ai-usage-cache-creation-input-tokens" href="#gen-ai-usage-cache-creation-input-tokens">`gen_ai.usage.cache_creation.input_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of input tokens written to a provider-managed cache. [18] | `25` |
+| <a id="gen-ai-usage-cache-read-input-tokens" href="#gen-ai-usage-cache-read-input-tokens">`gen_ai.usage.cache_read.input_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of input tokens served from a provider-managed cache. [19] | `50` |
+| <a id="gen-ai-usage-input-tokens" href="#gen-ai-usage-input-tokens">`gen_ai.usage.input_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of tokens used in the GenAI input (prompt). [20] | `100` |
 | <a id="gen-ai-usage-output-tokens" href="#gen-ai-usage-output-tokens">`gen_ai.usage.output_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of tokens used in the GenAI response (completion). | `180` |
 | <a id="gen-ai-usage-reasoning-output-tokens" href="#gen-ai-usage-reasoning-output-tokens">`gen_ai.usage.reasoning.output_tokens`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of output tokens used for reasoning (e.g. chain-of-thought, extended thinking). [19] | `50` |
 | <a id="gen-ai-workflow-name" href="#gen-ai-workflow-name">`gen_ai.workflow.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Human-readable name of the GenAI workflow provided by the application. [20] | `multi_agent_rag`; `customer_support_pipeline` |
@@ -166,7 +168,19 @@ system instructions.
 See [Recording content on attributes](/docs/gen-ai/gen-ai-spans.md#recording-content-on-attributes)
 section for more details.
 
-**[12] `gen_ai.tool.call.arguments`:**
+**[12] `gen_ai.token.cache`:** This attribute SHOULD only be set on data points where `gen_ai.token.type=input`
+and the provider reports a cache breakdown.
+
+When set, it represents a subset of total input tokens. Omit this attribute
+for non-cached input tokens to preserve metric additivity.
+
+**[13] `gen_ai.token.reasoning`:** This attribute SHOULD only be set to `true` on data points where
+`gen_ai.token.type=output` and the provider reports a reasoning token breakdown.
+
+When set, it represents a subset of total output tokens. Omit this attribute
+(or set to `false`) for non-reasoning output tokens to preserve metric additivity.
+
+**[14] `gen_ai.tool.call.arguments`:**
 
 > [!WARNING]
 > This attribute may contain sensitive information.
@@ -175,7 +189,7 @@ It's expected to be an object - in case a serialized string is available
 to the instrumentation, the instrumentation SHOULD do the best effort to
 deserialize it to an object. When recorded on spans, it MAY be recorded as a JSON string if structured format is not supported and SHOULD be recorded in structured form otherwise.
 
-**[13] `gen_ai.tool.call.result`:**
+**[15] `gen_ai.tool.call.result`:**
 
 > [!WARNING]
 > This attribute may contain sensitive information.
@@ -184,7 +198,7 @@ It's expected to be an object - in case a serialized string is available
 to the instrumentation, the instrumentation SHOULD do the best effort to
 deserialize it to an object. When recorded on spans, it MAY be recorded as a JSON string if structured format is not supported and SHOULD be recorded in structured form otherwise.
 
-**[14] `gen_ai.tool.definitions`:** Instrumentations MUST follow [Tool Definitions JSON Schema](/docs/gen-ai/gen-ai-tool-definitions.json).
+**[16] `gen_ai.tool.definitions`:** Instrumentations MUST follow [Tool Definitions JSON Schema](/docs/gen-ai/gen-ai-tool-definitions.json).
 
 When the attribute is recorded on events, it MUST be recorded in structured
 form. When recorded on spans, it MAY be recorded as a JSON string if structured
@@ -194,17 +208,17 @@ Since this attribute could be large, it's NOT RECOMMENDED to populate
 non-required properties by default. Instrumentations MAY provide a way
 to enable populating optional properties.
 
-**[15] `gen_ai.tool.type`:** Extension: A tool executed on the agent-side to directly call external APIs, bridging the gap between the agent and real-world systems.
+**[17] `gen_ai.tool.type`:** Extension: A tool executed on the agent-side to directly call external APIs, bridging the gap between the agent and real-world systems.
   Agent-side operations involve actions that are performed by the agent on the server or within the agent's controlled environment.
 Function: A tool executed on the client-side, where the agent generates parameters for a predefined function, and the client executes the logic.
   Client-side operations are actions taken on the user's end or within the client application.
 Datastore: A tool used by the agent to access and query structured or unstructured external data for retrieval-augmented tasks or knowledge updates.
 
-**[16] `gen_ai.usage.cache_creation.input_tokens`:** The value SHOULD be included in `gen_ai.usage.input_tokens`.
+**[18] `gen_ai.usage.cache_creation.input_tokens`:** The value SHOULD be included in `gen_ai.usage.input_tokens`.
 
-**[17] `gen_ai.usage.cache_read.input_tokens`:** The value SHOULD be included in `gen_ai.usage.input_tokens`.
+**[19] `gen_ai.usage.cache_read.input_tokens`:** The value SHOULD be included in `gen_ai.usage.input_tokens`.
 
-**[18] `gen_ai.usage.input_tokens`:** This value SHOULD include all types of input tokens, including cached tokens.
+**[20] `gen_ai.usage.input_tokens`:** This value SHOULD include all types of input tokens, including cached tokens.
 Instrumentations SHOULD make a best effort to populate this value, using a total
 provided by the provider when available or, depending on the provider API,
 by summing different token types parsed from the provider output.
@@ -267,6 +281,14 @@ by summing different token types parsed from the provider output.
 **[22]:** May be used when specific backend is unknown.
 
 **[23]:** Used when accessing the 'aiplatform.googleapis.com' endpoint.
+---
+
+`gen_ai.token.cache` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value | Description | Stability |
+| --- | --- | --- |
+| `creation` | Input tokens written to a provider-managed cache. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `read` | Input tokens served from a provider-managed cache. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 

--- a/model/gen-ai/metrics.yaml
+++ b/model/gen-ai/metrics.yaml
@@ -46,6 +46,20 @@ groups:
       code_generation:
         metric_value_type: int
     brief: 'Number of input and output tokens used.'
+    note: |
+      When detailed token usage is available (e.g., cache read tokens, reasoning tokens),
+      instrumentations SHOULD record additional data points with the `gen_ai.token.cache`
+      or `gen_ai.token.reasoning` attributes set. These detailed data points represent
+      subsets of the total `input` or `output` token counts and MUST NOT be summed with
+      them to avoid double counting.
+
+      For example, a response with 100 input tokens (50 cached) and 200 output tokens (150 reasoning)
+      SHOULD produce:
+
+      - `gen_ai.client.token.usage{gen_ai.token.type="input"}` = 100
+      - `gen_ai.client.token.usage{gen_ai.token.type="input", gen_ai.token.cache="read"}` = 50
+      - `gen_ai.client.token.usage{gen_ai.token.type="output"}` = 200
+      - `gen_ai.client.token.usage{gen_ai.token.type="output", gen_ai.token.reasoning=true}` = 150
     instrument: histogram
     unit: "{token}"
     stability: development
@@ -53,6 +67,12 @@ groups:
     attributes:
       - ref: gen_ai.token.type
         requirement_level: required
+      - ref: gen_ai.token.cache
+        requirement_level:
+          conditionally_required: when the provider reports a cache breakdown for input tokens.
+      - ref: gen_ai.token.reasoning
+        requirement_level:
+          conditionally_required: when the provider reports reasoning token usage for output tokens.
   - id: metric.gen_ai.client.operation.duration
     type: metric
     metric_name: gen_ai.client.operation.duration

--- a/model/gen-ai/metrics.yaml
+++ b/model/gen-ai/metrics.yaml
@@ -47,19 +47,22 @@ groups:
         metric_value_type: int
     brief: 'Number of input and output tokens used.'
     note: |
-      When detailed token usage is available (e.g., cache read tokens, reasoning tokens),
-      instrumentations SHOULD record additional data points with the `gen_ai.token.cache`
-      or `gen_ai.token.reasoning` attributes set. These detailed data points represent
-      subsets of the total `input` or `output` token counts and MUST NOT be summed with
-      them to avoid double counting.
+      When the provider reports a detailed token breakdown, instrumentations
+      SHOULD partition the token count across the relevant attribute values
+      instead of emitting a separate total. The partitioned data points MUST
+      sum to the total token count for that token type, and a bare data point
+      with only `gen_ai.token.type` set MUST NOT be emitted alongside them.
 
-      For example, a response with 100 input tokens (50 cached) and 200 output tokens (150 reasoning)
-      SHOULD produce:
+      When no breakdown is available, a single data point with only
+      `gen_ai.token.type` set SHOULD be recorded.
 
-      - `gen_ai.client.token.usage{gen_ai.token.type="input"}` = 100
+      For example, a response with 100 input tokens (50 cache-read, 50 uncached)
+      and 200 output tokens (150 reasoning, 50 non-reasoning) SHOULD produce:
+
       - `gen_ai.client.token.usage{gen_ai.token.type="input", gen_ai.token.cache="read"}` = 50
-      - `gen_ai.client.token.usage{gen_ai.token.type="output"}` = 200
+      - `gen_ai.client.token.usage{gen_ai.token.type="input", gen_ai.token.cache="uncached"}` = 50
       - `gen_ai.client.token.usage{gen_ai.token.type="output", gen_ai.token.reasoning=true}` = 150
+      - `gen_ai.client.token.usage{gen_ai.token.type="output", gen_ai.token.reasoning=false}` = 50
     instrument: histogram
     unit: "{token}"
     stability: development

--- a/model/gen-ai/registry.yaml
+++ b/model/gen-ai/registry.yaml
@@ -258,24 +258,41 @@ groups:
               stability: development
               value: "creation"
               brief: 'Input tokens written to a provider-managed cache.'
+            - id: uncached
+              stability: development
+              value: "uncached"
+              brief: 'Input tokens neither served from nor written to a provider-managed cache.'
         brief: The cache classification for input tokens.
         note: |
-          This attribute SHOULD only be set on data points where `gen_ai.token.type=input`
-          and the provider reports a cache breakdown.
+          When the provider reports a cache breakdown, instrumentations SHOULD
+          partition input tokens across values of this attribute so that they
+          sum to the total input token count. Instrumentations MUST NOT emit a
+          bare `gen_ai.token.type=input` data point alongside cache-partitioned
+          data points for the same request.
 
-          When set, it represents a subset of total input tokens. Omit this attribute
-          for non-cached input tokens to preserve metric additivity.
-        examples: ['read', 'creation']
+          When the provider does not report a cache breakdown, omit this
+          attribute entirely and record a single `gen_ai.token.type=input`
+          data point with the total count.
+
+          Partition members with a value of zero MAY be omitted.
+        examples: ['read', 'creation', 'uncached']
       - id: gen_ai.token.reasoning
         stability: development
         type: boolean
         brief: Whether the output tokens were used for internal reasoning (e.g., chain-of-thought).
         note: |
-          This attribute SHOULD only be set to `true` on data points where
-          `gen_ai.token.type=output` and the provider reports a reasoning token breakdown.
+          When the provider reports a reasoning token breakdown, instrumentations
+          SHOULD partition output tokens by setting this attribute to `true`
+          (reasoning tokens) and `false` (non-reasoning tokens) so that they
+          sum to the total output token count. Instrumentations MUST NOT emit a
+          bare `gen_ai.token.type=output` data point alongside reasoning-partitioned
+          data points for the same request.
 
-          When set, it represents a subset of total output tokens. Omit this attribute
-          (or set to `false`) for non-reasoning output tokens to preserve metric additivity.
+          When the provider does not report a reasoning breakdown, omit this
+          attribute entirely and record a single `gen_ai.token.type=output`
+          data point with the total count.
+
+          Partition members with a value of zero MAY be omitted.
       - id: gen_ai.conversation.id
         stability: development
         type: string

--- a/model/gen-ai/registry.yaml
+++ b/model/gen-ai/registry.yaml
@@ -246,6 +246,36 @@ groups:
               brief: 'Output tokens (completion, response, etc.)'
         brief: The type of token being counted.
         examples: ['input', 'output']
+      - id: gen_ai.token.cache
+        stability: development
+        type:
+          members:
+            - id: read
+              stability: development
+              value: "read"
+              brief: 'Input tokens served from a provider-managed cache.'
+            - id: creation
+              stability: development
+              value: "creation"
+              brief: 'Input tokens written to a provider-managed cache.'
+        brief: The cache classification for input tokens.
+        note: |
+          This attribute SHOULD only be set on data points where `gen_ai.token.type=input`
+          and the provider reports a cache breakdown.
+
+          When set, it represents a subset of total input tokens. Omit this attribute
+          for non-cached input tokens to preserve metric additivity.
+        examples: ['read', 'creation']
+      - id: gen_ai.token.reasoning
+        stability: development
+        type: boolean
+        brief: Whether the output tokens were used for internal reasoning (e.g., chain-of-thought).
+        note: |
+          This attribute SHOULD only be set to `true` on data points where
+          `gen_ai.token.type=output` and the provider reports a reasoning token breakdown.
+
+          When set, it represents a subset of total output tokens. Omit this attribute
+          (or set to `false`) for non-reasoning output tokens to preserve metric additivity.
       - id: gen_ai.conversation.id
         stability: development
         type: string


### PR DESCRIPTION
Add `gen_ai.token.cache` and `gen_ai.token.reasoning` attributes to `gen_ai.client.token.usage` for detailed token breakdowns.

Fixes open-telemetry/semantic-conventions-genai#76

Modern providers report richer token data than just input vs output. Anthropic gives cache read/creation/uncached counts, OpenAI reports cached input and reasoning output tokens. Right now there's no way to capture this in the metric without losing additivity.

This adds two attributes that partition the token count when breakdowns are available:

- `gen_ai.token.cache` (enum: read, creation, uncached) for input tokens
- `gen_ai.token.reasoning` (boolean) for output tokens

When the provider reports a breakdown, instrumentations emit partitioned data points that sum to the total instead of emitting a total row plus overlapping subsets. When no breakdown is available, a bare `gen_ai.token.type` data point is recorded as before.

Example -- 100 input tokens (50 cache-read, 50 uncached), 200 output (150 reasoning, 50 not):

| token.type | token.cache | token.reasoning | value |
|---|---|---|---|
| input | read | | 50 |
| input | uncached | | 50 |
| output | | true | 150 |
| output | | false | 50 |

Follows the multi-attribute direction from @alexmojaki in open-telemetry/semantic-conventions-genai#76.