### PR TITLE
Add metrics, events, and entities to name collision detection policy and fix violations

### DIFF
--- a/.chloggen/exclude-k8s-metrics.yaml
+++ b/.chloggen/exclude-k8s-metrics.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: k8s
+note: "Exclude `k8s.container.cpu.limit_utilization` and `k8s.container.cpu.request_utilization` metrics from code generation"
+issues: [3711, 3705]
+

--- a/.chloggen/exclude-k8s-metrics.yaml
+++ b/.chloggen/exclude-k8s-metrics.yaml
@@ -2,4 +2,3 @@ change_type: bug_fix
 component: k8s
 note: "Exclude `k8s.container.cpu.limit_utilization` and `k8s.container.cpu.request_utilization` metrics from code generation"
 issues: [3711, 3705]
-

--- a/model/k8s/deprecated/metrics-deprecated.yaml
+++ b/model/k8s/deprecated/metrics-deprecated.yaml
@@ -532,6 +532,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: double
+        exclude: true
     stability: development
     deprecated:
       reason: renamed
@@ -562,6 +563,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: double
+        exclude: true
     stability: development
     deprecated:
       reason: renamed

--- a/policies/attribute_name_collisions.rego
+++ b/policies/attribute_name_collisions.rego
@@ -6,29 +6,11 @@ import rego.v1
 attribute_names := { obj |
     group := input.groups[_];
     attr := group.attributes[_];
-    obj := { "name": attr.name, "const_name": to_const_name(attr.name), "namespace_prefix": to_namespace_prefix(attr.name), "deprecated": is_property_set(attr, "deprecated"), "annotations": property_or_null(attr, "annotations") }
-}
-
-# check that attribute constant names do not collide
-deny contains attr_registry_collision(description, name) if {
-    some i
-    name := attribute_names[i].name
-    const_name := attribute_names[i].const_name
-    annotations := attribute_names[i].annotations
-
-    not annotations["code_generation"]["exclude"]
-
-    collisions := [other.name |
-        other := attribute_names[_]
-        other.name != name
-        other.const_name == const_name
-
-        not other.annotations["code_generation"]["exclude"]
-    ]
-    count(collisions) > 0
-
-    # TODO (https://github.com/open-telemetry/weaver/issues/279): provide other violation properties once weaver supports it.
-    description := sprintf("Attribute '%s' has the same constant name '%s' as '%s'.", [name, const_name, collisions])
+    obj := {
+        "name": attr.name,
+        "namespace_prefix": to_namespace_prefix(attr.name),
+        "deprecated": is_property_set(attr, "deprecated"),
+    }
 }
 
 # check that attribute names do not collide with namespaces
@@ -74,8 +56,3 @@ attr_registry_collision(description, attr_name) = violation if {
         "group": "",
     }
 }
-
-to_namespace_prefix(name) = namespace if {
-    namespace := concat("", [name, "."])
-}
-

