### PR TITLE
chore: add codeowner for js

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -191,7 +191,6 @@
 /docs/oracle-cloud                @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-oracle-cloud-approvers
 /model/oracle-cloud               @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-oracle-cloud-approvers
 
-
 # JavaScript semantic conventions
 /model/nodejs                     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approver
 /model/v8js                       @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approver

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -194,3 +194,5 @@
 # JavaScript semantic conventions
 /model/nodejs                     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approver
 /model/v8js                       @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approver
+/docs/runtime/v8js-metrics.md     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approver
+/docs/runtime/nodejs-metrics.md   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approver

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -190,3 +190,8 @@
 # Oracle Cloud Infrastructure semantic conventions
 /docs/oracle-cloud                @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-oracle-cloud-approvers
 /model/oracle-cloud               @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-oracle-cloud-approvers
+
+
+# JavaScript semantic conventions
+/model/nodejs                     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approver
+/model/v8js                       @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approver


### PR DESCRIPTION
Fixes #3780

## Changes

Update codeowners with the new created team `@open-telemetry/semconv-js-approver`

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [x] no AI used
  * [ ] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
