### PR TITLE
Update weaver to 0.23.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "editor.rulers": [80],
     "yaml.schemas": {
-        "https://raw.githubusercontent.com/open-telemetry/weaver/v0.17.0/schemas/semconv.schema.json": [
+        "https://raw.githubusercontent.com/open-telemetry/weaver/v0.23.0/schemas/semconv.schema.json": [
             "model/**/*.yaml"
         ],
         "./sigs-schema.json": [

--- a/dependencies.Dockerfile
+++ b/dependencies.Dockerfile
@@ -3,7 +3,7 @@
 # Dependabot can keep this file up to date with latest containers.
 
 # Weaver is used to generate markdown docs, and enforce policies on the model.
-FROM otel/weaver:v0.22.1@sha256:33ae522ae4b71c1c562563c1d81f46aa0f79f088a0873199143a1f11ac30e5c9 AS weaver
+FROM otel/weaver:v0.23.0@sha256:7984ecb55b859eb3034ae9d836c4eeda137e2bdd0873b7ba2bb6c3d24d6ff457 AS weaver
 
 # OPA is used to test policies enforced by weaver.
 FROM openpolicyagent/opa:1.15.2@sha256:4750afa83e85a1b0a4964ea5700e9caa1c1e61b508435e09fd77f038747340e6 AS opa

--- a/policies/attribute_name_collisions.rego
+++ b/policies/attribute_name_collisions.rego
@@ -79,14 +79,3 @@ to_namespace_prefix(name) = namespace if {
     namespace := concat("", [name, "."])
 }
 
-to_const_name(name) = const_name if {
-    const_name := replace(name, ".", "_")
-}
-
-is_property_set(obj, property) = true if {
-    obj[property] != null
-} else = false
-
-property_or_null(obj, property) := obj[property] if {
-    obj[property]
-} else = null

--- a/policies/helpers.rego
+++ b/policies/helpers.rego
@@ -1,0 +1,15 @@
+package after_resolution
+
+import rego.v1
+
+to_const_name(name) = const_name if {
+    const_name := replace(name, ".", "_")
+}
+
+is_property_set(obj, property) = true if {
+    obj[property] != null
+} else = false
+
+property_or_null(obj, property) := obj[property] if {
+    obj[property]
+} else = null

--- a/policies/metrics_collisions.rego
+++ b/policies/metrics_collisions.rego
@@ -55,6 +55,3 @@ extract_metric_namespace_prefix(name) = namespace if {
     namespace := concat("", [name, "."])
 }
 
-is_property_set(obj, property) = true if {
-    obj[property] != null
-} else = false

--- a/policies/registry.rego
+++ b/policies/registry.rego
@@ -148,10 +148,3 @@ get_attribute_name(attr, group) := name if {
     name := trim(full_name, ".")
 }
 
-to_const_name(name) = const_name if {
-    const_name := replace(name, ".", "_")
-}
-
-is_property_set(obj, property) = true if {
-    obj[property] != null
-} else = false


### PR DESCRIPTION
replaces https://github.com/open-telemetry/semantic-conventions/pull/3649.
New rego lib weaver uses doesn't like functions with the same name and package in different files, separating common functions to helper file.