### PR TITLE
Align Oracle parameterized query capture with other databases

### DIFF
--- a/.chloggen/oracledb-query-text-example.yaml
+++ b/.chloggen/oracledb-query-text-example.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: db
+
+note: "Align Oracle Database `db.query.text` guidance with other SQL database conventions."
+
+subtext: |
+  Parameterized query text is now recommended to be collected by default, while
+  query parameter values remain opt-in.
+
+issues: [3790]

--- a/docs/db/oracledb.md
+++ b/docs/db/oracledb.md
@@ -46,7 +46,7 @@ Spans representing calls to a Oracle SQL Database adhere to the general [Semanti
 | [`db.operation.batch.size`](/docs/registry/attributes/db.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | int | The number of queries included in a batch operation. [8] | `2`; `3`; `4` |
 | [`db.operation.name`](/docs/registry/attributes/db.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` [9] | string | The name of the operation or command being executed. [10] | `EXECUTE`; `INSERT` |
 | [`db.query.summary`](/docs/registry/attributes/db.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` [11] | string | Low cardinality summary of a database query. [12] | `SELECT wuser_table`; `INSERT shipping_details SELECT orders`; `get user by id` |
-| [`db.query.text`](/docs/registry/attributes/db.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` [13] | string | The database query being executed. [14] | `SELECT * FROM wuser_table where username = :mykey` |
+| [`db.query.text`](/docs/registry/attributes/db.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` [13] | string | The database query being executed. [14] | `SELECT * FROM wuser_table where username = ?` |
 | [`db.stored_procedure.name`](/docs/registry/attributes/db.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` [15] | string | The name of a stored procedure within the database. [16] | `GetCustomer` |
 | [`oracle.db.domain`](/docs/registry/attributes/oracledb.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The database domain associated with the connection. [17] | `example.com`; `corp.internal`; `prod.db.local` |
 | [`oracle.db.instance.name`](/docs/registry/attributes/oracledb.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The instance name associated with the connection in an Oracle Real Application Clusters environment. [18] | `ORCL1`; `ORCL2`; `ORCL3` |
@@ -96,9 +96,12 @@ then that query summary SHOULD be used prepended by `BATCH `,
 otherwise `db.query.summary` SHOULD be `BATCH` or some other database
 system specific term if more applicable.
 
-**[13] `db.query.text`:** Non-parameterized query text SHOULD NOT be collected by default unless explicitly configured and sanitized to exclude sensitive data, e.g. by redacting all literal values present in the query text. See [Sanitization of `db.query.text`](/docs/db/database-spans.md#sanitization-of-dbquerytext). Parameterized query text MUST also NOT be collected by default unless explicitly configured. The query parameter values themselves are opt-in, see [`db.query.parameter.<key>`](../registry/attributes/db.md)).
+**[13] `db.query.text`:** Non-parameterized query text SHOULD NOT be collected by default unless there is sanitization that excludes sensitive data, e.g. by redacting all literal values present in the query text. See [Sanitization of `db.query.text`](/docs/db/database-spans.md#sanitization-of-dbquerytext).
+Parameterized query text SHOULD be collected by default (the query parameter values themselves are opt-in, see [`db.query.parameter.<key>`](/docs/registry/attributes/db.md)).
 
-**[14] `db.query.text`:** For sanitization see [Sanitization of `db.query.text`](/docs/db/database-spans.md#sanitization-of-dbquerytext). For batch operations, if the individual operations are known to have the same query text then that query text SHOULD be used, otherwise all of the individual query texts SHOULD be concatenated with separator `; ` or some other database system specific separator if more applicable.
+**[14] `db.query.text`:** For sanitization see [Sanitization of `db.query.text`](/docs/db/database-spans.md#sanitization-of-dbquerytext).
+For batch operations, if the individual operations are known to have the same query text then that query text SHOULD be used, otherwise all of the individual query texts SHOULD be concatenated with separator `; ` or some other database system specific separator if more applicable.
+Parameterized query text SHOULD NOT be sanitized. Even though parameterized query text can potentially have sensitive data, by using a parameterized query the user is giving a strong signal that any sensitive data will be passed as parameter values, and the benefit to observability of capturing the static part of the query text by default outweighs the risk.
 
 **[15] `db.stored_procedure.name`:** If operation applies to a specific stored procedure.
 

--- a/model/db/spans.yaml
+++ b/model/db/spans.yaml
@@ -1014,19 +1014,4 @@ groups:
           conventions. All Oracle Database error codes SHOULD be considered errors.
         examples: ["ORA-02813", "ORA-02613"]
       - ref: db.query.text
-        sampling_relevant: true
-        brief: >
-          The database query being executed.
-        requirement_level:
-          recommended: >
-            Non-parameterized query text SHOULD NOT be collected by default unless explicitly configured
-            and sanitized to exclude sensitive data, e.g. by redacting all literal values present
-            in the query text. See [Sanitization of `db.query.text`](/docs/db/database-spans.md#sanitization-of-dbquerytext).
-            Parameterized query text MUST also NOT be collected by default unless explicitly configured.
-            The query parameter values themselves are opt-in,
-            see [`db.query.parameter.<key>`](../registry/attributes/db.md)).
-        note: >
-          For sanitization see [Sanitization of `db.query.text`](/docs/db/database-spans.md#sanitization-of-dbquerytext).
-          For batch operations, if the individual operations are known to have the same query text then that query text SHOULD be used,
-          otherwise all of the individual query texts SHOULD be concatenated with separator `; ` or some other database system specific separator if more applicable.
-        examples: ["SELECT * FROM wuser_table where username = :mykey"]
+        examples: ["SELECT * FROM wuser_table where username = ?"]


### PR DESCRIPTION
Scouring Java database instrumentations as part of

- https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12608

and AI told me I wasn't compliant with Oracle semconv.

I suspect @lmolkova and I just missed this in #1911. This doc is still RC.

cc @sudarshan12s