### PR TITLE
Reserve `already_shutdown` as error.type value for SDK processor processed metrics

### DIFF
--- a/.chloggen/sdk-processor-error-type-closed-set.yaml
+++ b/.chloggen/sdk-processor-error-type-closed-set.yaml
@@ -2,7 +2,7 @@ change_type: enhancement
 
 component: otel
 
-note: Clarify that `error.type` for the `otel.sdk.processor.span.processed` and `otel.sdk.processor.log.processed` metrics is a closed set defined by the SDK specification, currently containing only `queue_full`.
+note: Reserve `already_shutdown` as a value for `error.type` on the `otel.sdk.processor.span.processed` and `otel.sdk.processor.log.processed` metrics, used when a processor drops items because it has already been shut down.
 
 issues: [3710]
 

--- a/.chloggen/sdk-processor-error-type-closed-set.yaml
+++ b/.chloggen/sdk-processor-error-type-closed-set.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: otel
+
+note: Clarify that `error.type` for the `otel.sdk.processor.span.processed` and `otel.sdk.processor.log.processed` metrics is a closed set defined by the SDK specification, currently containing only `queue_full`.
+
+issues: []
+
+subtext:

--- a/.chloggen/sdk-processor-error-type-closed-set.yaml
+++ b/.chloggen/sdk-processor-error-type-closed-set.yaml
@@ -4,6 +4,6 @@ component: otel
 
 note: Clarify that `error.type` for the `otel.sdk.processor.span.processed` and `otel.sdk.processor.log.processed` metrics is a closed set defined by the SDK specification, currently containing only `queue_full`.
 
-issues: []
+issues: [3710]
 
 subtext:

--- a/.chloggen/sdk-processor-error-type-closed-set.yaml
+++ b/.chloggen/sdk-processor-error-type-closed-set.yaml
@@ -2,7 +2,10 @@ change_type: enhancement
 
 component: otel
 
-note: Reserve `already_shutdown` as a value for `error.type` on the `otel.sdk.processor.span.processed` and `otel.sdk.processor.log.processed` metrics, used when a processor drops items because it has already been shut down.
+note: >
+  Reserve `already_shutdown` as a value for `error.type` on the
+  `otel.sdk.processor.span.processed` and `otel.sdk.processor.log.processed`
+  metrics, used when a processor drops items because it has already been shut down.
 
 issues: [3710]
 

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -261,17 +261,43 @@ This metric is [recommended][MetricRecommended].
 | `otel.sdk.processor.span.processed` | Counter | `{span}` | The number of spans for which the processing has finished, either successful or failed. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
 
 **[1]:** For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
+SDK Batching Span Processors MUST use `queue_full` as the value of `error.type` for spans dropped due to a full queue.
+SDK Span Processors MUST use `already_shutdown` as the value of `error.type` for spans dropped because the processor has already been shut down.
 For the SDK Simple and Batching Span Processor a span is considered to be processed already when it has been submitted to the exporter, not when the corresponding export call has finished.
 
 **Attributes:**
 
 | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- |
-| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | A low-cardinality description of the failure reason. [1] | `queue_full`; `already_shutdown` |
+| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | Describes a class of error the operation ended with. [1] | `queue_full`; `already_shutdown` |
 | [`otel.component.name`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name uniquely identifying the instance of the OpenTelemetry component within its containing SDK instance. [2] | `otlp_grpc_span_exporter/0`; `custom-name` |
 | [`otel.component.type`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name identifying the type of the OpenTelemetry component. [3] | `batching_span_processor`; `com.example.MySpanExporter` |
 
-**[1] `error.type`:** SDK Batching Span Processors MUST use `queue_full` for spans dropped due to a full queue. SDK Span Processors MUST use `already_shutdown` for spans dropped because the processor has already been shut down.
+**[1] `error.type`:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
+
+When `error.type` is set to a type (e.g., an exception type), its
+canonical class name identifying the type within the artifact SHOULD be used.
+
+If the recorded error type is a wrapper that is not meaningful for
+failure classification, instrumentation MAY use the type of the inner
+error instead. For example, in Go, errors created with `fmt.Errorf`
+using `%w` MAY be unwrapped when the wrapper type does not help
+classify the failure.
+
+Instrumentations SHOULD document the list of errors they report.
+
+The cardinality of `error.type` within one instrumentation library SHOULD be low.
+Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+should be prepared for `error.type` to have high cardinality at query time when no
+additional filters are applied.
+
+If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+
+If a specific domain defines its own set of error identifiers (such as HTTP or RPC status codes),
+it's RECOMMENDED to:
+
+- Use a domain-specific attribute
+- Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
 
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
@@ -671,6 +697,8 @@ This metric is [recommended][MetricRecommended].
 | `otel.sdk.processor.log.processed` | Counter | `{log_record}` | The number of log records for which the processing has finished, either successful or failed. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
 
 **[1]:** For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
+SDK Batching Log Record Processors MUST use `queue_full` as the value of `error.type` for log records dropped due to a full queue.
+SDK Log Record Processors MUST use `already_shutdown` as the value of `error.type` for log records dropped because the processor has already been shut down.
 For the SDK Simple and Batching Log Record Processor a log record is considered to be processed already when it has been submitted to the exporter,
 not when the corresponding export call has finished.
 
@@ -678,11 +706,35 @@ not when the corresponding export call has finished.
 
 | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- |
-| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | A low-cardinality description of the failure reason. [1] | `queue_full`; `already_shutdown` |
+| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | Describes a class of error the operation ended with. [1] | `queue_full`; `already_shutdown` |
 | [`otel.component.name`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name uniquely identifying the instance of the OpenTelemetry component within its containing SDK instance. [2] | `otlp_grpc_span_exporter/0`; `custom-name` |
 | [`otel.component.type`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name identifying the type of the OpenTelemetry component. [3] | `batching_span_processor`; `com.example.MySpanExporter` |
 
-**[1] `error.type`:** SDK Batching Log Record Processors MUST use `queue_full` for log records dropped due to a full queue. SDK Log Record Processors MUST use `already_shutdown` for log records dropped because the processor has already been shut down.
+**[1] `error.type`:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
+
+When `error.type` is set to a type (e.g., an exception type), its
+canonical class name identifying the type within the artifact SHOULD be used.
+
+If the recorded error type is a wrapper that is not meaningful for
+failure classification, instrumentation MAY use the type of the inner
+error instead. For example, in Go, errors created with `fmt.Errorf`
+using `%w` MAY be unwrapped when the wrapper type does not help
+classify the failure.
+
+Instrumentations SHOULD document the list of errors they report.
+
+The cardinality of `error.type` within one instrumentation library SHOULD be low.
+Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+should be prepared for `error.type` to have high cardinality at query time when no
+additional filters are applied.
+
+If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+
+If a specific domain defines its own set of error identifiers (such as HTTP or RPC status codes),
+it's RECOMMENDED to:
+
+- Use a domain-specific attribute
+- Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
 
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
@@ -1106,7 +1158,7 @@ E.g. for Java the fully qualified classname SHOULD be used in this case.
 
 This metric is [recommended][MetricRecommended].
 
-This metric SHOULD be specified with [`ExplicitBucketBoundaries` advisory parameter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.56.0/specification/metrics/api.md#instrument-advisory-parameters) with a single bucket with no boundaries.
+This metric SHOULD be specified with [`ExplicitBucketBoundaries` advisory parameter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.57.0/specification/metrics/api.md#instrument-advisory-parameters) with a single bucket with no boundaries.
 
 <!-- semconv metric.otel.sdk.metric_reader.collection.duration -->
 <!-- NOTE: THIS TEXT IS AUTOGENERATED. DO NOT EDIT BY HAND. -->
@@ -1210,7 +1262,7 @@ E.g. for Java the fully qualified classname SHOULD be used in this case.
 
 This metric is [recommended][MetricRecommended].
 
-This metric SHOULD be specified with [`ExplicitBucketBoundaries` advisory parameter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.56.0/specification/metrics/api.md#instrument-advisory-parameters) with a single bucket with no boundaries.
+This metric SHOULD be specified with [`ExplicitBucketBoundaries` advisory parameter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.57.0/specification/metrics/api.md#instrument-advisory-parameters) with a single bucket with no boundaries.
 
 <!-- semconv metric.otel.sdk.exporter.operation.duration -->
 <!-- NOTE: THIS TEXT IS AUTOGENERATED. DO NOT EDIT BY HAND. -->

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -269,7 +269,7 @@ For the SDK Simple and Batching Span Processor a span is considered to be proces
 
 | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- |
-| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | Describes a class of error the operation ended with. [1] | `queue_full`; `already_shutdown` |
+| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | A low-cardinality description of the failure reason. [1] | `queue_full`; `already_shutdown` |
 | [`otel.component.name`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name uniquely identifying the instance of the OpenTelemetry component within its containing SDK instance. [2] | `otlp_grpc_span_exporter/0`; `custom-name` |
 | [`otel.component.type`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name identifying the type of the OpenTelemetry component. [3] | `batching_span_processor`; `com.example.MySpanExporter` |
 
@@ -706,7 +706,7 @@ not when the corresponding export call has finished.
 
 | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- |
-| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | Describes a class of error the operation ended with. [1] | `queue_full`; `already_shutdown` |
+| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | A low-cardinality description of the failure reason. [1] | `queue_full`; `already_shutdown` |
 | [`otel.component.name`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name uniquely identifying the instance of the OpenTelemetry component within its containing SDK instance. [2] | `otlp_grpc_span_exporter/0`; `custom-name` |
 | [`otel.component.type`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name identifying the type of the OpenTelemetry component. [3] | `batching_span_processor`; `com.example.MySpanExporter` |
 

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -267,35 +267,11 @@ For the SDK Simple and Batching Span Processor a span is considered to be proces
 
 | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- |
-| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | A low-cardinality description of the failure reason. SDK Batching Span Processors MUST use `queue_full` for spans dropped due to a full queue. SDK Span Processors MUST use `already_shutdown` for spans dropped because the processor has already been shut down. [1] | `queue_full`; `already_shutdown` |
+| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | A low-cardinality description of the failure reason. [1] | `queue_full`; `already_shutdown` |
 | [`otel.component.name`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name uniquely identifying the instance of the OpenTelemetry component within its containing SDK instance. [2] | `otlp_grpc_span_exporter/0`; `custom-name` |
 | [`otel.component.type`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name identifying the type of the OpenTelemetry component. [3] | `batching_span_processor`; `com.example.MySpanExporter` |
 
-**[1] `error.type`:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
-
-When `error.type` is set to a type (e.g., an exception type), its
-canonical class name identifying the type within the artifact SHOULD be used.
-
-If the recorded error type is a wrapper that is not meaningful for
-failure classification, instrumentation MAY use the type of the inner
-error instead. For example, in Go, errors created with `fmt.Errorf`
-using `%w` MAY be unwrapped when the wrapper type does not help
-classify the failure.
-
-Instrumentations SHOULD document the list of errors they report.
-
-The cardinality of `error.type` within one instrumentation library SHOULD be low.
-Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-should be prepared for `error.type` to have high cardinality at query time when no
-additional filters are applied.
-
-If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
-
-If a specific domain defines its own set of error identifiers (such as HTTP or RPC status codes),
-it's RECOMMENDED to:
-
-- Use a domain-specific attribute
-- Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
+**[1] `error.type`:** SDK Batching Span Processors MUST use `queue_full` for spans dropped due to a full queue. SDK Span Processors MUST use `already_shutdown` for spans dropped because the processor has already been shut down.
 
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
@@ -702,35 +678,11 @@ not when the corresponding export call has finished.
 
 | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- |
-| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | A low-cardinality description of the failure reason. SDK Batching Log Record Processors MUST use `queue_full` for log records dropped due to a full queue. SDK Log Record Processors MUST use `already_shutdown` for log records dropped because the processor has already been shut down. [1] | `queue_full`; `already_shutdown` |
+| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | A low-cardinality description of the failure reason. [1] | `queue_full`; `already_shutdown` |
 | [`otel.component.name`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name uniquely identifying the instance of the OpenTelemetry component within its containing SDK instance. [2] | `otlp_grpc_span_exporter/0`; `custom-name` |
 | [`otel.component.type`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name identifying the type of the OpenTelemetry component. [3] | `batching_span_processor`; `com.example.MySpanExporter` |
 
-**[1] `error.type`:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
-
-When `error.type` is set to a type (e.g., an exception type), its
-canonical class name identifying the type within the artifact SHOULD be used.
-
-If the recorded error type is a wrapper that is not meaningful for
-failure classification, instrumentation MAY use the type of the inner
-error instead. For example, in Go, errors created with `fmt.Errorf`
-using `%w` MAY be unwrapped when the wrapper type does not help
-classify the failure.
-
-Instrumentations SHOULD document the list of errors they report.
-
-The cardinality of `error.type` within one instrumentation library SHOULD be low.
-Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-should be prepared for `error.type` to have high cardinality at query time when no
-additional filters are applied.
-
-If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
-
-If a specific domain defines its own set of error identifiers (such as HTTP or RPC status codes),
-it's RECOMMENDED to:
-
-- Use a domain-specific attribute
-- Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
+**[1] `error.type`:** SDK Batching Log Record Processors MUST use `queue_full` for log records dropped due to a full queue. SDK Log Record Processors MUST use `already_shutdown` for log records dropped because the processor has already been shut down.
 
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -271,31 +271,8 @@ For the SDK Simple and Batching Span Processor a span is considered to be proces
 | [`otel.component.name`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name uniquely identifying the instance of the OpenTelemetry component within its containing SDK instance. [2] | `otlp_grpc_span_exporter/0`; `custom-name` |
 | [`otel.component.type`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name identifying the type of the OpenTelemetry component. [3] | `batching_span_processor`; `com.example.MySpanExporter` |
 
-**[1] `error.type`:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
-
-When `error.type` is set to a type (e.g., an exception type), its
-canonical class name identifying the type within the artifact SHOULD be used.
-
-If the recorded error type is a wrapper that is not meaningful for
-failure classification, instrumentation MAY use the type of the inner
-error instead. For example, in Go, errors created with `fmt.Errorf`
-using `%w` MAY be unwrapped when the wrapper type does not help
-classify the failure.
-
-Instrumentations SHOULD document the list of errors they report.
-
-The cardinality of `error.type` within one instrumentation library SHOULD be low.
-Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-should be prepared for `error.type` to have high cardinality at query time when no
-additional filters are applied.
-
-If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
-
-If a specific domain defines its own set of error identifiers (such as HTTP or RPC status codes),
-it's RECOMMENDED to:
-
-- Use a domain-specific attribute
-- Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
+**[1] `error.type`:** The set of failure modes for SDK Span Processors is defined by the OpenTelemetry SDK specification and is intended to be closed: implementations SHOULD NOT introduce new `error.type` values for this metric outside of those defined by the specification.
+Currently, the only specification-defined value is `queue_full` (used by Batching Span Processors when spans are dropped because the queue is full). The well-known values listed below are inherited from the generic `error.type` attribute and are not all applicable to this metric.
 
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
@@ -706,31 +683,8 @@ not when the corresponding export call has finished.
 | [`otel.component.name`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name uniquely identifying the instance of the OpenTelemetry component within its containing SDK instance. [2] | `otlp_grpc_span_exporter/0`; `custom-name` |
 | [`otel.component.type`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name identifying the type of the OpenTelemetry component. [3] | `batching_span_processor`; `com.example.MySpanExporter` |
 
-**[1] `error.type`:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
-
-When `error.type` is set to a type (e.g., an exception type), its
-canonical class name identifying the type within the artifact SHOULD be used.
-
-If the recorded error type is a wrapper that is not meaningful for
-failure classification, instrumentation MAY use the type of the inner
-error instead. For example, in Go, errors created with `fmt.Errorf`
-using `%w` MAY be unwrapped when the wrapper type does not help
-classify the failure.
-
-Instrumentations SHOULD document the list of errors they report.
-
-The cardinality of `error.type` within one instrumentation library SHOULD be low.
-Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-should be prepared for `error.type` to have high cardinality at query time when no
-additional filters are applied.
-
-If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
-
-If a specific domain defines its own set of error identifiers (such as HTTP or RPC status codes),
-it's RECOMMENDED to:
-
-- Use a domain-specific attribute
-- Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
+**[1] `error.type`:** The set of failure modes for SDK Log Record Processors is defined by the OpenTelemetry SDK specification and is intended to be closed: implementations SHOULD NOT introduce new `error.type` values for this metric outside of those defined by the specification.
+Currently, the only specification-defined value is `queue_full` (used by Batching Log Record Processors when log records are dropped because the queue is full). The well-known values listed below are inherited from the generic `error.type` attribute and are not all applicable to this metric.
 
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -267,12 +267,35 @@ For the SDK Simple and Batching Span Processor a span is considered to be proces
 
 | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- |
-| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | A low-cardinality description of the failure reason. SDK Batching Span Processors MUST use `queue_full` for spans dropped due to a full queue. [1] | `queue_full` |
+| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | A low-cardinality description of the failure reason. SDK Batching Span Processors MUST use `queue_full` for spans dropped due to a full queue. SDK Span Processors MUST use `already_shutdown` for spans dropped because the processor has already been shut down. [1] | `queue_full`; `already_shutdown` |
 | [`otel.component.name`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name uniquely identifying the instance of the OpenTelemetry component within its containing SDK instance. [2] | `otlp_grpc_span_exporter/0`; `custom-name` |
 | [`otel.component.type`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name identifying the type of the OpenTelemetry component. [3] | `batching_span_processor`; `com.example.MySpanExporter` |
 
-**[1] `error.type`:** The set of failure modes for SDK Span Processors is defined by the OpenTelemetry SDK specification and is intended to be closed: implementations SHOULD NOT introduce new `error.type` values for this metric outside of those defined by the specification.
-Currently, the only specification-defined value is `queue_full` (used by Batching Span Processors when spans are dropped because the queue is full). The well-known values listed below are inherited from the generic `error.type` attribute and are not all applicable to this metric.
+**[1] `error.type`:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
+
+When `error.type` is set to a type (e.g., an exception type), its
+canonical class name identifying the type within the artifact SHOULD be used.
+
+If the recorded error type is a wrapper that is not meaningful for
+failure classification, instrumentation MAY use the type of the inner
+error instead. For example, in Go, errors created with `fmt.Errorf`
+using `%w` MAY be unwrapped when the wrapper type does not help
+classify the failure.
+
+Instrumentations SHOULD document the list of errors they report.
+
+The cardinality of `error.type` within one instrumentation library SHOULD be low.
+Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+should be prepared for `error.type` to have high cardinality at query time when no
+additional filters are applied.
+
+If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+
+If a specific domain defines its own set of error identifiers (such as HTTP or RPC status codes),
+it's RECOMMENDED to:
+
+- Use a domain-specific attribute
+- Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
 
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
@@ -679,12 +702,35 @@ not when the corresponding export call has finished.
 
 | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- |
-| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | A low-cardinality description of the failure reason. SDK Batching Log Record Processors MUST use `queue_full` for log records dropped due to a full queue. [1] | `queue_full` |
+| [`error.type`](/docs/registry/attributes/error.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | A low-cardinality description of the failure reason. SDK Batching Log Record Processors MUST use `queue_full` for log records dropped due to a full queue. SDK Log Record Processors MUST use `already_shutdown` for log records dropped because the processor has already been shut down. [1] | `queue_full`; `already_shutdown` |
 | [`otel.component.name`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name uniquely identifying the instance of the OpenTelemetry component within its containing SDK instance. [2] | `otlp_grpc_span_exporter/0`; `custom-name` |
 | [`otel.component.type`](/docs/registry/attributes/otel.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | A name identifying the type of the OpenTelemetry component. [3] | `batching_span_processor`; `com.example.MySpanExporter` |
 
-**[1] `error.type`:** The set of failure modes for SDK Log Record Processors is defined by the OpenTelemetry SDK specification and is intended to be closed: implementations SHOULD NOT introduce new `error.type` values for this metric outside of those defined by the specification.
-Currently, the only specification-defined value is `queue_full` (used by Batching Log Record Processors when log records are dropped because the queue is full). The well-known values listed below are inherited from the generic `error.type` attribute and are not all applicable to this metric.
+**[1] `error.type`:** The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
+
+When `error.type` is set to a type (e.g., an exception type), its
+canonical class name identifying the type within the artifact SHOULD be used.
+
+If the recorded error type is a wrapper that is not meaningful for
+failure classification, instrumentation MAY use the type of the inner
+error instead. For example, in Go, errors created with `fmt.Errorf`
+using `%w` MAY be unwrapped when the wrapper type does not help
+classify the failure.
+
+Instrumentations SHOULD document the list of errors they report.
+
+The cardinality of `error.type` within one instrumentation library SHOULD be low.
+Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+should be prepared for `error.type` to have high cardinality at query time when no
+additional filters are applied.
+
+If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+
+If a specific domain defines its own set of error identifiers (such as HTTP or RPC status codes),
+it's RECOMMENDED to:
+
+- Use a domain-specific attribute
+- Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
 
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -79,6 +79,7 @@ groups:
       - ref: otel.component.type
       - ref: otel.component.name
       - ref: error.type
+        brief: A low-cardinality description of the failure reason.
         examples: ["queue_full", "already_shutdown"]
 
   - id: metric.otel.sdk.exporter.span.inflight
@@ -192,6 +193,7 @@ groups:
       - ref: otel.component.type
       - ref: otel.component.name
       - ref: error.type
+        brief: A low-cardinality description of the failure reason.
         examples: ["queue_full", "already_shutdown"]
 
   - id: metric.otel.sdk.exporter.log.inflight

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -70,6 +70,8 @@ groups:
     brief: "The number of spans for which the processing has finished, either successful or failed."
     note: |
       For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
+      SDK Batching Span Processors MUST use `queue_full` as the value of `error.type` for spans dropped due to a full queue.
+      SDK Span Processors MUST use `already_shutdown` as the value of `error.type` for spans dropped because the processor has already been shut down.
       For the SDK Simple and Batching Span Processor a span is considered to be processed already when it has been submitted to the exporter, not when the corresponding export call has finished.
     instrument: counter
     unit: "{span}"
@@ -77,11 +79,6 @@ groups:
       - ref: otel.component.type
       - ref: otel.component.name
       - ref: error.type
-        brief: >
-          A low-cardinality description of the failure reason.
-        note:
-          SDK Batching Span Processors MUST use `queue_full` for spans dropped due to a full queue.
-          SDK Span Processors MUST use `already_shutdown` for spans dropped because the processor has already been shut down.
         examples: ["queue_full", "already_shutdown"]
 
   - id: metric.otel.sdk.exporter.span.inflight
@@ -185,6 +182,8 @@ groups:
     brief: "The number of log records for which the processing has finished, either successful or failed."
     note: |
       For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
+      SDK Batching Log Record Processors MUST use `queue_full` as the value of `error.type` for log records dropped due to a full queue.
+      SDK Log Record Processors MUST use `already_shutdown` as the value of `error.type` for log records dropped because the processor has already been shut down.
       For the SDK Simple and Batching Log Record Processor a log record is considered to be processed already when it has been submitted to the exporter,
       not when the corresponding export call has finished.
     instrument: counter
@@ -193,11 +192,6 @@ groups:
       - ref: otel.component.type
       - ref: otel.component.name
       - ref: error.type
-        brief: >
-          A low-cardinality description of the failure reason.
-        note:
-          SDK Batching Log Record Processors MUST use `queue_full` for log records dropped due to a full queue.
-          SDK Log Record Processors MUST use `already_shutdown` for log records dropped because the processor has already been shut down.
         examples: ["queue_full", "already_shutdown"]
 
   - id: metric.otel.sdk.exporter.log.inflight

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -79,6 +79,7 @@ groups:
       - ref: error.type
         brief: >
           A low-cardinality description of the failure reason.
+        note:
           SDK Batching Span Processors MUST use `queue_full` for spans dropped due to a full queue.
           SDK Span Processors MUST use `already_shutdown` for spans dropped because the processor has already been shut down.
         examples: ["queue_full", "already_shutdown"]

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -194,6 +194,7 @@ groups:
       - ref: error.type
         brief: >
           A low-cardinality description of the failure reason.
+        note:
           SDK Batching Log Record Processors MUST use `queue_full` for log records dropped due to a full queue.
           SDK Log Record Processors MUST use `already_shutdown` for log records dropped because the processor has already been shut down.
         examples: ["queue_full", "already_shutdown"]

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -78,11 +78,10 @@ groups:
       - ref: otel.component.name
       - ref: error.type
         brief: >
-          A low-cardinality description of the failure reason. SDK Batching Span Processors MUST use `queue_full` for spans dropped due to a full queue.
-        note: |
-          The set of failure modes for SDK Span Processors is defined by the OpenTelemetry SDK specification and is intended to be closed: implementations SHOULD NOT introduce new `error.type` values for this metric outside of those defined by the specification.
-          Currently, the only specification-defined value is `queue_full` (used by Batching Span Processors when spans are dropped because the queue is full). The well-known values listed below are inherited from the generic `error.type` attribute and are not all applicable to this metric.
-        examples: ["queue_full"]
+          A low-cardinality description of the failure reason.
+          SDK Batching Span Processors MUST use `queue_full` for spans dropped due to a full queue.
+          SDK Span Processors MUST use `already_shutdown` for spans dropped because the processor has already been shut down.
+        examples: ["queue_full", "already_shutdown"]
 
   - id: metric.otel.sdk.exporter.span.inflight
     type: metric
@@ -194,11 +193,10 @@ groups:
       - ref: otel.component.name
       - ref: error.type
         brief: >
-          A low-cardinality description of the failure reason. SDK Batching Log Record Processors MUST use `queue_full` for log records dropped due to a full queue.
-        note: |
-          The set of failure modes for SDK Log Record Processors is defined by the OpenTelemetry SDK specification and is intended to be closed: implementations SHOULD NOT introduce new `error.type` values for this metric outside of those defined by the specification.
-          Currently, the only specification-defined value is `queue_full` (used by Batching Log Record Processors when log records are dropped because the queue is full). The well-known values listed below are inherited from the generic `error.type` attribute and are not all applicable to this metric.
-        examples: ["queue_full"]
+          A low-cardinality description of the failure reason.
+          SDK Batching Log Record Processors MUST use `queue_full` for log records dropped due to a full queue.
+          SDK Log Record Processors MUST use `already_shutdown` for log records dropped because the processor has already been shut down.
+        examples: ["queue_full", "already_shutdown"]
 
   - id: metric.otel.sdk.exporter.log.inflight
     type: metric

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -79,6 +79,9 @@ groups:
       - ref: error.type
         brief: >
           A low-cardinality description of the failure reason. SDK Batching Span Processors MUST use `queue_full` for spans dropped due to a full queue.
+        note: |
+          The set of failure modes for SDK Span Processors is defined by the OpenTelemetry SDK specification and is intended to be closed: implementations SHOULD NOT introduce new `error.type` values for this metric outside of those defined by the specification.
+          Currently, the only specification-defined value is `queue_full` (used by Batching Span Processors when spans are dropped because the queue is full). The well-known values listed below are inherited from the generic `error.type` attribute and are not all applicable to this metric.
         examples: ["queue_full"]
 
   - id: metric.otel.sdk.exporter.span.inflight
@@ -192,6 +195,9 @@ groups:
       - ref: error.type
         brief: >
           A low-cardinality description of the failure reason. SDK Batching Log Record Processors MUST use `queue_full` for log records dropped due to a full queue.
+        note: |
+          The set of failure modes for SDK Log Record Processors is defined by the OpenTelemetry SDK specification and is intended to be closed: implementations SHOULD NOT introduce new `error.type` values for this metric outside of those defined by the specification.
+          Currently, the only specification-defined value is `queue_full` (used by Batching Log Record Processors when log records are dropped because the queue is full). The well-known values listed below are inherited from the generic `error.type` attribute and are not all applicable to this metric.
         examples: ["queue_full"]
 
   - id: metric.otel.sdk.exporter.log.inflight


### PR DESCRIPTION
Reserves `already_shutdown` as an `error.type` value on `otel.sdk.processor.span.processed` and `otel.sdk.processor.log.processed`, used when a processor drops items because it has already been shut down. Applies to any SDK processor (not just batching).

## Why the processor is the right place

`TracerProvider.Shutdown` only requires *new* `GetTracer(...)` calls to return a no-op; it doesn't invalidate pre-existing Tracers or affect in-flight Spans (`span.End()` calls `SpanProcessor.OnEnd` directly). [`SpanProcessor.Shutdown`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#shutdown-1) explicitly anticipates this: "subsequent calls to OnStart/OnEnd/ForceFlush are not allowed. SDKs SHOULD ignore these calls gracefully." So the drop is observed at the processor and recorded as `error.type=already_shutdown`.

Note: `GetTracer(...)` *after* shutdown returns a no-op Tracer — spans never enter the SDK, so no metric fires. Tracked as a follow-up.

Related:
- Spec issue: open-telemetry/opentelemetry-specification#5086
- Spec PR: open-telemetry/opentelemetry-specification#5087
- Prototype (Rust): open-telemetry/opentelemetry-rust#3514
