### PR TITLE
Add ASN attributes to client, destination, server, and source namespaces

### DIFF
--- a/.chloggen/add-asn-attributes.yaml
+++ b/.chloggen/add-asn-attributes.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: client, destination, server, source
+
+note: Add `as.number` and `as.organization.name` attributes to `client`, `destination`, `server`, and `source` namespaces for Autonomous System Number (ASN) support.
+
+issues: [1663]
+
+subtext:

--- a/docs/registry/attributes/client.md
+++ b/docs/registry/attributes/client.md
@@ -12,6 +12,8 @@ These attributes may be used to describe the client in a connection-based networ
 | Key | Stability | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- |
 | <a id="client-address" href="#client-address">`client.address`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [1] | `client.example.com`; `10.1.2.80`; `/tmp/my.sock` |
+| <a id="client-as-number" href="#client-as-number">`client.as.number`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The [Autonomous System Number (ASN)](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) associated with the client's IP address. | `64496`; `15169` |
+| <a id="client-as-organization-name" href="#client-as-organization-name">`client.as.organization.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the organization associated with the client's ASN. | `Example Networks Inc.`; `Google LLC` |
 | <a id="client-port" href="#client-port">`client.port`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | int | Client port number. [2] | `65123` |
 
 **[1] `client.address`:** When observed from the server side, and when communicating through an intermediary, `client.address` SHOULD represent the client address behind any intermediaries,  for example proxies, if it's available.

--- a/docs/registry/attributes/destination.md
+++ b/docs/registry/attributes/destination.md
@@ -12,6 +12,8 @@ These attributes may be used to describe the receiver of a network exchange/pack
 | Key | Stability | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- |
 | <a id="destination-address" href="#destination-address">`destination.address`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Destination address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [1] | `destination.example.com`; `10.1.2.80`; `/tmp/my.sock` |
+| <a id="destination-as-number" href="#destination-as-number">`destination.as.number`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The [Autonomous System Number (ASN)](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) associated with the destination's IP address. | `64496`; `15169` |
+| <a id="destination-as-organization-name" href="#destination-as-organization-name">`destination.as.organization.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the organization associated with the destination's ASN. | `Example Networks Inc.`; `Google LLC` |
 | <a id="destination-port" href="#destination-port">`destination.port`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | Destination port number | `3389`; `2888` |
 
 **[1] `destination.address`:** When observed from the source side, and when communicating through an intermediary, `destination.address` SHOULD represent the destination address behind any intermediaries, for example proxies, if it's available.

--- a/docs/registry/attributes/server.md
+++ b/docs/registry/attributes/server.md
@@ -12,6 +12,8 @@ These attributes may be used to describe the server in a connection-based networ
 | Key | Stability | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- |
 | <a id="server-address" href="#server-address">`server.address`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [1] | `example.com`; `10.1.2.80`; `/tmp/my.sock` |
+| <a id="server-as-number" href="#server-as-number">`server.as.number`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The [Autonomous System Number (ASN)](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) associated with the server's IP address. | `64496`; `15169` |
+| <a id="server-as-organization-name" href="#server-as-organization-name">`server.as.organization.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the organization associated with the server's ASN. | `Example Networks Inc.`; `Google LLC` |
 | <a id="server-port" href="#server-port">`server.port`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | int | Server port number. [2] | `80`; `8080`; `443` |
 
 **[1] `server.address`:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.

--- a/docs/registry/attributes/source.md
+++ b/docs/registry/attributes/source.md
@@ -12,6 +12,8 @@ These attributes may be used to describe the sender of a network exchange/packet
 | Key | Stability | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- |
 | <a id="source-address" href="#source-address">`source.address`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Source address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [1] | `source.example.com`; `10.1.2.80`; `/tmp/my.sock` |
+| <a id="source-as-number" href="#source-as-number">`source.as.number`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The [Autonomous System Number (ASN)](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) associated with the source's IP address. | `64496`; `15169` |
+| <a id="source-as-organization-name" href="#source-as-organization-name">`source.as.organization.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the organization associated with the source's ASN. | `Example Networks Inc.`; `Google LLC` |
 | <a id="source-port" href="#source-port">`source.port`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | Source port number | `3389`; `2888` |
 
 **[1] `source.address`:** When observed from the destination side, and when communicating through an intermediary, `source.address` SHOULD represent the source address behind any intermediaries, for example proxies, if it's available.

--- a/model/client/registry.yaml
+++ b/model/client/registry.yaml
@@ -26,3 +26,13 @@ groups:
         note: >
           When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent
           the client port behind any intermediaries,  for example proxies, if it's available.
+      - id: client.as.number
+        type: int
+        stability: development
+        brief: "The [Autonomous System Number (ASN)](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) associated with the client's IP address."
+        examples: [64496, 15169]
+      - id: client.as.organization.name
+        type: string
+        stability: development
+        brief: "The name of the organization associated with the client's ASN."
+        examples: ["Example Networks Inc.", "Google LLC"]

--- a/model/destination/registry.yaml
+++ b/model/destination/registry.yaml
@@ -23,3 +23,13 @@ groups:
         stability: development
         brief: 'Destination port number'
         examples: [3389, 2888]
+      - id: destination.as.number
+        type: int
+        stability: development
+        brief: "The [Autonomous System Number (ASN)](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) associated with the destination's IP address."
+        examples: [64496, 15169]
+      - id: destination.as.organization.name
+        type: string
+        stability: development
+        brief: "The name of the organization associated with the destination's ASN."
+        examples: ["Example Networks Inc.", "Google LLC"]

--- a/model/server/registry.yaml
+++ b/model/server/registry.yaml
@@ -26,3 +26,13 @@ groups:
           When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent
           the server port behind any intermediaries, for example proxies, if it's available.
         examples: [80, 8080, 443]
+      - id: server.as.number
+        type: int
+        stability: development
+        brief: "The [Autonomous System Number (ASN)](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) associated with the server's IP address."
+        examples: [64496, 15169]
+      - id: server.as.organization.name
+        type: string
+        stability: development
+        brief: "The name of the organization associated with the server's ASN."
+        examples: ["Example Networks Inc.", "Google LLC"]

--- a/model/source/registry.yaml
+++ b/model/source/registry.yaml
@@ -23,3 +23,13 @@ groups:
         stability: development
         brief: 'Source port number'
         examples: [3389, 2888]
+      - id: source.as.number
+        type: int
+        stability: development
+        brief: "The [Autonomous System Number (ASN)](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) associated with the source's IP address."
+        examples: [64496, 15169]
+      - id: source.as.organization.name
+        type: string
+        stability: development
+        brief: "The name of the organization associated with the source's ASN."
+        examples: ["Example Networks Inc.", "Google LLC"]


### PR DESCRIPTION
Fixes #1663

## Changes

Add `as.number` (int) and `as.organization.name` (string) attributes to
the `client`, `destination`, `server`, and `source` namespaces for
Autonomous System Number (ASN) support.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)