### PR TITLE
Added annotation to exclude mainframe and zos definitions from depend…

### DIFF
--- a/model/mainframe/registry_lpar.yaml
+++ b/model/mainframe/registry_lpar.yaml
@@ -1,5 +1,8 @@
 groups:
   - id: registry.mainframe.lpar
+    annotations:
+      dependency_resolution:
+        exclude: true
     type: attribute_group
     display_name: Mainframe LPAR attributes
     brief: This document defines attributes of a Mainframe Logical Partition (LPAR).

--- a/model/mainframe/registry_lpar.yaml
+++ b/model/mainframe/registry_lpar.yaml
@@ -1,13 +1,13 @@
 groups:
   - id: registry.mainframe.lpar
-    annotations:
-      dependency_resolution:
-        exclude: true
     type: attribute_group
     display_name: Mainframe LPAR attributes
     brief: This document defines attributes of a Mainframe Logical Partition (LPAR).
     attributes:
       - id: mainframe.lpar.name
+        annotations:
+          dependency_resolution:
+            exclude: true
         type: string
         stability: development
         brief: "Name of the logical partition that hosts a systems with a mainframe operating system."

--- a/model/zos/common.yaml
+++ b/model/zos/common.yaml
@@ -1,5 +1,8 @@
 groups:
   - id: service.zos.software
+    annotations:
+      dependency_resolution:
+        exclude: true
     type: attribute_group
     stability: development
     name: service.zos.software
@@ -22,7 +25,10 @@ groups:
         examples: 'CICSPLX2'
         requirement_level: required
   - id: process.zos
-    type: attribute_group
+    annotations:
+      dependency_resolution:
+        exclude: true
+    type: attribute_group    
     stability: development
     name: process.zos
     brief: A process running on a z/OS system.
@@ -49,6 +55,9 @@ groups:
         examples: '5.6'
         requirement_level: opt_in
   - id: os.zos
+    annotations:
+      dependency_resolution:
+        exclude: true
     type: attribute_group
     stability: development
     name: os.zos
@@ -68,6 +77,9 @@ groups:
         brief: 'The version string of the operating system. On z/OS, SHOULD be the release returned by the command `d iplinfo`.'
         examples: '3.1.0'
   - id: host.zos
+    annotations:
+      dependency_resolution:
+        exclude: true
     type: attribute_group
     stability: development
     name: host.zos

--- a/model/zos/common.yaml
+++ b/model/zos/common.yaml
@@ -55,9 +55,6 @@ groups:
         examples: '5.6'
         requirement_level: opt_in
   - id: os.zos
-    annotations:
-      dependency_resolution:
-        exclude: true
     type: attribute_group
     stability: development
     name: os.zos
@@ -77,9 +74,6 @@ groups:
         brief: 'The version string of the operating system. On z/OS, SHOULD be the release returned by the command `d iplinfo`.'
         examples: '3.1.0'
   - id: host.zos
-    annotations:
-      dependency_resolution:
-        exclude: true
     type: attribute_group
     stability: development
     name: host.zos

--- a/model/zos/common.yaml
+++ b/model/zos/common.yaml
@@ -1,8 +1,5 @@
 groups:
   - id: service.zos.software
-    annotations:
-      dependency_resolution:
-        exclude: true
     type: attribute_group
     stability: development
     name: service.zos.software
@@ -25,9 +22,6 @@ groups:
         examples: 'CICSPLX2'
         requirement_level: required
   - id: process.zos
-    annotations:
-      dependency_resolution:
-        exclude: true
     type: attribute_group
     stability: development
     name: process.zos

--- a/model/zos/common.yaml
+++ b/model/zos/common.yaml
@@ -28,7 +28,7 @@ groups:
     annotations:
       dependency_resolution:
         exclude: true
-    type: attribute_group    
+    type: attribute_group
     stability: development
     name: process.zos
     brief: A process running on a z/OS system.

--- a/model/zos/entities.yaml
+++ b/model/zos/entities.yaml
@@ -1,5 +1,8 @@
 groups:
   - id: entity.zos.software
+    annotations:
+      dependency_resolution:
+        exclude: true
     type: entity
     stability: development
     name: zos.software

--- a/model/zos/registry.yaml
+++ b/model/zos/registry.yaml
@@ -1,19 +1,22 @@
 groups:
   - id: registry.zos
-    annotations:
-      dependency_resolution:
-        exclude: true
     type: attribute_group
     display_name: z/OS attributes
     brief: >
       This document defines attributes of a z/OS resource.
     attributes:
       - id: zos.smf.id
+        annotations:
+          dependency_resolution:
+            exclude: true
         type: string
         stability: development
         brief: "The System Management Facility (SMF) Identifier uniquely identified a z/OS system within a SYSPLEX or mainframe environment and is used for system and performance analysis."
         examples: ["SYS1"]
       - id: zos.sysplex.name
+        annotations:
+          dependency_resolution:
+            exclude: true
         type: string
         stability: development
         brief: "The name of the SYSPLEX to which the z/OS system belongs too."

--- a/model/zos/registry.yaml
+++ b/model/zos/registry.yaml
@@ -1,5 +1,8 @@
 groups:
   - id: registry.zos
+    annotations:
+      dependency_resolution:
+        exclude: true
     type: attribute_group
     display_name: z/OS attributes
     brief: >


### PR DESCRIPTION
…ency resolution, as they will move to a federated repo

Fixes #

## Changes

Please provide a brief description of the changes here.

As we move to Mainframe Semantic Convention to a federated repo, prepared that the related conventions are not considered in the dependency resolution.


> [!IMPORTANT]
> Pull request acceptance is subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above may be automatically rejected and closed.

## Merge requirement checklist

* [ x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [x] no AI used
  * [ ] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
