### PR TITLE
Make usages of pull-request-target safe

### DIFF
--- a/.github/scripts/prepare-new-pr.sh
+++ b/.github/scripts/prepare-new-pr.sh
@@ -31,7 +31,7 @@ if [ $COUNT -eq 1 ]; then
     # trusted "pull_request_target" context, and GITHUB_REPOSITORY (the base repo)
     # can access the PR head commit by SHA.
     HEAD_SHA="$(gh pr view "$PR" --json headRefOid --jq '.headRefOid')"
-    CHLOG_CONTENT="$(gh api "repos/${GITHUB_REPOSITORY}/contents/${CHLOG}?ref=${HEAD_SHA}" --jq '.content' | base64 -d)"
+    CHLOG_CONTENT="$(gh api "repos/${GITHUB_REPOSITORY}/contents/${CHLOG}?ref=${HEAD_SHA}" --jq '.content' | (base64 -d 2>/dev/null || base64 -D 2>/dev/null))"
 
     CHANGE_TYPE=$(echo "$CHLOG_CONTENT" | awk -F': ' '/^change_type:/ {print $2}' | xargs)
     echo $CHANGE_TYPE

--- a/.github/scripts/prepare-new-pr.sh
+++ b/.github/scripts/prepare-new-pr.sh
@@ -16,11 +16,6 @@ if [ -z ${PR:-} ]; then
     exit 1
 fi
 
-if [ -z ${PR_CHANGELOG_PATH:-} ]; then
-    echo "PR_CHANGELOG_PATH is required"
-    exit 1
-fi
-
 CHLOG="$(gh pr view $PR --json files --jq '.files.[].path | select (. | startswith(".chloggen/"))')"
 echo "Change log file(s): ${CHLOG}"
 
@@ -31,10 +26,17 @@ fi
 
 COUNT="$(echo "$CHLOG" | wc -l)"
 if [ $COUNT -eq 1 ]; then
-    CHANGE_TYPE=$(awk -F': ' '/^change_type:/ {print $2}' "$PR_CHANGELOG_PATH/$CHLOG" | xargs)
+    # Fetch the changelog file content from the PR head commit via the API rather
+    # than checking out the (untrusted) fork code. This workflow runs in the
+    # trusted "pull_request_target" context, and GITHUB_REPOSITORY (the base repo)
+    # can access the PR head commit by SHA.
+    HEAD_SHA="$(gh pr view "$PR" --json headRefOid --jq '.headRefOid')"
+    CHLOG_CONTENT="$(gh api "repos/${GITHUB_REPOSITORY}/contents/${CHLOG}?ref=${HEAD_SHA}" --jq '.content' | base64 -d)"
+
+    CHANGE_TYPE=$(echo "$CHLOG_CONTENT" | awk -F': ' '/^change_type:/ {print $2}' | xargs)
     echo $CHANGE_TYPE
     gh pr edit "${PR}" --add-label "${CHANGE_TYPE}" || true
-    AREA=$(awk -F': ' '/^component:/ {print $2}' "$PR_CHANGELOG_PATH/$CHLOG" | xargs)
+    AREA=$(echo "$CHLOG_CONTENT" | awk -F': ' '/^component:/ {print $2}' | xargs)
     echo $AREA
     if [[ "$AREA" == \[*\] ]]; then
       cleaned=$(echo "$AREA" | tr -d '[]' | tr ',' '\n')

--- a/.github/workflows/check-changes-ownership.yml
+++ b/.github/workflows/check-changes-ownership.yml
@@ -14,23 +14,35 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
-      changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
+      changed_files: ${{ steps.changed-files.outputs.changed_files }}
       any_changed: ${{ steps.changed-files.outputs.any_changed }}
     steps:
-       # Checkout the PR branch only to get the changed files from the .git folder
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          fetch-depth: 0
-      - name: Get changed files
+      # Determine the changed directories under model/ from the GitHub API.
+      # This intentionally does NOT check out the (untrusted) fork PR code:
+      # this workflow runs in the trusted "pull_request_target" context, so
+      # fetching and executing fork code here would be a "pwn request" risk.
+      - name: Get changed model directories
         id: changed-files
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        with:
-          dir_names: "true"
-          files: model/**
-          separator: ","
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          changed_files=$(gh api --paginate \
+            "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' \
+            | grep -E '^model/' \
+            | xargs -r -L1 dirname \
+            | sort -u \
+            | paste -sd, -)
+          echo "changed_files=${changed_files}" >> "$GITHUB_OUTPUT"
+          if [ -n "${changed_files}" ]; then
+            echo "any_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any_changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
   validate-area-ownership:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-changes-ownership.yml
+++ b/.github/workflows/check-changes-ownership.yml
@@ -33,8 +33,7 @@ jobs:
           changed_files=$(gh api --paginate \
             "repos/${REPO}/pulls/${PR_NUMBER}/files" \
             --jq '.[].filename' \
-            | grep -E '^model/' \
-            | xargs -r -L1 dirname \
+            | sed -n 's|^\(model/[^/][^/]*\)/.*|\1|p' \
             | sort -u \
             | paste -sd, -)
           echo "changed_files=${changed_files}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prepare-new-pr.yml
+++ b/.github/workflows/prepare-new-pr.yml
@@ -16,15 +16,11 @@ jobs:
       pull-requests: write
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
-      # check out main
+      # Check out the base repo (main) only, so we run our own trusted script.
+      # We do NOT check out the fork PR code: this workflow runs in the trusted
+      # "pull_request_target" context, so the changelog file is read via the
+      # GitHub API inside the script instead.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      # sparse checkout to only get the .chloggen directory
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.head_ref }}
-          path: prchangelog
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          sparse-checkout: .chloggen
 
       # we're going to run prepare-new-pr script from the main branch
       # to parse changelog record from the PR branch.
@@ -33,4 +29,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
-          PR_CHANGELOG_PATH: prchangelog

--- a/.github/workflows/prepare-new-pr.yml
+++ b/.github/workflows/prepare-new-pr.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       # Check out the base repo (main) only, so we run our own trusted script.
-      # We do NOT check out the fork PR code: this workflow runs in the trusted
+      # We do NOT check out the fork PR code: this workflow runs in the 
       # "pull_request_target" context, so the changelog file is read via the
       # GitHub API inside the script instead.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
CI fails with 

> Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

on [Check changes ownership](https://github.com/open-telemetry/semantic-conventions/actions/workflows/check-changes-ownership.yml) and [Prepare new PR](https://github.com/open-telemetry/semantic-conventions/actions/workflows/prepare-new-pr.yml)

none of them really needs to check out fork.

One only needs names of changed files and another only needs chloggen folder. We can use github api to get those instead of checking out forks.

All credit goes to AI, pretty smart bot.