### PR TITLE
Change network.peer.address to opt-in on http.client.open_connections (related to #3279)

### DIFF
--- a/.chloggen/http-peer-address-opt-in.yaml
+++ b/.chloggen/http-peer-address-opt-in.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: http
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change `network.peer.address` attribute requirement level from Recommended to Opt-In on the `http.client.open_connections` metric.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [3279]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `network.peer.address` is typically high-cardinality (one time series per remote IP).
+  On `http.client.open_connections` (an UpDownCounter, always exported with cumulative
+  temporality) this caused unbounded growth of metric streams over the lifetime of the
+  process, exhausting SDK cardinality limits and collapsing useful low-cardinality
+  attributes (e.g. `url.scheme`) into the overflow bucket. Operators that need this
+  attribute can still opt-in.

--- a/.chloggen/http-peer-address-opt-in.yaml
+++ b/.chloggen/http-peer-address-opt-in.yaml
@@ -10,7 +10,7 @@ change_type: breaking
 component: http
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Change `network.peer.address` attribute requirement level from Recommended to Opt-In on the `http.client.open_connections` metric.
+note: Change `network.peer.address` attribute requirement level from Recommended to Opt-In on the `http.client.open_connections` and `http.client.connection.duration` metrics.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.
@@ -20,9 +20,9 @@ issues: [3279]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  `network.peer.address` is typically high-cardinality (one time series per remote IP).
-  On `http.client.open_connections` (an UpDownCounter, always exported with cumulative
-  temporality) this caused unbounded growth of metric streams over the lifetime of the
-  process, exhausting SDK cardinality limits and collapsing useful low-cardinality
-  attributes (e.g. `url.scheme`) into the overflow bucket. Operators that need this
-  attribute can still opt-in.
+  `network.peer.address` is typically high-cardinality (one time series per remote IP)
+  and causes unbounded growth of metric streams over the lifetime of the process when
+  exported with cumulative temporality (always the case for `http.client.open_connections`
+  since it is an UpDownCounter, and possible for `http.client.connection.duration` when
+  the histogram is configured for cumulative). Operators that need this attribute can
+  still opt-in.

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -995,8 +995,8 @@ This metric is optional.
 | --- | --- | --- | --- | --- | --- |
 | [`server.address`](/docs/registry/attributes/server.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Required` | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [1] | `example.com`; `10.1.2.80`; `/tmp/my.sock` |
 | [`server.port`](/docs/registry/attributes/server.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Required` | int | Server port number. [2] | `80`; `8080`; `443` |
-| [`network.peer.address`](/docs/registry/attributes/network.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | Peer address of the network connection - IP address or Unix domain socket name. | `10.1.2.80`; `/tmp/my.sock` |
 | [`network.protocol.version`](/docs/registry/attributes/network.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The actual version of the protocol used for network communication. [3] | `1.1`; `2` |
+| [`network.peer.address`](/docs/registry/attributes/network.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | Peer address of the network connection - IP address or Unix domain socket name. | `10.1.2.80`; `/tmp/my.sock` |
 | [`url.scheme`](/docs/registry/attributes/url.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` |
 
 **[1] `server.address`:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -951,8 +951,8 @@ This metric is optional.
 | [`http.connection.state`](/docs/registry/attributes/http.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Required` | string | State of the HTTP connection in the HTTP connection pool. | `active`; `idle` |
 | [`server.address`](/docs/registry/attributes/server.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Required` | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [1] | `example.com`; `10.1.2.80`; `/tmp/my.sock` |
 | [`server.port`](/docs/registry/attributes/server.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Required` | int | Server port number. [2] | `80`; `8080`; `443` |
-| [`network.peer.address`](/docs/registry/attributes/network.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | Peer address of the network connection - IP address or Unix domain socket name. | `10.1.2.80`; `/tmp/my.sock` |
 | [`network.protocol.version`](/docs/registry/attributes/network.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The actual version of the protocol used for network communication. [3] | `1.1`; `2` |
+| [`network.peer.address`](/docs/registry/attributes/network.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | Peer address of the network connection - IP address or Unix domain socket name. [4] | `10.1.2.80`; `/tmp/my.sock` |
 | [`url.scheme`](/docs/registry/attributes/url.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` |
 
 **[1] `server.address`:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
@@ -960,6 +960,8 @@ This metric is optional.
 **[2] `server.port`:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
 
 **[3] `network.protocol.version`:** If protocol version is subject to negotiation (for example using [ALPN](https://www.rfc-editor.org/rfc/rfc7301.html)), this attribute SHOULD be set to the negotiated version. If the actual protocol version is not known, this attribute SHOULD NOT be set.
+
+**[4] `network.peer.address`:** `network.peer.address` is opt-in because it is typically high-cardinality (one time series per remote IP) and, combined with the cumulative temporality of UpDownCounter, can cause unbounded memory growth and metric stream accumulation in the SDK over the lifetime of the process.
 
 ---
 

--- a/docs/http/http-metrics.md
+++ b/docs/http/http-metrics.md
@@ -952,7 +952,7 @@ This metric is optional.
 | [`server.address`](/docs/registry/attributes/server.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Required` | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [1] | `example.com`; `10.1.2.80`; `/tmp/my.sock` |
 | [`server.port`](/docs/registry/attributes/server.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Required` | int | Server port number. [2] | `80`; `8080`; `443` |
 | [`network.protocol.version`](/docs/registry/attributes/network.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The actual version of the protocol used for network communication. [3] | `1.1`; `2` |
-| [`network.peer.address`](/docs/registry/attributes/network.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | Peer address of the network connection - IP address or Unix domain socket name. [4] | `10.1.2.80`; `/tmp/my.sock` |
+| [`network.peer.address`](/docs/registry/attributes/network.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | Peer address of the network connection - IP address or Unix domain socket name. | `10.1.2.80`; `/tmp/my.sock` |
 | [`url.scheme`](/docs/registry/attributes/url.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` |
 
 **[1] `server.address`:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
@@ -960,8 +960,6 @@ This metric is optional.
 **[2] `server.port`:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
 
 **[3] `network.protocol.version`:** If protocol version is subject to negotiation (for example using [ALPN](https://www.rfc-editor.org/rfc/rfc7301.html)), this attribute SHOULD be set to the negotiated version. If the actual protocol version is not known, this attribute SHOULD NOT be set.
-
-**[4] `network.peer.address`:** `network.peer.address` is opt-in because it is typically high-cardinality (one time series per remote IP) and, combined with the cumulative temporality of UpDownCounter, can cause unbounded memory growth and metric stream accumulation in the SDK over the lifetime of the process.
 
 ---
 

--- a/model/http/metrics.yaml
+++ b/model/http/metrics.yaml
@@ -178,11 +178,6 @@ groups:
         requirement_level: required
       - ref: network.peer.address
         requirement_level: opt_in
-        note: >
-          `network.peer.address` is opt-in because it is typically high-cardinality
-          (one time series per remote IP) and, combined with the cumulative temporality
-          of UpDownCounter, can cause unbounded memory growth and metric stream
-          accumulation in the SDK over the lifetime of the process.
       - ref: network.protocol.version
         requirement_level: recommended
       - ref: server.address

--- a/model/http/metrics.yaml
+++ b/model/http/metrics.yaml
@@ -177,7 +177,12 @@ groups:
       - ref: http.connection.state
         requirement_level: required
       - ref: network.peer.address
-        requirement_level: recommended
+        requirement_level: opt_in
+        note: >
+          `network.peer.address` is opt-in because it is typically high-cardinality
+          (one time series per remote IP) and, combined with the cumulative temporality
+          of UpDownCounter, can cause unbounded memory growth and metric stream
+          accumulation in the SDK over the lifetime of the process.
       - ref: network.protocol.version
         requirement_level: recommended
       - ref: server.address

--- a/model/http/metrics.yaml
+++ b/model/http/metrics.yaml
@@ -200,7 +200,7 @@ groups:
     unit: "s"
     attributes:
       - ref: network.peer.address
-        requirement_level: recommended
+        requirement_level: opt_in
       - ref: network.protocol.version
         requirement_level: recommended
       - ref: server.address


### PR DESCRIPTION
Towards #3279 (does not fully resolve it).

`http.client.open_connections` is a synchronous `UpDownCounter`, which is commonly exported with cumulative temporality. Combined with `network.peer.address` at `recommended`, this produces one persistent time series per remote IP for the lifetime of the process — even after connections close — leading to unbounded SDK memory growth, exhaustion of cardinality limits, and collapse of useful low-cardinality attributes (e.g. `url.scheme`) into the overflow bucket.

This PR moves `network.peer.address` from `Recommended` to `Opt-In` on `http.client.open_connections`.

A deeper fix will require a spec change. The proposed `finish()` / remove-series API (open-telemetry/opentelemetry-specification#4702) may also help address this in the future by letting instrumentations explicitly drop a series when the underlying entity (e.g. a connection) goes away.

/cc @open-telemetry/semconv-http-approvers @lmolkova @ManickaP @noahfalk