### PR TITLE
otel: clarify otel.sdk.span.live attribute values

### DIFF
--- a/.chloggen/sdk-span-live-non-recording.yaml
+++ b/.chloggen/sdk-span-live-non-recording.yaml
@@ -7,6 +7,6 @@ note: >
   can only take values `RECORD_ONLY` and `RECORD_AND_SAMPLE`, not `DROP`,
   since the metric does not count non-recording spans.
 
-issues: []
+issues: [3782]
 
 subtext:

--- a/.chloggen/sdk-span-live-non-recording.yaml
+++ b/.chloggen/sdk-span-live-non-recording.yaml
@@ -1,0 +1,12 @@
+change_type: enhancement
+
+component: otel
+
+note: >
+  Clarify that the `otel.span.sampling_result` attribute of `otel.sdk.span.live`
+  can only take values `RECORD_ONLY` and `RECORD_AND_SAMPLE`, not `DROP`,
+  since the metric does not count non-recording spans.
+
+issues: []
+
+subtext:

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -47,7 +47,9 @@ This metric is [recommended][MetricRecommended].
 
 | Name | Instrument Type | Unit (UCUM) | Description | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `otel.sdk.span.live` | UpDownCounter | `{span}` | The number of created spans with `recording=true` for which the end operation has not been called yet. | ![Development](https://img.shields.io/badge/-development-blue) | |
+| `otel.sdk.span.live` | UpDownCounter | `{span}` | The number of created spans with `recording=true` for which the end operation has not been called yet. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
+
+**[1]:** Non-recording spans are not counted, hence `otel.span.sampling_result` can only take values `RECORD_ONLY` and `RECORD_AND_SAMPLE`, not `DROP`.
 
 **Attributes:**
 

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -7,6 +7,8 @@ groups:
         metric_value_type: int
     stability: development
     brief: "The number of created spans with `recording=true` for which the end operation has not been called yet."
+    note: |
+      Non-recording spans are not counted, hence `otel.span.sampling_result` can only take values `RECORD_ONLY` and `RECORD_AND_SAMPLE`, not `DROP`.
     instrument: updowncounter
     unit: "{span}"
     attributes:


### PR DESCRIPTION
Adds a clarifying note to `otel.sdk.span.live` stating that its `otel.span.sampling_result` attribute can only take values `RECORD_ONLY` and `RECORD_AND_SAMPLE`, not `DROP`, because the metric does not count non-recording spans.