--- a/policies/constant_name_collisions.rego
+++ b/policies/constant_name_collisions.rego
@@ -1,0 +1,81 @@
+package after_resolution
+
+import rego.v1
+
+# Data structures to make checking things faster.
+# constant_names collects everything that produces a generated-code constant:
+# attributes, metrics, events, and entities. The collision check below
+# matches within the same type, since each type lives in its own namespace
+# in generated code.
+constant_names contains obj if {
+    group := input.groups[_]
+    attr := group.attributes[_]
+    obj := to_constant_entry(attr.name, "attribute", group.id, attr.name, attr)
+}
+
+constant_names contains obj if {
+    group := input.groups[_]
+    group.type == "metric"
+    obj := to_constant_entry(group.metric_name, "metric", group.id, "", group)
+}
+
+constant_names contains obj if {
+    group := input.groups[_]
+    group.type == "event"
+    obj := to_constant_entry(group.name, "event", group.id, "", group)
+}
+
+constant_names contains obj if {
+    group := input.groups[_]
+    group.type == "entity"
+    obj := to_constant_entry(group.name, "entity", group.id, "", group)
+}
+
+to_constant_entry(name, type, group_id, attr_name, source) = obj if {
+    obj := {
+        "name": name,
+        "const_name": to_const_name(name),
+        "type": type,
+        "group_id": group_id,
+        "attr_name": attr_name,
+        "annotations": property_or_null(source, "annotations"),
+    }
+}
+
+# check that constant names do not collide within the same type
+deny contains constant_name_collision(description, group_id, attr_name) if {
+    some i
+    name := constant_names[i].name
+    const_name := constant_names[i].const_name
+    type := constant_names[i].type
+    group_id := constant_names[i].group_id
+    attr_name := constant_names[i].attr_name
+    annotations := constant_names[i].annotations
+
+    not annotations["code_generation"]["exclude"]
+
+    collisions := [other.name |
+        other := constant_names[_]
+        other.type == type
+        other.name != name
+        other.const_name == const_name
+
+        not other.annotations["code_generation"]["exclude"]
+    ]
+    count(collisions) > 0
+
+    # TODO (https://github.com/open-telemetry/weaver/issues/279): provide other violation properties once weaver supports it.
+    description := sprintf("%s '%s' has the same constant name '%s' as '%s'.", [type, name, const_name, collisions])
+}
+
+# attr_name is empty for metric/event/entity, since
+# those collisions are reported on the group itself.
+constant_name_collision(description, group_id, attr_name) = violation if {
+    violation := {
+        "id": description,
+        "type": "semconv_attribute",
+        "category": "naming_collision",
+        "attr": attr_name,
+        "group": group_id,
+    }
+}

--- a/policies/helpers.rego
+++ b/policies/helpers.rego
@@ -6,6 +6,12 @@ to_const_name(name) = const_name if {
     const_name := replace(name, ".", "_")
 }
 
+# Appends a trailing dot so the result can be used with `startswith` to find
+# names nested under this namespace, e.g. "foo.bar" -> "foo.bar.".
+to_namespace_prefix(name) = prefix if {
+    prefix := concat("", [name, "."])
+}
+
 is_property_set(obj, property) = true if {
     obj[property] != null
 } else = false

--- a/policies/metrics_collisions.rego
+++ b/policies/metrics_collisions.rego
@@ -8,7 +8,7 @@ metric_names := { obj |
     group.type = "metric"
     obj := {
     "name": group.metric_name,
-    "namespace_prefix": extract_metric_namespace_prefix(group.metric_name),
+    "namespace_prefix": to_namespace_prefix(group.metric_name),
     "deprecated": is_property_set(group, "deprecated")
     }
 }
@@ -49,9 +49,5 @@ metrics_registry_collision(description, metric_name) = violation if {
         "attr": metric_name,
         "group": "",
     }
-}
-
-extract_metric_namespace_prefix(name) = namespace if {
-    namespace := concat("", [name, "."])
 }
 

--- a/policies_test/attribute_name_collisions_test.rego
+++ b/policies_test/attribute_name_collisions_test.rego
@@ -1,15 +1,6 @@
 package after_resolution
 import future.keywords
 
