### PR TITLE
Clarify db.query.parameter semantics around sensitive data handling

### DIFF
--- a/.chloggen/clarify-db-parameter-sanitization.yaml
+++ b/.chloggen/clarify-db-parameter-sanitization.yaml
@@ -1,0 +1,10 @@
+change_type: enhancement
+
+component: db
+
+note: >
+  Clarify `db.query.parameter.<key>` semantics around sensitive data handling.
+
+issues: [3831]
+
+subtext:

--- a/docs/db/cassandra.md
+++ b/docs/db/cassandra.md
@@ -163,8 +163,10 @@ up with the parameterized placeholders present in `db.query.text`.
 It is RECOMMENDED to capture the value as provided by the application
 without attempting to do any case normalization or sanitization.
 
-If sanitization is required for a parameter,
-`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
+Instrumentations SHOULD NOT capture `db.query.parameter.<key>` by default
+since values may contain PII or sensitive details.
+Application operators are expected to enable specific keys depending
+on their privacy and security considerations.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/cassandra.md
+++ b/docs/db/cassandra.md
@@ -161,7 +161,10 @@ then `<key>` SHOULD be the 0-based index.
 up with the parameterized placeholders present in `db.query.text`.
 
 It is RECOMMENDED to capture the value as provided by the application
-without attempting to do any case normalization.
+without attempting to do any case normalization or sanitization.
+
+If sanitization is required for a parameter,
+`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/cosmosdb.md
+++ b/docs/db/cosmosdb.md
@@ -257,7 +257,10 @@ then `<key>` SHOULD be the 0-based index.
 up with the parameterized placeholders present in `db.query.text`.
 
 It is RECOMMENDED to capture the value as provided by the application
-without attempting to do any case normalization.
+without attempting to do any case normalization or sanitization.
+
+If sanitization is required for a parameter,
+`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/cosmosdb.md
+++ b/docs/db/cosmosdb.md
@@ -259,8 +259,10 @@ up with the parameterized placeholders present in `db.query.text`.
 It is RECOMMENDED to capture the value as provided by the application
 without attempting to do any case normalization or sanitization.
 
-If sanitization is required for a parameter,
-`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
+Instrumentations SHOULD NOT capture `db.query.parameter.<key>` by default
+since values may contain PII or sensitive details.
+Application operators are expected to enable specific keys depending
+on their privacy and security considerations.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/database-spans.md
+++ b/docs/db/database-spans.md
@@ -247,8 +247,10 @@ up with the parameterized placeholders present in `db.query.text`.
 It is RECOMMENDED to capture the value as provided by the application
 without attempting to do any case normalization or sanitization.
 
-If sanitization is required for a parameter,
-`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
+Instrumentations SHOULD NOT capture `db.query.parameter.<key>` by default
+since values may contain PII or sensitive details.
+Application operators are expected to enable specific keys depending
+on their privacy and security considerations.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/database-spans.md
+++ b/docs/db/database-spans.md
@@ -245,7 +245,10 @@ then `<key>` SHOULD be the 0-based index.
 up with the parameterized placeholders present in `db.query.text`.
 
 It is RECOMMENDED to capture the value as provided by the application
-without attempting to do any case normalization.
+without attempting to do any case normalization or sanitization.
+
+If sanitization is required for a parameter,
+`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/mariadb.md
+++ b/docs/db/mariadb.md
@@ -144,8 +144,10 @@ up with the parameterized placeholders present in `db.query.text`.
 It is RECOMMENDED to capture the value as provided by the application
 without attempting to do any case normalization or sanitization.
 
-If sanitization is required for a parameter,
-`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
+Instrumentations SHOULD NOT capture `db.query.parameter.<key>` by default
+since values may contain PII or sensitive details.
+Application operators are expected to enable specific keys depending
+on their privacy and security considerations.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/mariadb.md
+++ b/docs/db/mariadb.md
@@ -142,7 +142,10 @@ then `<key>` SHOULD be the 0-based index.
 up with the parameterized placeholders present in `db.query.text`.
 
 It is RECOMMENDED to capture the value as provided by the application
-without attempting to do any case normalization.
+without attempting to do any case normalization or sanitization.
+
+If sanitization is required for a parameter,
+`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/mysql.md
+++ b/docs/db/mysql.md
@@ -144,8 +144,10 @@ up with the parameterized placeholders present in `db.query.text`.
 It is RECOMMENDED to capture the value as provided by the application
 without attempting to do any case normalization or sanitization.
 
-If sanitization is required for a parameter,
-`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
+Instrumentations SHOULD NOT capture `db.query.parameter.<key>` by default
+since values may contain PII or sensitive details.
+Application operators are expected to enable specific keys depending
+on their privacy and security considerations.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/mysql.md
+++ b/docs/db/mysql.md
@@ -142,7 +142,10 @@ then `<key>` SHOULD be the 0-based index.
 up with the parameterized placeholders present in `db.query.text`.
 
 It is RECOMMENDED to capture the value as provided by the application
-without attempting to do any case normalization.
+without attempting to do any case normalization or sanitization.
+
+If sanitization is required for a parameter,
+`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/oracledb.md
+++ b/docs/db/oracledb.md
@@ -164,7 +164,10 @@ then `<key>` SHOULD be the 0-based index.
 up with the parameterized placeholders present in `db.query.text`.
 
 It is RECOMMENDED to capture the value as provided by the application
