### PR TITLE
Revert "Better downstream registry support"

### DIFF
--- a/templates/registry/markdown/registry_readme.md.j2
+++ b/templates/registry/markdown/registry_readme.md.j2
@@ -7,9 +7,5 @@ weight: -2
 This is an automatically generated registry of available semantic conventions.
 
 - [Attributes](attributes/README.md)
-{#- Only emit the Entities link when the registry actually defines entity
-    groups. Downstream registries that reuse this template may have no entities. #}
-{% if ctx.groups | selectattr("type", "equalto", "entity") | list | length > 0 -%}
 - [Entities](entities/README.md)
-{% endif -%}
 


### PR DESCRIPTION
Reverts open-telemetry/semantic-conventions#3654

Proposing to revert my PR because I realized the real solution is using (and updating where needed) the opentelemetry-weaver-packages 😅.