### PR TITLE
docs: clarify Hugo linkTitle guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,9 +220,13 @@ linkTitle: HTTP
 --->
 ```
 
-When creating new markdown files, you should provide the `linkTitle` attribute.
-This is used to generate the navigation bar on the website,
-and will be listed relative to the "parent" document.
+Set `linkTitle` when adding a new Markdown file. It drives the website navigation, and shows up relative to the parent document, so it's easy to miss until someone points it out in review.
+
+Keep it short. Something like `Spans` or `Metrics` works better than spelling out the full convention name again.
+
+Sentence case is the default, but if the name is an established acronym or product name, keep its usual capitalization.
+
+Also, when renaming or moving files under `docs/`, make sure nothing on the website or any relative links still point to the old path.
 
 ### 3. Check new convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,7 +226,6 @@ Keep it short. Something like `Spans` or `Metrics` works better than spelling ou
 
 Sentence case is the default, but if the name is an established acronym or product name, keep its usual capitalization.
 
-Also, when renaming or moving files under `docs/`, make sure nothing on the website or any relative links still point to the old path.
 
 ### 3. Check new convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,11 +220,17 @@ linkTitle: HTTP
 --->
 ```
 
-Set `linkTitle` when adding a new Markdown file. It drives the [website navigation](https://opentelemetry.io/docs/specs/semconv/) and shows up relative to the parent document.
+`linkTitle` is a short version of the page's title, shown in the website's
+[left side navigation][docsy-nav]. When adding a new Markdown file, keep it to
+the sub-area name -- for example, `Spans`, `Metrics`, or `Resources` -- instead of
+repeating the page's full title. Omit `linkTitle` when it would be identical to
+the title.
 
-Keep it short. Something like `Spans` or `Metrics` works better than spelling out the full convention name again.
+For title and heading capitalization, follow the
+[OpenTelemetry documentation style guide][otel-style-guide].
 
-Sentence case is the default, but if the name is an established acronym or product name, keep its usual capitalization.
+[docsy-nav]: https://www.docsy.dev/docs/content/navigation/#side-nav
+[otel-style-guide]: https://opentelemetry.io/docs/contributing/style-guide/
 
 ### 3. Check new convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,7 +220,7 @@ linkTitle: HTTP
 --->
 ```
 
-Set `linkTitle` when adding a new Markdown file. It drives the website navigation, and shows up relative to the parent document, so it's easy to miss until someone points it out in review.
+Set `linkTitle` when adding a new Markdown file. It drives the [website navigation](https://opentelemetry.io/docs/specs/semconv/) and shows up relative to the parent document.
 
 Keep it short. Something like `Spans` or `Metrics` works better than spelling out the full convention name again.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,7 +226,6 @@ Keep it short. Something like `Spans` or `Metrics` works better than spelling ou
 
 Sentence case is the default, but if the name is an established acronym or product name, keep its usual capitalization.
 
-
 ### 3. Check new convention
 
 Semantic conventions are validated for name formatting and backward compatibility with last released versions.


### PR DESCRIPTION
Refs #1834

## Changes

Clarified the Hugo front-matter section in `CONTRIBUTING.md`.

The old text explained that new Markdown files should have `linkTitle`, but it did not say much about how contributors should actually choose one. This update makes the guidance more practical:

- `linkTitle` is a short version of the page title shown in the website's left side navigation
- contributors should prefer short sub-area names such as `Spans`, `Metrics`, or `Resources`
- `linkTitle` should be omitted when it would be identical to the page title
- title and heading capitalization should follow the OpenTelemetry documentation style guide

> [!IMPORTANT]
> Pull request acceptance is subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [ ] no AI used
  * [x] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
