### PR TITLE
Add kotlin to telemetry.sdk.language

### DIFF
--- a/.chloggen/add-kotlin.yaml
+++ b/.chloggen/add-kotlin.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: telemetry
+
+note: Add `kotlin` as a value for the `telemetry.sdk.language` attribute.
+
+issues: [3552]
+
+subtext:

--- a/docs/registry/attributes/telemetry.md
+++ b/docs/registry/attributes/telemetry.md
@@ -38,6 +38,7 @@ All custom identifiers SHOULD be stable across different versions of an implemen
 | `erlang` | erlang | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `go` | go | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `java` | java | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `kotlin` | kotlin | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `nodejs` | nodejs | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `php` | php | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `python` | python | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |

--- a/docs/registry/entities/telemetry.md
+++ b/docs/registry/entities/telemetry.md
@@ -55,6 +55,7 @@ All custom identifiers SHOULD be stable across different versions of an implemen
 | `erlang` | erlang | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `go` | go | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `java` | java | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `kotlin` | kotlin | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `nodejs` | nodejs | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `php` | php | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `python` | python | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |

--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -110,6 +110,7 @@ All custom identifiers SHOULD be stable across different versions of an implemen
 | `erlang` | erlang | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `go` | go | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `java` | java | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `kotlin` | kotlin | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `nodejs` | nodejs | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `php` | php | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
 | `python` | python | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |

--- a/model/telemetry/registry.yaml
+++ b/model/telemetry/registry.yaml
@@ -36,6 +36,9 @@ groups:
             - id: java
               value: "java"
               stability: stable
+            - id: kotlin
+              value: "kotlin"
+              stability: stable
             - id: nodejs
               value: "nodejs"
               stability: stable


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-kotlin/issues/600

## Changes

Just adds `kotlin` as an accepted `telemetry.sdk.language` value.

Codex was used to generate the changelog entry.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [ ] no AI used
  * [ ] AI-assisted
  * [ ] bulk AI-generated
* [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