-test_fails_on_const_name_collision if {
-    collision := {"groups": [
-        {"id": "test1", "attributes": [{"name": "foo.bar.baz", "stability": "development", "brief": "brief."}]},
-        {"id": "test2", "attributes": [{"name": "foo.bar_baz", "stability": "development", "brief": "brief."}]}
-    ]}
-    # each attribute counts as a collision, so there are 2 collisions
-    count(deny) == 2 with input as collision
-}
-
 test_fails_on_namespace_collision if {
     collision := {"groups": [
         {"id": "test1", "attributes": [{"name": "foo.bar.baz", "stability": "development", "brief": "brief."}]},
@@ -28,13 +19,3 @@ test_does_not_fail_on_deprecated_namespace_collision if {
     ]}
     count(deny) == 0 with input as collision
 }
-
-test_does_not_fail_on_excluded_name_collision if {
-    collision := {"groups": [
-        {"id": "test1", "attributes": [{"name": "test1.namespace.id", "stability": "development", "brief": "brief."}, {"name": "test1.namespace_id", "stability": "development", "brief": "brief.", "annotations": {"code_generation": {"exclude": true}}}]},
-
-        {"id": "test2", "attributes": [{"name": "test2.namespace_id", "stability": "development", "brief": "brief."}, {"name": "test2.namespace.id", "stability": "development", "brief": "brief.", "annotations": {"code_generation": {"exclude": true}}}]},
-    ]}
-    count(deny) == 0 with input as collision
-}
-

--- a/policies_test/constant_name_collisions_test.rego
+++ b/policies_test/constant_name_collisions_test.rego
@@ -1,0 +1,56 @@
+package after_resolution
+import future.keywords
+
+test_fails_on_const_name_collision if {
+    collision := {"groups": [
+        {"id": "test1", "attributes": [{"name": "foo.bar.baz", "stability": "development", "brief": "brief."}]},
+        {"id": "test2", "attributes": [{"name": "foo.bar_baz", "stability": "development", "brief": "brief."}]}
+    ]}
+    # each attribute counts as a collision, so there are 2 collisions
+    count(deny) == 2 with input as collision
+}
+
+test_does_not_fail_on_excluded_name_collision if {
+    collision := {"groups": [
+        {"id": "test1", "attributes": [{"name": "test1.namespace.id", "stability": "development", "brief": "brief."}, {"name": "test1.namespace_id", "stability": "development", "brief": "brief.", "annotations": {"code_generation": {"exclude": true}}}]},
+
+        {"id": "test2", "attributes": [{"name": "test2.namespace_id", "stability": "development", "brief": "brief."}, {"name": "test2.namespace.id", "stability": "development", "brief": "brief.", "annotations": {"code_generation": {"exclude": true}}}]},
+    ]}
+    count(deny) == 0 with input as collision
+}
+
+test_fails_on_metric_const_name_collision if {
+    collision := {"groups": [
+        {"id": "metric.foo.bar.baz", "type": "metric", "metric_name": "foo.bar.baz", "stability": "development", "brief": "brief.", "attributes": []},
+        {"id": "metric.foo.bar_baz", "type": "metric", "metric_name": "foo.bar_baz", "stability": "development", "brief": "brief.", "attributes": []},
+    ]}
+    count(deny) == 2 with input as collision
+}
+
+test_fails_on_event_const_name_collision if {
+    collision := {"groups": [
+        {"id": "event.foo.bar.baz", "type": "event", "name": "foo.bar.baz", "stability": "development", "brief": "brief.", "attributes": []},
+        {"id": "event.foo.bar_baz", "type": "event", "name": "foo.bar_baz", "stability": "development", "brief": "brief.", "attributes": []},
+    ]}
+    count(deny) == 2 with input as collision
+}
+
+test_fails_on_entity_const_name_collision if {
+    collision := {"groups": [
+        {"id": "entity.foo.bar.baz", "type": "entity", "name": "foo.bar.baz", "stability": "development", "brief": "brief.", "attributes": []},
+        {"id": "entity.foo.bar_baz", "type": "entity", "name": "foo.bar_baz", "stability": "development", "brief": "brief.", "attributes": []},
+    ]}
+    count(deny) == 2 with input as collision
+}
+
+# Same constant name across different kinds is fine — each kind lives in its
+# own generated-code namespace.
+test_does_not_fail_on_cross_kind_const_name_collision if {
+    collision := {"groups": [
+        {"id": "test", "attributes": [{"name": "foo.bar", "stability": "development", "brief": "brief."}]},
+        {"id": "metric.foo.bar", "type": "metric", "metric_name": "foo.bar", "stability": "development", "brief": "brief.", "attributes": []},
+        {"id": "event.foo.bar", "type": "event", "name": "foo.bar", "stability": "development", "brief": "brief.", "attributes": []},
+        {"id": "entity.foo.bar", "type": "entity", "name": "foo.bar", "stability": "development", "brief": "brief.", "attributes": []},
+    ]}
+    count(deny) == 0 with input as collision
+}


### PR DESCRIPTION
Fixes #3705

We didn't run naming collision tests on metric/event names and entities types. Extending policies and fixing existing violations