### PR TITLE
chore(makefile): stop printing 'Neither docker nor podman' on happy path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,14 @@ ifndef DOCKER_COMMAND
     ifneq ($(strip $(shell podman --version 2>&1)),)
         DOCKER_COMMAND := podman
     endif
-else
+endif
+
+# Only warn once both autodetect paths have failed. The previous
+# condition printed the warning whenever DOCKER_COMMAND *was* set
+# (i.e. docker or podman had been found), so every container target
+# on a working machine emitted a spurious "Neither docker nor podman
+# can be executed" line (#3626).
+ifndef DOCKER_COMMAND
     $(info Neither docker nor podman can be executed. Did you install and configure one of them to be used?)
 endif
 


### PR DESCRIPTION
## Summary

Fixes #3626.

The existing branch tree prints the `Neither docker nor podman can be executed` info whenever `DOCKER_COMMAND` *was* set (i.e. autodetect had already found a runtime), so every container Make target on a working machine logged a spurious warning. The warning should run only when both autodetect paths (docker then podman) failed.

```makefile
# Before
ifndef DOCKER_COMMAND
    ifneq ($(strip $(shell podman --version 2>&1)),)
        DOCKER_COMMAND := podman
    endif
else
    $(info Neither docker nor podman can be executed. ...)
endif
```

The `else` fires when `DOCKER_COMMAND` *is* defined — i.e. docker was just detected a few lines earlier. That's the opposite of the intent.

## Fix

Split autodetect and the warning into two separate `ifndef` blocks. Detect runs first; if `DOCKER_COMMAND` is still unset afterwards, print the warning.

## Test plan

- [x] `make -n markdownlint` on macOS with both docker and podman installed no longer emits `Neither docker nor podman can be executed`.
- [x] `make -n markdownlint DOCKER_COMMAND=podman` (user-provided) no longer emits the warning.
- [ ] `PATH=/non-existent make -n markdownlint` (neither binary on PATH) still emits the warning, matching the original intent.
