### PR TITLE
Mark service.criticality attribute as alpha

### DIFF
--- a/.chloggen/alpha-service-criticality.yaml
+++ b/.chloggen/alpha-service-criticality.yaml
@@ -1,7 +1,7 @@
 change_type: "enhancement"
 component: "service"
-note: "Stabilize `service.criticality` attribute."
+note: "Mark `service.criticality` attribute as alpha."
 issues: [2986]
 subtext: |
   The `service.criticality` attribute and its allowed values (`critical`, `high`, `medium`, `low`)
-  are now stable.
+  are now in alpha status.

--- a/.chloggen/stabilize-service-criticality.yaml
+++ b/.chloggen/stabilize-service-criticality.yaml
@@ -1,0 +1,7 @@
+change_type: "enhancement"
+component: "service"
+note: "Stabilize `service.criticality` attribute."
+issues: [2986]
+subtext: |
+  The `service.criticality` attribute and its allowed values (`critical`, `high`, `medium`, `low`)
+  are now stable.

--- a/docs/registry/attributes/service.md
+++ b/docs/registry/attributes/service.md
@@ -14,7 +14,7 @@ A service instance.
 
 | Key | Stability | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- |
-| <a id="service-criticality" href="#service-criticality">`service.criticality`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The operational criticality of the service. [1] | `critical`; `high`; `medium`; `low` |
+| <a id="service-criticality" href="#service-criticality">`service.criticality`</a> | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) | string | The operational criticality of the service. [1] | `critical`; `high`; `medium`; `low` |
 | <a id="service-instance-id" href="#service-instance-id">`service.instance.id`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The string ID of the service instance. [2] | `627cc493-f310-47de-96bd-71410b7dec09` |
 | <a id="service-name" href="#service-name">`service.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | Logical name of the service. [3] | `shoppingcart` |
 | <a id="service-namespace" href="#service-namespace">`service.namespace`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | A namespace for `service.name`. [4] | `Shop` |
@@ -60,10 +60,10 @@ The process executable name is the name of the process executable, the same valu
 
 | Value | Description | Stability |
 | --- | --- | --- |
-| `critical` | Service is business-critical; downtime directly impacts revenue, user experience, or core functionality. [5] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `high` | Service is important but has degradation tolerance or fallback mechanisms. [6] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `low` | Service is non-essential to core operations; used for background tasks or internal tools. [7] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `medium` | Service provides supplementary functionality; degradation has limited user impact. [8] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `critical` | Service is business-critical; downtime directly impacts revenue, user experience, or core functionality. [5] | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) |
+| `high` | Service is important but has degradation tolerance or fallback mechanisms. [6] | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) |
+| `low` | Service is non-essential to core operations; used for background tasks or internal tools. [7] | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) |
+| `medium` | Service provides supplementary functionality; degradation has limited user impact. [8] | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) |
 
 **[5]:** Examples include payment processing, authentication, and primary user-facing APIs.
 

--- a/docs/registry/attributes/service.md
+++ b/docs/registry/attributes/service.md
@@ -14,7 +14,7 @@ A service instance.
 
 | Key | Stability | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- |
-| <a id="service-criticality" href="#service-criticality">`service.criticality`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The operational criticality of the service. [1] | `critical`; `high`; `medium`; `low` |
+| <a id="service-criticality" href="#service-criticality">`service.criticality`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The operational criticality of the service. [1] | `critical`; `high`; `medium`; `low` |
 | <a id="service-instance-id" href="#service-instance-id">`service.instance.id`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The string ID of the service instance. [2] | `627cc493-f310-47de-96bd-71410b7dec09` |
 | <a id="service-name" href="#service-name">`service.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | Logical name of the service. [3] | `shoppingcart` |
 | <a id="service-namespace" href="#service-namespace">`service.namespace`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | A namespace for `service.name`. [4] | `Shop` |
@@ -60,10 +60,10 @@ The process executable name is the name of the process executable, the same valu
 
 | Value | Description | Stability |
 | --- | --- | --- |
