### PR TITLE
[chore] Switch to gh releases for weaver version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,9 +10,10 @@
       matchStrings: [
         "https://raw\\.githubusercontent\\.com/open-telemetry/weaver/(?<currentValue>v\\d+\\.\\d+\\.\\d+)/schemas/semconv\\.schema\\.json",
       ],
-      depNameTemplate: "otel/weaver",
-      datasourceTemplate: "docker",
-      versioningTemplate: "semver",
+      depNameTemplate: "open-telemetry/weaver",
+      datasourceTemplate: "github-releases",
+      versioningTemplate": "semver",
+      extractVersionTemplate: "^v(?<version>.*)$"
     },
   ],
   packageRules: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,7 @@
       ],
       depNameTemplate: "open-telemetry/weaver",
       datasourceTemplate: "github-releases",
-      versioningTemplate": "semver",
+      versioningTemplate: "semver",
       extractVersionTemplate: "^v(?<version>.*)$"
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,6 @@
       depNameTemplate: "open-telemetry/weaver",
       datasourceTemplate: "github-releases",
       versioningTemplate: "semver",
-      extractVersionTemplate: "^v(?<version>.*)$"
     },
   ],
   packageRules: [
@@ -27,7 +26,7 @@
       schedule: ["* 0-7 * * 2"], // weekly, before 8am on Tuesday
     },
     {
-      matchPackageNames: ["otel/**"],
+      matchPackageNames: ["otel/**", "open-telemetry/weaver"],
       schedule: ["at any time"],
     },
   ],


### PR DESCRIPTION
## Changes

This switches to sourcing the weaver version from gh releases as opposed to docker hub. This switch is to address the error shown in the renovate dashboard #2101 due to not being able to pin it.

![image](https://github.com/user-attachments/assets/c88f56cc-da7c-494f-8242-499e4dfc7638)

This is a transfer of what is working in the ruby contrib repo to keep semconv version up to date.

> [!IMPORTANT]
> Pull request acceptance is subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [x] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [x] no AI used
  * [ ] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
