### PR TITLE
Add http.client.request.time in queue to model for .NET

### DIFF
--- a/.chloggen/dotnet-add-http.client.request.time_in_queue.yaml
+++ b/.chloggen/dotnet-add-http.client.request.time_in_queue.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: dotnet
+note: "Add the http.client.request.time_in_queue metric to .NET semantic conventions which was documented but missing"
+issues: []

--- a/.chloggen/dotnet-add-http.client.request.time_in_queue.yaml
+++ b/.chloggen/dotnet-add-http.client.request.time_in_queue.yaml
@@ -1,4 +1,4 @@
 change_type: bug_fix
 component: dotnet
 note: "Add the http.client.request.time_in_queue metric to .NET semantic conventions which was documented but missing"
-issues: []
+issues: [3720]

--- a/docs/dotnet/dotnet-http-metrics.md
+++ b/docs/dotnet/dotnet-http-metrics.md
@@ -103,7 +103,7 @@ This metric SHOULD be specified with [`ExplicitBucketBoundaries` advisory parame
 
 ### Metric: `http.client.request.time_in_queue`
 
-this metric SHOULD be specified with [`ExplicitBucketBoundaries` advisory parameter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.56.0/specification/metrics/api.md#instrument-advisory-parameters) of `[ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 ]`.
+This metric SHOULD be specified with [`ExplicitBucketBoundaries` advisory parameter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.56.0/specification/metrics/api.md#instrument-advisory-parameters) of `[ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 ]`.
 
 <!-- Tables in this document are not auto-generated and are intentionally frozen in time. From the .NET perspective this metric and its attributes are stable till the next major version. They are still experimental in the OpenTelemetry. -->
 | Name | Instrument Type | Unit (UCUM) | Description |

--- a/model/dotnet/http-metrics.yaml
+++ b/model/dotnet/http-metrics.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: http.client.request.time_in_queue
+  - id: metric.http.client.request.time_in_queue
     type: metric
     metric_name: http.client.request.time_in_queue
     annotations:

--- a/model/dotnet/http-metrics.yaml
+++ b/model/dotnet/http-metrics.yaml
@@ -1,0 +1,25 @@
+groups:
+  - id: http.client.request.time_in_queue
+    type: metric
+    metric_name: http.client.request.time_in_queue
+    annotations:
+      code_generation:
+        metric_value_type: double
+    stability: stable
+    brief: "The amount of time requests spent on a queue waiting for an available connection."
+    instrument: histogram
+    unit: "s"
+    note: >
+      Meter name: `System.Net.Http`; Added in: .NET 8.0.
+    attributes:
+      - ref: http.request.method
+        requirement_level: recommended
+      - ref: network.protocol.version
+        requirement_level: recommended
+      - ref: server.address
+        requirement_level: required
+      - ref: server.port
+        requirement_level:
+          conditionally_required: If not the default (`80` for `http` scheme, `443` for `https`).
+      - ref: url.scheme
+        requirement_level: recommended


### PR DESCRIPTION
Fixes #3720

## Changes

The .NET [http.client.request.time_in_queue](https://github.com/dotnet/runtime/blob/47e3ca7e1e9c79c8f69b88fc5620c88778676616/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs#L26-L30) metric is documented as stable ([source](https://github.com/open-telemetry/semantic-conventions/blob/v1.41.1/docs/dotnet/dotnet-http-metrics.md#metric-httpclientrequesttime_in_queue)), but does not actually exist in the model YAML.

I found this while doing to some experimentation with weaver, which flushed this out.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
