### PR TITLE
Exclude mcp attributes from dependency resolution

### DIFF
--- a/model/mcp/deprecated/registry-deprecated.yaml
+++ b/model/mcp/deprecated/registry-deprecated.yaml
@@ -153,6 +153,9 @@ groups:
           reason: uncategorized
           note: >
             Moved to the [OpenTelemetry GenAI semantic conventions repository](https://github.com/open-telemetry/semantic-conventions-genai).
+        annotations:
+          dependency_resolution:
+            exclude: true
         type: string
         brief: Identifies [MCP session](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management).
         stability: development
@@ -177,6 +180,9 @@ groups:
           reason: uncategorized
           note: >
             Moved to the [OpenTelemetry GenAI semantic conventions repository](https://github.com/open-telemetry/semantic-conventions-genai).
+        annotations:
+          dependency_resolution:
+            exclude: true
         type: string
         brief: The [version](https://modelcontextprotocol.io/specification/versioning) of the Model Context Protocol used.
         stability: development


### PR DESCRIPTION
Missed a couple of MCP attributes in https://github.com/open-telemetry/semantic-conventions/pull/3824, excluding them from dependency resolution here
