### PR TITLE
[chore] ci: Run workflow notification only on otel owner

### DIFF
--- a/.github/workflows/daily-link-check.yml
+++ b/.github/workflows/daily-link-check.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write
     needs:
       - link-check
-    if: always()
+    if: github.repository_owner == 'open-telemetry'
     uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
       success: ${{ needs.link-check.result == 'success' }}

--- a/.github/workflows/daily-link-check.yml
+++ b/.github/workflows/daily-link-check.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write
     needs:
       - link-check
-    if: github.repository_owner == 'open-telemetry'
+    if: always() && github.repository_owner == 'open-telemetry'
     uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
       success: ${{ needs.link-check.result == 'success' }}


### PR DESCRIPTION
## Changes

I believe the `if: always()` part of this job is causing it to attempt to run, but it will fail on forks unless they enable issues. 

Follow up to: #3605

Example workflow run from this branch: https://github.com/kaylareopelle/semantic-conventions/actions/runs/27358859199 

No related issue.

> [!IMPORTANT]
> Pull request acceptance is subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above may be automatically rejected and closed.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [ ] no AI used
  * [ ] AI-assisted
  * [ ] bulk AI-generated
* [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