-| `critical` | Service is business-critical; downtime directly impacts revenue, user experience, or core functionality. [5] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `high` | Service is important but has degradation tolerance or fallback mechanisms. [6] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `low` | Service is non-essential to core operations; used for background tasks or internal tools. [7] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `medium` | Service provides supplementary functionality; degradation has limited user impact. [8] | ![Development](https://img.shields.io/badge/-development-blue) |
+| `critical` | Service is business-critical; downtime directly impacts revenue, user experience, or core functionality. [5] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `high` | Service is important but has degradation tolerance or fallback mechanisms. [6] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `low` | Service is non-essential to core operations; used for background tasks or internal tools. [7] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `medium` | Service provides supplementary functionality; degradation has limited user impact. [8] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 **[5]:** Examples include payment processing, authentication, and primary user-facing APIs.
 

--- a/docs/registry/entities/service.md
+++ b/docs/registry/entities/service.md
@@ -16,7 +16,7 @@
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`service.name`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Required` | string | Logical name of the service. [1] | `shoppingcart` |
-| Description | [`service.criticality`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The operational criticality of the service. [2] | `critical`; `high`; `medium`; `low` |
+| Description | [`service.criticality`](/docs/registry/attributes/service.md) | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) | `Recommended` | string | The operational criticality of the service. [2] | `critical`; `high`; `medium`; `low` |
 | Description | [`service.version`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The version string of the service component. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` |
 
 **[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with the process executable name, e.g. `unknown_service:bash`. If the process executable name is not available, the value MUST be set to `unknown_service`.
@@ -30,10 +30,10 @@ The process executable name is the name of the process executable, the same valu
 
 | Value | Description | Stability |
 | --- | --- | --- |
-| `critical` | Service is business-critical; downtime directly impacts revenue, user experience, or core functionality. [3] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `high` | Service is important but has degradation tolerance or fallback mechanisms. [4] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `low` | Service is non-essential to core operations; used for background tasks or internal tools. [5] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `medium` | Service provides supplementary functionality; degradation has limited user impact. [6] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `critical` | Service is business-critical; downtime directly impacts revenue, user experience, or core functionality. [3] | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) |
+| `high` | Service is important but has degradation tolerance or fallback mechanisms. [4] | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) |
+| `low` | Service is non-essential to core operations; used for background tasks or internal tools. [5] | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) |
+| `medium` | Service provides supplementary functionality; degradation has limited user impact. [6] | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) |
 
 **[3]:** Examples include payment processing, authentication, and primary user-facing APIs.
 

