### PR TITLE
promote telemetry.distro.{name,version} to stable

### DIFF
--- a/.chloggen/telemetry-distro-stable.yaml
+++ b/.chloggen/telemetry-distro-stable.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: telemetry
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote `telemetry.distro.name` and `telemetry.distro.version` attributes to 'stable'.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `telemetry.distro.name` and `telemetry.distro.version` attributes and the `telemetry.distro` entity are promoted from development to stable.

--- a/.chloggen/telemetry-distro-stable.yaml
+++ b/.chloggen/telemetry-distro-stable.yaml
@@ -14,7 +14,7 @@ note: Promote `telemetry.distro.name` and `telemetry.distro.version` attributes 
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.
-issues: []
+issues: [3650]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/docs/registry/attributes/telemetry.md
+++ b/docs/registry/attributes/telemetry.md
@@ -11,8 +11,8 @@ This document defines attributes for telemetry SDK.
 
 | Key | Stability | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- |
-| <a id="telemetry-distro-name" href="#telemetry-distro-name">`telemetry.distro.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the auto instrumentation agent or distribution, if used. [1] | `parts-unlimited-java` |
-| <a id="telemetry-distro-version" href="#telemetry-distro-version">`telemetry.distro.version`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The version string of the auto instrumentation agent or distribution, if used. | `1.2.3` |
+| <a id="telemetry-distro-name" href="#telemetry-distro-name">`telemetry.distro.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The name of the auto instrumentation agent or distribution, if used. [1] | `parts-unlimited-java` |
+| <a id="telemetry-distro-version" href="#telemetry-distro-version">`telemetry.distro.version`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The version string of the auto instrumentation agent or distribution, if used. | `1.2.3` |
 | <a id="telemetry-sdk-language" href="#telemetry-sdk-language">`telemetry.sdk.language`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The language of the telemetry SDK. | `cpp`; `dotnet`; `erlang` |
 | <a id="telemetry-sdk-name" href="#telemetry-sdk-name">`telemetry.sdk.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The name of the telemetry SDK as defined above. [2] | `opentelemetry` |
 | <a id="telemetry-sdk-version" href="#telemetry-sdk-version">`telemetry.sdk.version`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The version string of the telemetry SDK. | `1.2.3` |

--- a/docs/registry/entities/README.md
+++ b/docs/registry/entities/README.md
@@ -96,7 +96,7 @@ Currently, the following namespaces exist:
 | | [service.instance](service.md#service-instance) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | | [service.namespace](service.md#service-namespace) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | Telemetry | | |
-| | [telemetry.distro](telemetry.md#telemetry-distro) | ![Development](https://img.shields.io/badge/-development-blue) |
+| | [telemetry.distro](telemetry.md#telemetry-distro) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | | [telemetry.sdk](telemetry.md#telemetry-sdk) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | VCS | | |
 | | [vcs.ref](vcs.md#vcs-ref) | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/registry/entities/telemetry.md
+++ b/docs/registry/entities/telemetry.md
@@ -5,22 +5,18 @@
 
 ## Telemetry Distro
 
-**Status:** ![Development](https://img.shields.io/badge/-development-blue)
+**Status:** ![Stable](https://img.shields.io/badge/-stable-lightgreen)
 
 **type:** `telemetry.distro`
 
 **Description:** The distribution of telemetry SDK used to capture data recorded by the instrumentation libraries.
 
-> [!warning]
-> This entity definition contains attributes without a role.
-> Stable Entities MUST NOT have attributes without a defined role.
-
 **Attributes:**
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- | --- |
-| Other | [`telemetry.distro.name`](/docs/registry/attributes/telemetry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the auto instrumentation agent or distribution, if used. [1] | `parts-unlimited-java` |
-| Other | [`telemetry.distro.version`](/docs/registry/attributes/telemetry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The version string of the auto instrumentation agent or distribution, if used. | `1.2.3` |
+| Identity | [`telemetry.distro.name`](/docs/registry/attributes/telemetry.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the auto instrumentation agent or distribution, if used. [1] | `parts-unlimited-java` |
+| Description | [`telemetry.distro.version`](/docs/registry/attributes/telemetry.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The version string of the auto instrumentation agent or distribution, if used. | `1.2.3` |
 
 **[1] `telemetry.distro.name`:** Official auto instrumentation agents and distributions SHOULD set the `telemetry.distro.name` attribute to
 a string starting with `opentelemetry-`, e.g. `opentelemetry-java-instrumentation`.

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -128,22 +128,18 @@ All custom identifiers SHOULD be stable across different versions of an implemen
 <!-- see templates/registry/markdown/snippet.md.j2 -->
 <!-- prettier-ignore-start -->
 
-**Status:** ![Development](https://img.shields.io/badge/-development-blue)
+**Status:** ![Stable](https://img.shields.io/badge/-stable-lightgreen)
 
 **type:** `telemetry.distro`
 
 **Description:** The distribution of telemetry SDK used to capture data recorded by the instrumentation libraries.
 
-> [!warning]
-> This entity definition contains attributes without a role.
-> Stable Entities MUST NOT have attributes without a defined role.
-
 **Attributes:**
 
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- | --- |
-| Other | [`telemetry.distro.name`](/docs/registry/attributes/telemetry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the auto instrumentation agent or distribution, if used. [1] | `parts-unlimited-java` |
-| Other | [`telemetry.distro.version`](/docs/registry/attributes/telemetry.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The version string of the auto instrumentation agent or distribution, if used. | `1.2.3` |
+| Identity | [`telemetry.distro.name`](/docs/registry/attributes/telemetry.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the auto instrumentation agent or distribution, if used. [1] | `parts-unlimited-java` |
+| Description | [`telemetry.distro.version`](/docs/registry/attributes/telemetry.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The version string of the auto instrumentation agent or distribution, if used. | `1.2.3` |
 
 **[1] `telemetry.distro.name`:** Official auto instrumentation agents and distributions SHOULD set the `telemetry.distro.name` attribute to
 a string starting with `opentelemetry-`, e.g. `opentelemetry-java-instrumentation`.

--- a/model/telemetry/entities.yaml
+++ b/model/telemetry/entities.yaml
@@ -18,11 +18,13 @@ groups:
   - id: entity.telemetry.distro
     name: 'telemetry.distro'
     type: entity
-    stability: development
+    stability: stable
     brief: >
       The distribution of telemetry SDK used to capture data recorded by the instrumentation libraries.
     attributes:
       - ref: telemetry.distro.name
         requirement_level: recommended
+        role: identifying
       - ref: telemetry.distro.version
         requirement_level: recommended
+        role: descriptive

--- a/model/telemetry/registry.yaml
+++ b/model/telemetry/registry.yaml
@@ -68,7 +68,7 @@ groups:
         examples: ["1.2.3"]
       - id: telemetry.distro.name
         type: string
-        stability: development
+        stability: stable
         brief: >
           The name of the auto instrumentation agent or distribution, if used.
         note: |
@@ -77,7 +77,7 @@ groups:
         examples: ["parts-unlimited-java"]
       - id: telemetry.distro.version
         type: string
-        stability: development
+        stability: stable
         brief: >
           The version string of the auto instrumentation agent or distribution, if used.
         examples: ["1.2.3"]


### PR DESCRIPTION
The `telemetry.distro.name` and `telemetry.distro.version` should be ready to be promoted to 'stable'
- they have been introduced (through a rename) about 2.5 years ago with https://github.com/open-telemetry/semantic-conventions/pull/178
- they are widely used, so changing them would imply lots of breaking changes, just a few examples:
  - [open-telemetry/opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/f50f0580ef5d9763da03d8753801d0004258c940/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/resources/DistroResourceProvider.java#L8)
  - [elastic/elastic-otel-java](https://github.com/elastic/elastic-otel-java/blob/108dbd636d74463f9e72aed24e24e90f82dd8446/custom/src/main/java/co/elastic/otel/ElasticDistroResource.java#L43)
  - [elastic/elastic-otel-php](https://github.com/elastic/elastic-otel-php/blob/f165d11d72ea9176eaed4143166d80cb5c9fca51/prod/php/ElasticOTel/OverrideOTelSdkResourceAttributes.php#L55)
  - [elastic/elastic-otel-dotnet](https://github.com/elastic/elastic-otel-dotnet/blob/db7b7031b1ea655af9c9f8c3cb402ee141ca7e09/src/Elastic.OpenTelemetry.Core/SemanticConventions/ResourceSemanticConventions.cs#L8)
  - [elastic/elastic-otel-rum-js](https://github.com/elastic/elastic-otel-rum-js/blob/30adcd592f7754f2eb770a0ce11f553de4fcdcac/packages/opentelemetry-browser/lib/detector.js#L74)
  - [elastic/elastic-otel-node](https://github.com/elastic/elastic-otel-node/blob/edc15203dd8c819b7724132b1e0ecd295e335c75/packages/opentelemetry-node/lib/detectors.js#L52)
  - [signalfx/splunk-otel-java](https://github.com/signalfx/splunk-otel-java/blob/fd5b0749cff65bd781b39ecf0c7ac4d27c722dc9/custom/src/main/java/com/splunk/opentelemetry/resource/SplunkDistroVersionResourceFactory.java#L19)
  - [alibaba/loongsuite-java-agent](https://github.com/alibaba/loongsuite-java-agent/blob/d9abdbbab6f1d00b53faa6d77ebea4a0df16891e/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/DistroVersionResourceProvider.java#L9)
  - [open-telemetry/opentelemetry-dotnet-instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/4b6ba3913a9af919a7ee3373429aa86d18dc2dbc/src/OpenTelemetry.AutoInstrumentation/Constants.cs#L10)
  - [signalfx/splunk-otel-js](https://github.com/signalfx/splunk-otel-js/blob/cc6e08fd25932c2ba92238ebecf75eb18310b317/src/detectors/DistroDetector.ts#L27)
  - [signalfx/splunk-otel-go](https://github.com/signalfx/splunk-otel-go/blob/404e13e21c12e11940bb5d59d955a9591bd59b29/distro/otel.go#L36)
  - [signalfx/splunk-otel-python](https://github.com/signalfx/splunk-otel-python/blob/e477a7c0b7290d215d422c38182f99f4e00175ff/src/splunk_otel/distro.py#L102)
  - [signalfx/splunk-otel-dotnet](https://github.com/signalfx/splunk-otel-dotnet/blob/eb9554b107958064c321dc5fac6f76fb54ff276e/src/Splunk.OpenTelemetry.AutoInstrumentation/ResourceConfigurator.cs#L29)
  - [grafana/faro-web-sdk](https://github.com/grafana/faro-web-sdk/blob/0dcca81629cfc20cb18c6a7306209dceccdc75c8/packages/web-tracing/src/semconv.ts#L19)
  - [grafana/grafana-opentelemetry-dotnet](https://github.com/grafana/grafana-opentelemetry-dotnet/blob/001641628af16026a284015a099bfe2ed3257d15/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs#L14)
  - [grafana/grafana-opentelemetry-java](https://github.com/grafana/grafana-opentelemetry-java/blob/4c0557d1785ac459b92d4875371d0eed16bd265a/custom/src/main/java/com/grafana/extensions/resources/DistributionResource.java#L15)
  - [grafana/opentelemetry-rust](https://github.com/grafana/opentelemetry-rust/blob/0e3511ee92f4e9d02eadd529b191ee7a33f6afe9/opentelemetry-semantic-conventions/src/attribute.rs#L7905)
  - [grafana/grafana-opentelemetry-dotnet](https://github.com/grafana/grafana-opentelemetry-dotnet/blob/001641628af16026a284015a099bfe2ed3257d15/docker/docker-compose-aspnetcore/oats.yaml#L37)
