### PR TITLE
[chore] add policy to force entity attribute roles earlier in dev cycle

### DIFF
--- a/policies/entity_stability.rego
+++ b/policies/entity_stability.rego
@@ -6,8 +6,7 @@ deny contains entity_stability_violation(description, group.id, "") if {
     group := input.groups[_]
     # ignore attribute_groups
     group.type == "entity"
-    stabilities := {"stable", "release_candidate", "beta"}
-    stabilities[group.stability]
+    group.stability != "development"
 
     exceptions = {}
     not exceptions[group.id]
@@ -27,8 +26,7 @@ deny contains entity_stability_violation(description, group.id, attr.name) if {
     group := input.groups[_]
     # ignore attribute_groups
     group.type == "entity"
-    stabilities := {"stable", "release_candidate", "beta"}
-    stabilities[group.stability]
+    group.stability != "development"
 
     exceptions = {}
     not exceptions[group.id]

--- a/policies/entity_stability.rego
+++ b/policies/entity_stability.rego
@@ -18,7 +18,7 @@ deny contains entity_stability_violation(description, group.id, "") if {
     ]
     count(ids) < 1
 
-    description := sprintf("%s entity '%s' has no identifying attributes", [group.stability, group.name])
+    description := sprintf("Entity '%s' with stability '%s' has no identifying attributes", [group.name, group.stability])
 }
 
 
@@ -36,7 +36,7 @@ deny contains entity_stability_violation(description, group.id, attr.name) if {
     attr := group.attributes[_]
     not attr.role
 
-    description := sprintf("%s entity '%s' has attribute without role: '%s'", [group.stability, group.name, attr.name])
+    description := sprintf("Entity '%s' with stability '%s' has attribute without role: '%s'", [group.name, group.stability, attr.name])
 }
 
 entity_stability_violation(description, group, attr) = violation if {

--- a/policies/entity_stability.rego
+++ b/policies/entity_stability.rego
@@ -6,7 +6,7 @@ deny contains entity_stability_violation(description, group.id, "") if {
     group := input.groups[_]
     # ignore attribute_groups
     group.type == "entity"
-    stabilities := ["stable", "release_candidate", "beta"]
+    stabilities := {"stable", "release_candidate", "beta"}
     stabilities[group.stability]
 
     exceptions = {}
@@ -27,7 +27,7 @@ deny contains entity_stability_violation(description, group.id, attr.name) if {
     group := input.groups[_]
     # ignore attribute_groups
     group.type == "entity"
-    stabilities := ["stable", "release_candidate", "beta"]
+    stabilities := {"stable", "release_candidate", "beta"}
     stabilities[group.stability]
 
     exceptions = {}

--- a/policies/entity_stability.rego
+++ b/policies/entity_stability.rego
@@ -18,7 +18,7 @@ deny contains entity_stability_violation(description, group.id, "") if {
     ]
     count(ids) < 1
 
-    description := sprintf("Stable entity '%s' has no identifying attributes", [group.name])
+    description := sprintf("%s entity '%s' has no identifying attributes", [group.stability, group.name])
 }
 
 
@@ -36,7 +36,7 @@ deny contains entity_stability_violation(description, group.id, attr.name) if {
     attr := group.attributes[_]
     not attr.role
 
-    description := sprintf("Stable entity '%s' has attribute without role: '%s'", [group.name, attr.name])
+    description := sprintf("%s entity '%s' has attribute without role: '%s'", [group.stability, group.name, attr.name])
 }
 
 entity_stability_violation(description, group, attr) = violation if {

--- a/policies/entity_stability.rego
+++ b/policies/entity_stability.rego
@@ -1,12 +1,13 @@
 package after_resolution
 import rego.v1
 
-# checks for stable entity groups that have no identifying attributes
+# checks for entity groups that have no identifying attributes
 deny contains entity_stability_violation(description, group.id, "") if {
     group := input.groups[_]
     # ignore attribute_groups
     group.type == "entity"
-    group.stability == "stable"
+    stabilities := ["stable", "release_candidate", "beta"]
+    stabilities[group.stability]
 
     exceptions = {}
     not exceptions[group.id]
@@ -21,12 +22,13 @@ deny contains entity_stability_violation(description, group.id, "") if {
 }
 
 
-# checks for stable entity groups that have attributes with no role
+# checks for entity groups that have attributes with no role
 deny contains entity_stability_violation(description, group.id, attr.name) if {
     group := input.groups[_]
     # ignore attribute_groups
     group.type == "entity"
-    group.stability == "stable"
+    stabilities := ["stable", "release_candidate", "beta"]
+    stabilities[group.stability]
 
     exceptions = {}
     not exceptions[group.id]

--- a/policies_test/entity_association_test.rego
+++ b/policies_test/entity_association_test.rego
@@ -15,10 +15,10 @@ test_succeed_on_valid_entity_association if {
 
 create_metric_with_association(name, association) = json if {
     id := sprintf("metric.%s", [name])
-    json := {"id": id, "type": "metric", "metric_name": name, "stability": "rc", "entity_associations": [association], "brief": "brief."}
+    json := {"id": id, "type": "metric", "metric_name": name, "stability": "development", "entity_associations": [association], "brief": "brief."}
 }
 
 create_entity(name) = json if {
     id := sprintf("resource.%s", [name])
-    json := {"id": id, "type": "entity", "name": name, "stability": "rc", "brief": "brief."}
+    json := {"id": id, "type": "entity", "name": name, "stability": "development", "brief": "brief."}
 }

--- a/policies_test/entity_stability_test.rego
+++ b/policies_test/entity_stability_test.rego
@@ -123,7 +123,7 @@ test_passes_on_stable_entity_with_id if {
         }]}]}
 }
 
-test_passes_on_stable_entity_with_id if {
+test_passes_on_rc_entity_with_id if {
     count(deny) == 0 with input as {"groups": [{
         "id": "entity.foo",
         "type": "entity",
@@ -143,7 +143,7 @@ test_passes_on_stable_entity_with_id if {
         }]}]}
 }
 
-test_passes_on_stable_entity_with_id if {
+test_passes_on_beta_entity_with_id if {
     count(deny) == 0 with input as {"groups": [{
         "id": "entity.foo",
         "type": "entity",

--- a/policies_test/entity_stability_test.rego
+++ b/policies_test/entity_stability_test.rego
@@ -35,6 +35,74 @@ test_fails_on_stable_entity_with_attributes_having_no_id if {
         }]}]}
 }
 
+test_fails_on_rc_entity_with_attributes_having_no_role if {
+    count(deny) >= 1 with input as {"groups": [{
+        "id": "entity.foo",
+        "type": "entity",
+        "name": "foo",
+        "stability": "release_candidate",
+        "brief": "brief.",
+        "attributes": [{
+            "name": "test.experimental",
+            "stability": "release_candidate",
+            "brief": "brief."
+        }, {
+            "name": "test.id",
+            "stability": "release_candidate",
+            "role": "identifying",
+            "brief": "brief."
+        }]}]}
+}
+
+test_fails_on_rc_entity_with_attributes_having_no_id if {
+    count(deny) >= 1 with input as {"groups": [{
+        "id": "entity.foo",
+        "type": "entity",
+        "name": "foo",
+        "stability": "release_candidate",
+        "brief": "brief.",
+        "attributes": [{
+            "name": "test.experimental",
+            "stability": "release_candidate",
+            "role": "descriptive",
+            "brief": "brief."
+        }]}]}
+}
+
+test_fails_on_beta_entity_with_attributes_having_no_role if {
+    count(deny) >= 1 with input as {"groups": [{
+        "id": "entity.foo",
+        "type": "entity",
+        "name": "foo",
+        "stability": "beta",
+        "brief": "brief.",
+        "attributes": [{
+            "name": "test.experimental",
+            "stability": "beta",
+            "brief": "brief."
+        }, {
+            "name": "test.id",
+            "stability": "beta",
+            "role": "identifying",
+            "brief": "brief."
+        }]}]}
+}
+
+test_fails_on_beta_entity_with_attributes_having_no_id if {
+    count(deny) >= 1 with input as {"groups": [{
+        "id": "entity.foo",
+        "type": "entity",
+        "name": "foo",
+        "stability": "beta",
+        "brief": "brief.",
+        "attributes": [{
+            "name": "test.experimental",
+            "stability": "beta",
+            "role": "descriptive",
+            "brief": "brief."
+        }]}]}
+}
+
 test_passes_on_stable_entity_with_id if {
     count(deny) == 0 with input as {"groups": [{
         "id": "entity.foo",
@@ -50,6 +118,46 @@ test_passes_on_stable_entity_with_id if {
         },{
             "name": "test.id",
             "stability": "stable",
+            "role": "identifying",
+            "brief": "brief."
+        }]}]}
+}
+
+test_passes_on_stable_entity_with_id if {
+    count(deny) == 0 with input as {"groups": [{
+        "id": "entity.foo",
+        "type": "entity",
+        "name": "foo",
+        "stability": "release_candidate",
+        "brief": "brief.",
+        "attributes": [{
+            "name": "test.experimental",
+            "stability": "release_candidate",
+            "role": "descriptive",
+            "brief": "brief."
+        },{
+            "name": "test.id",
+            "stability": "release_candidate",
+            "role": "identifying",
+            "brief": "brief."
+        }]}]}
+}
+
+test_passes_on_stable_entity_with_id if {
+    count(deny) == 0 with input as {"groups": [{
+        "id": "entity.foo",
+        "type": "entity",
+        "name": "foo",
+        "stability": "beta",
+        "brief": "brief.",
+        "attributes": [{
+            "name": "test.experimental",
+            "stability": "beta",
+            "role": "descriptive",
+            "brief": "brief."
+        },{
+            "name": "test.id",
+            "stability": "beta",
             "role": "identifying",
             "brief": "brief."
         }]}]}

--- a/policies_test/entity_stability_test.rego
+++ b/policies_test/entity_stability_test.rego
@@ -162,3 +162,21 @@ test_passes_on_beta_entity_with_id if {
             "brief": "brief."
         }]}]}
 }
+
+test_passes_on_development_entity_having_no_role if {
+    count(deny) == 0 with input as {"groups": [{
+        "id": "entity.foo",
+        "type": "entity",
+        "name": "foo",
+        "stability": "development",
+        "brief": "brief.",
+        "attributes": [{
+            "name": "test.experimental",
+            "stability": "development",
+            "brief": "brief."
+        },{
+            "name": "test.id",
+            "stability": "beta",
+            "brief": "brief."
+        }]}]}
+}


### PR DESCRIPTION
Fixes #

## Changes

This forces all attributes of entities which are beta or higher to have a role. This ensures that testing can be done with the beta, the bump to rc is an indicator that it has been tested and works but more use cases need confirmation but is unlikely to change.

> [!IMPORTANT]
> Pull requests acceptance are subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above, may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
