### PR TITLE
[chore] Clarify service.name fallback does not require process.executable.name attribute

### DIFF
--- a/docs/registry/attributes/service.md
+++ b/docs/registry/attributes/service.md
@@ -49,7 +49,8 @@ However, Collectors can set the `service.instance.id` if they can unambiguously 
 for that telemetry. This is typically the case for scraping receivers, as they know the target address and
 port.
 
-**[3] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+**[3] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with the process executable name, e.g. `unknown_service:bash`. If the process executable name is not available, the value MUST be set to `unknown_service`.
+The process executable name is the name of the process executable, the same value as described by the [`process.executable.name`](process.md) resource attribute.
 
 **[4] `service.namespace`:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
 

--- a/docs/registry/entities/service.md
+++ b/docs/registry/entities/service.md
@@ -19,7 +19,8 @@
 | Description | [`service.criticality`](/docs/registry/attributes/service.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The operational criticality of the service. [2] | `critical`; `high`; `medium`; `low` |
 | Description | [`service.version`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The version string of the service component. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` |
 
-**[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+**[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with the process executable name, e.g. `unknown_service:bash`. If the process executable name is not available, the value MUST be set to `unknown_service`.
+The process executable name is the name of the process executable, the same value as described by the [`process.executable.name`](process.md) resource attribute.
 
 **[2] `service.criticality`:** Application developers are encouraged to set `service.criticality` to express the operational importance of their services. Telemetry consumers MAY use this attribute to optimize telemetry collection or improve user experience.
 

--- a/docs/resource/service.md
+++ b/docs/resource/service.md
@@ -66,7 +66,8 @@ between them. Additionally, there's a single database instance.
 | Description | [`service.criticality`](/docs/registry/attributes/service.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The operational criticality of the service. [2] | `critical`; `high`; `medium`; `low` |
 | Description | [`service.version`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The version string of the service component. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` |
 
-**[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+**[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with the process executable name, e.g. `unknown_service:bash`. If the process executable name is not available, the value MUST be set to `unknown_service`.
+The process executable name is the name of the process executable, the same value as described by the [`process.executable.name`](process.md) resource attribute.
 
 **[2] `service.criticality`:** Application developers are encouraged to set `service.criticality` to express the operational importance of their services. Telemetry consumers MAY use this attribute to optimize telemetry collection or improve user experience.
 

--- a/model/service/registry.yaml
+++ b/model/service/registry.yaml
@@ -12,8 +12,11 @@ groups:
         note: >
           MUST be the same for all instances of horizontally scaled services.
           If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated
-          with [`process.executable.name`](process.md), e.g. `unknown_service:bash`.
-          If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+          with the process executable name, e.g. `unknown_service:bash`.
+          If the process executable name is not available, the value MUST be set to `unknown_service`.
+
+          The process executable name is the name of the process executable,
+          the same value as described by the [`process.executable.name`](process.md) resource attribute.
         examples: ["shoppingcart"]
         stability: stable
       - id: service.version


### PR DESCRIPTION
## Changes

The service.name fallback note previously linked process.executable.name as an attribute reference, which caused SDK implementors to believe they must read it from an attribute of that name.

The intent is for SDKs to use the process executable name (obtained via platform APIs), not to require the `process.executable.name` resource attribute to be populated. This change clarifies that.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
