### PR TITLE
Fix 'reverse proxy lookup' wording in rpc spans

### DIFF
--- a/.chloggen/fix-rpc-reverse-dns-lookup.yaml
+++ b/.chloggen/fix-rpc-reverse-dns-lookup.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: rpc
+
+note: >
+  Fix wording in `server.address` note to say "reverse DNS lookup" instead of
+  "reverse proxy lookup".
+
+issues: [3871]
+
+subtext:

--- a/docs/rpc/connect-rpc.md
+++ b/docs/rpc/connect-rpc.md
@@ -54,7 +54,7 @@ document for details on how to record span status.
 | [`rpc.request.metadata.<key>`](/docs/registry/attributes/rpc.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string[] | RPC request metadata, `<key>` being the normalized RPC metadata key (lowercase), the value being the metadata values. [7] | `["1.2.3.4", "1.2.3.5"]` |
 | [`rpc.response.metadata.<key>`](/docs/registry/attributes/rpc.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string[] | RPC response metadata, `<key>` being the normalized RPC metadata key (lowercase), the value being the metadata values. [8] | `["attribute_value"]` |
 
-**[1] `server.address`:** When an IP address is provided instead of a domain name, instrumentations SHOULD NOT do a reverse proxy lookup to obtain DNS name and SHOULD set `server.address` to the provided IP address.
+**[1] `server.address`:** When an IP address is provided instead of a domain name, instrumentations SHOULD NOT do a reverse DNS lookup to obtain DNS name and SHOULD set `server.address` to the provided IP address.
 
 **[2] `error.type`:** If the RPC fails with an error before status code is returned,
 `error.type` SHOULD be set to the exception type (its fully-qualified class name, if applicable)

--- a/docs/rpc/grpc.md
+++ b/docs/rpc/grpc.md
@@ -105,7 +105,7 @@ from the target string, it SHOULD set `server.address` to the entire
 target string and SHOULD NOT set `server.port`.
 
 When the address is an IP address, instrumentations SHOULD NOT do a
-reverse proxy lookup to obtain a DNS name and SHOULD set `server.address`
+reverse DNS lookup to obtain a DNS name and SHOULD set `server.address`
 to the IP address provided.
 
 Examples:

--- a/model/rpc/spans.yaml
+++ b/model/rpc/spans.yaml
@@ -109,7 +109,7 @@ groups:
         requirement_level: required
         note: >
           When an IP address is provided instead of a domain name,
-          instrumentations SHOULD NOT do a reverse proxy lookup to obtain DNS
+          instrumentations SHOULD NOT do a reverse DNS lookup to obtain DNS
           name and SHOULD set `server.address` to the provided IP address.
       - ref: server.port
         requirement_level:
@@ -197,7 +197,7 @@ groups:
           target string and SHOULD NOT set `server.port`.
 
           When the address is an IP address, instrumentations SHOULD NOT do a
-          reverse proxy lookup to obtain a DNS name and SHOULD set `server.address`
+          reverse DNS lookup to obtain a DNS name and SHOULD set `server.address`
           to the IP address provided.
 
           Examples:


### PR DESCRIPTION
Fixes the `server.address` note wording in the Connect RPC and gRPC spans to say "reverse DNS lookup" instead of "reverse proxy lookup".

Addresses the nit in https://github.com/open-telemetry/semantic-conventions/issues/3871#issuecomment-4926103502.