### PR TITLE
Convert "areas drop-down generation" make target to schema V2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,7 @@ generate-gh-issue-templates:
 	$(WEAVER_CONTAINER) registry generate \
 		--registry=/home/weaver/source \
 		--templates=/home/weaver/templates \
+		--v2 \
 		areas \
 		/home/weaver/target
 	$(TOOLS_DIR)/scripts/update-issue-template-areas.sh $(PWD)/internal/tools/bin/areas.txt

--- a/internal/tools/scripts/registry/areas/areas.md.j2
+++ b/internal/tools/scripts/registry/areas/areas.md.j2
@@ -1,5 +1,5 @@
 {{- template.set_file_name("areas.txt") -}}
 
-{% for item in ctx | map('map_text', 'areas') | unique | sort  %}
-area:{{ item | kebab_case }}
+{% for root_namespace in ctx | map('map_text', 'areas') | unique | sort  %}
+area:{{ root_namespace | kebab_case }}
 {% endfor %}

--- a/internal/tools/scripts/registry/areas/weaver.yaml
+++ b/internal/tools/scripts/registry/areas/weaver.yaml
@@ -1,7 +1,7 @@
 templates:
   - pattern: areas.md.j2
     filter: >
-      semconv_grouped_attributes({"exclude_deprecated": true}) | .[].root_namespace
+      semconv_grouped_attributes({"v2": true, "exclude_deprecated": true}) | map(.root_namespace)
     application_mode: single
 whitespace_control:
   trim_blocks: true


### PR DESCRIPTION
Part of #3808

Migrate the target that generates the `areas.txt` used by the issue template and other automations to schema V2.