### PR TITLE
Update script should consider links outside `specification` directory

### DIFF
--- a/.github/scripts/update-spec-repo-links.sh
+++ b/.github/scripts/update-spec-repo-links.sh
@@ -19,7 +19,7 @@ fix_file() {
   # Uses a negative lookahead to skip URLs pointing to semantic_conventions/
   # paths that were moved from the spec repo and no longer exist in newer versions.
   perl -pi -e "
-    s,\Q${SPECIFICATION_URL_PREFIX}\Ev1\.\d+\.\d+(?=/specification/(?!.*/semantic_conventions/)),${SPECIFICATION_URL_PREFIX}${LATEST_SPECIFICATION_VERSION},g;
+    s,\Q${SPECIFICATION_URL_PREFIX}\Ev1\.\d+\.\d+(?!.*/semantic_conventions/),${SPECIFICATION_URL_PREFIX}${LATEST_SPECIFICATION_VERSION},g;
     s,\Q${SPECIFICATION_BADGE_PREFIX}\Ev1\.\d+\.\d+,${SPECIFICATION_BADGE_PREFIX}${LATEST_SPECIFICATION_VERSION},g;
     s,\Q${SPECIFICATION_BADGE_RELEASE_TAG_PREFIX}\Ev1\.\d+\.\d+,${SPECIFICATION_BADGE_RELEASE_TAG_PREFIX}${LATEST_SPECIFICATION_VERSION},g;
   " "$1"


### PR DESCRIPTION
## Changes

The `update-spec-repo-links.sh` script was missing some URLs when updating the OTel specification version in the last run (https://github.com/open-telemetry/semantic-conventions/pull/3638). URLs whose path after the version didn't start with `/specification/` (e.g. /spec-compliance-matrix.md, /oteps/...) were skipped.

IIUC, the goal was to not update links back when semconv was inside the specification repo, where the URLs looked like `specification/trace/semantic_conventions/...` but only that and not other things like oteps which are still correct and exist there.

I simply removed the positive lookahead from the regex, but kept still the `semantic_conventions` negative one. I ran the script and now all files are updated and the olds that point to spec version `1.20.0` are still intact.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

AI helped me with the regex :D 

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