-without attempting to do any case normalization.
+without attempting to do any case normalization or sanitization.
+
+If sanitization is required for a parameter,
+`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/oracledb.md
+++ b/docs/db/oracledb.md
@@ -166,8 +166,10 @@ up with the parameterized placeholders present in `db.query.text`.
 It is RECOMMENDED to capture the value as provided by the application
 without attempting to do any case normalization or sanitization.
 
-If sanitization is required for a parameter,
-`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
+Instrumentations SHOULD NOT capture `db.query.parameter.<key>` by default
+since values may contain PII or sensitive details.
+Application operators are expected to enable specific keys depending
+on their privacy and security considerations.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/postgresql.md
+++ b/docs/db/postgresql.md
@@ -150,7 +150,10 @@ then `<key>` SHOULD be the 0-based index.
 up with the parameterized placeholders present in `db.query.text`.
 
 It is RECOMMENDED to capture the value as provided by the application
-without attempting to do any case normalization.
+without attempting to do any case normalization or sanitization.
+
+If sanitization is required for a parameter,
+`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/postgresql.md
+++ b/docs/db/postgresql.md
@@ -152,8 +152,10 @@ up with the parameterized placeholders present in `db.query.text`.
 It is RECOMMENDED to capture the value as provided by the application
 without attempting to do any case normalization or sanitization.
 
-If sanitization is required for a parameter,
-`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
+Instrumentations SHOULD NOT capture `db.query.parameter.<key>` by default
+since values may contain PII or sensitive details.
+Application operators are expected to enable specific keys depending
+on their privacy and security considerations.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/sql-server.md
+++ b/docs/db/sql-server.md
@@ -149,7 +149,10 @@ then `<key>` SHOULD be the 0-based index.
 up with the parameterized placeholders present in `db.query.text`.
 
 It is RECOMMENDED to capture the value as provided by the application
-without attempting to do any case normalization.
+without attempting to do any case normalization or sanitization.
+
+If sanitization is required for a parameter,
+`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/sql-server.md
+++ b/docs/db/sql-server.md
@@ -151,8 +151,10 @@ up with the parameterized placeholders present in `db.query.text`.
 It is RECOMMENDED to capture the value as provided by the application
 without attempting to do any case normalization or sanitization.
 
-If sanitization is required for a parameter,
-`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
+Instrumentations SHOULD NOT capture `db.query.parameter.<key>` by default
+since values may contain PII or sensitive details.
+Application operators are expected to enable specific keys depending
+on their privacy and security considerations.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/sql.md
+++ b/docs/db/sql.md
@@ -201,8 +201,10 @@ up with the parameterized placeholders present in `db.query.text`.
 It is RECOMMENDED to capture the value as provided by the application
 without attempting to do any case normalization or sanitization.
 
-If sanitization is required for a parameter,
-`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
+Instrumentations SHOULD NOT capture `db.query.parameter.<key>` by default
+since values may contain PII or sensitive details.
+Application operators are expected to enable specific keys depending
+on their privacy and security considerations.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/db/sql.md
+++ b/docs/db/sql.md
@@ -199,7 +199,10 @@ then `<key>` SHOULD be the 0-based index.
 up with the parameterized placeholders present in `db.query.text`.
 
 It is RECOMMENDED to capture the value as provided by the application
-without attempting to do any case normalization.
+without attempting to do any case normalization or sanitization.
+
+If sanitization is required for a parameter,
+`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/registry/attributes/db.md
+++ b/docs/registry/attributes/db.md
@@ -97,8 +97,10 @@ up with the parameterized placeholders present in `db.query.text`.
 It is RECOMMENDED to capture the value as provided by the application
 without attempting to do any case normalization or sanitization.
 
-If sanitization is required for a parameter,
-`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
+Instrumentations SHOULD NOT capture `db.query.parameter.<key>` by default
+since values may contain PII or sensitive details.
+Application operators are expected to enable specific keys depending
+on their privacy and security considerations.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/docs/registry/attributes/db.md
+++ b/docs/registry/attributes/db.md
@@ -95,7 +95,10 @@ then `<key>` SHOULD be the 0-based index.
 up with the parameterized placeholders present in `db.query.text`.
 
 It is RECOMMENDED to capture the value as provided by the application
-without attempting to do any case normalization.
+without attempting to do any case normalization or sanitization.
+
+If sanitization is required for a parameter,
+`db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
 
 `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/model/db/registry.yaml
+++ b/model/db/registry.yaml
@@ -94,8 +94,10 @@ groups:
           It is RECOMMENDED to capture the value as provided by the application
           without attempting to do any case normalization or sanitization.
 
-          If sanitization is required for a parameter,
-          `db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
+          Instrumentations SHOULD NOT capture `db.query.parameter.<key>` by default
+          since values may contain PII or sensitive details.
+          Application operators are expected to enable specific keys depending
+          on their privacy and security considerations.
 
           `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 

--- a/model/db/registry.yaml
+++ b/model/db/registry.yaml
@@ -92,7 +92,10 @@ groups:
           up with the parameterized placeholders present in `db.query.text`.
 
           It is RECOMMENDED to capture the value as provided by the application
-          without attempting to do any case normalization.
+          without attempting to do any case normalization or sanitization.
+
+          If sanitization is required for a parameter,
+          `db.query.parameter.<key>` SHOULD NOT be captured for that parameter.
 
           `db.query.parameter.<key>` SHOULD NOT be captured on batch operations.
 


### PR DESCRIPTION
Follow-up to https://github.com/open-telemetry/semantic-conventions/pull/3790#discussion_r3470153316

Clarifies `db.query.parameter.<key>` semantics around sensitive data handling.