--- a/docs/registry/entities/service.md
+++ b/docs/registry/entities/service.md
@@ -16,7 +16,7 @@
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`service.name`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Required` | string | Logical name of the service. [1] | `shoppingcart` |
-| Description | [`service.criticality`](/docs/registry/attributes/service.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The operational criticality of the service. [2] | `critical`; `high`; `medium`; `low` |
+| Description | [`service.criticality`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The operational criticality of the service. [2] | `critical`; `high`; `medium`; `low` |
 | Description | [`service.version`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The version string of the service component. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` |
 
 **[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with the process executable name, e.g. `unknown_service:bash`. If the process executable name is not available, the value MUST be set to `unknown_service`.
@@ -30,10 +30,10 @@ The process executable name is the name of the process executable, the same valu
 
 | Value | Description | Stability |
 | --- | --- | --- |
-| `critical` | Service is business-critical; downtime directly impacts revenue, user experience, or core functionality. [3] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `high` | Service is important but has degradation tolerance or fallback mechanisms. [4] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `low` | Service is non-essential to core operations; used for background tasks or internal tools. [5] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `medium` | Service provides supplementary functionality; degradation has limited user impact. [6] | ![Development](https://img.shields.io/badge/-development-blue) |
+| `critical` | Service is business-critical; downtime directly impacts revenue, user experience, or core functionality. [3] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `high` | Service is important but has degradation tolerance or fallback mechanisms. [4] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `low` | Service is non-essential to core operations; used for background tasks or internal tools. [5] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `medium` | Service provides supplementary functionality; degradation has limited user impact. [6] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 **[3]:** Examples include payment processing, authentication, and primary user-facing APIs.
 

--- a/docs/resource/service.md
+++ b/docs/resource/service.md
@@ -63,7 +63,7 @@ between them. Additionally, there's a single database instance.
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`service.name`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Required` | string | Logical name of the service. [1] | `shoppingcart` |
-| Description | [`service.criticality`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The operational criticality of the service. [2] | `critical`; `high`; `medium`; `low` |
+| Description | [`service.criticality`](/docs/registry/attributes/service.md) | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) | `Recommended` | string | The operational criticality of the service. [2] | `critical`; `high`; `medium`; `low` |
 | Description | [`service.version`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The version string of the service component. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` |
 
 **[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with the process executable name, e.g. `unknown_service:bash`. If the process executable name is not available, the value MUST be set to `unknown_service`.
@@ -77,10 +77,10 @@ The process executable name is the name of the process executable, the same valu
 
 | Value | Description | Stability |
 | --- | --- | --- |
-| `critical` | Service is business-critical; downtime directly impacts revenue, user experience, or core functionality. [3] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `high` | Service is important but has degradation tolerance or fallback mechanisms. [4] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `low` | Service is non-essential to core operations; used for background tasks or internal tools. [5] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
-| `medium` | Service provides supplementary functionality; degradation has limited user impact. [6] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `critical` | Service is business-critical; downtime directly impacts revenue, user experience, or core functionality. [3] | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) |
+| `high` | Service is important but has degradation tolerance or fallback mechanisms. [4] | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) |
+| `low` | Service is non-essential to core operations; used for background tasks or internal tools. [5] | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) |
+| `medium` | Service provides supplementary functionality; degradation has limited user impact. [6] | ![Alpha](https://img.shields.io/badge/alpha-mediumpurple) |
 
 **[3]:** Examples include payment processing, authentication, and primary user-facing APIs.
 

--- a/docs/resource/service.md
+++ b/docs/resource/service.md
@@ -63,7 +63,7 @@ between them. Additionally, there's a single database instance.
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`service.name`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Required` | string | Logical name of the service. [1] | `shoppingcart` |
-| Description | [`service.criticality`](/docs/registry/attributes/service.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The operational criticality of the service. [2] | `critical`; `high`; `medium`; `low` |
+| Description | [`service.criticality`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The operational criticality of the service. [2] | `critical`; `high`; `medium`; `low` |
 | Description | [`service.version`](/docs/registry/attributes/service.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The version string of the service component. The format is not defined by these conventions. | `2.0.0`; `a01dbef8a` |
 
 **[1] `service.name`:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with the process executable name, e.g. `unknown_service:bash`. If the process executable name is not available, the value MUST be set to `unknown_service`.
@@ -77,10 +77,10 @@ The process executable name is the name of the process executable, the same valu
 
 | Value | Description | Stability |
 | --- | --- | --- |
-| `critical` | Service is business-critical; downtime directly impacts revenue, user experience, or core functionality. [3] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `high` | Service is important but has degradation tolerance or fallback mechanisms. [4] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `low` | Service is non-essential to core operations; used for background tasks or internal tools. [5] | ![Development](https://img.shields.io/badge/-development-blue) |
-| `medium` | Service provides supplementary functionality; degradation has limited user impact. [6] | ![Development](https://img.shields.io/badge/-development-blue) |
+| `critical` | Service is business-critical; downtime directly impacts revenue, user experience, or core functionality. [3] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `high` | Service is important but has degradation tolerance or fallback mechanisms. [4] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `low` | Service is non-essential to core operations; used for background tasks or internal tools. [5] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `medium` | Service provides supplementary functionality; degradation has limited user impact. [6] | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 
 **[3]:** Examples include payment processing, authentication, and primary user-facing APIs.
 

--- a/model/service/registry.yaml
+++ b/model/service/registry.yaml
@@ -81,29 +81,29 @@ groups:
                 Service is business-critical; downtime directly impacts revenue, user experience, or core functionality.
               note: >
                 Examples include payment processing, authentication, and primary user-facing APIs.
-              stability: stable
+              stability: alpha
             - id: high
               value: 'high'
               brief: >
                 Service is important but has degradation tolerance or fallback mechanisms.
               note: >
                 Examples include shopping cart, search, and recommendation engines.
-              stability: stable
+              stability: alpha
             - id: medium
               value: 'medium'
               brief: >
                 Service provides supplementary functionality; degradation has limited user impact.
               note: >
                 Examples include analytics, reporting, and non-essential integrations.
-              stability: stable
+              stability: alpha
             - id: low
               value: 'low'
               brief: >
                 Service is non-essential to core operations; used for background tasks or internal tools.
               note: >
                 Examples include batch processors, cleanup jobs, and internal dashboards.
-              stability: stable
-        stability: stable
+              stability: alpha
+        stability: alpha
         brief: >
           The operational criticality of the service.
         note: >

--- a/model/service/registry.yaml
+++ b/model/service/registry.yaml
@@ -81,29 +81,29 @@ groups:
                 Service is business-critical; downtime directly impacts revenue, user experience, or core functionality.
               note: >
                 Examples include payment processing, authentication, and primary user-facing APIs.
-              stability: development
+              stability: stable
             - id: high
               value: 'high'
               brief: >
                 Service is important but has degradation tolerance or fallback mechanisms.
               note: >
                 Examples include shopping cart, search, and recommendation engines.
-              stability: development
+              stability: stable
             - id: medium
               value: 'medium'
               brief: >
                 Service provides supplementary functionality; degradation has limited user impact.
               note: >
                 Examples include analytics, reporting, and non-essential integrations.
-              stability: development
+              stability: stable
             - id: low
               value: 'low'
               brief: >
                 Service is non-essential to core operations; used for background tasks or internal tools.
               note: >
                 Examples include batch processors, cleanup jobs, and internal dashboards.
-              stability: development
-        stability: development
+              stability: stable
+        stability: stable
         brief: >
           The operational criticality of the service.
         note: >


### PR DESCRIPTION
Fixes #3726 

## Changes

- Updated service.criticality and its well-known values to stability: alpha in the registry.
- Regenerated documentation to show the Alpha badge for these attributes.
- Updated the changelog entry to reflect the alpha status.


> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
