### PR TITLE
[k8s]: update migration guide with label/annotation changes

### DIFF
--- a/docs/non-normative/k8s-migration.md
+++ b/docs/non-normative/k8s-migration.md
@@ -69,6 +69,7 @@ and one for disabling the old schema called `semconv.k8s.disableLegacy`. Then:
   - [K8s Node memory metrics](#k8s-node-memory-metrics)
   - [Container Runtime](#container-runtime)
   - [K8s Pod Status Phase and Reason](#k8s-pod-status-phase-and-reason)
+  - [K8s labels and annotations](#k8s-labels-and-annotations)
 
 <!-- tocstop -->
 
@@ -530,5 +531,36 @@ The changes in their metrics are the following:
 | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | `k8s.pod.status_reason`    metric [1,6]                                            | `k8s.pod.status.reason` metric [0,1] with attribute `k8s.pod.status.reason` for the different reasons |
 | `k8s.pod.phase`       metric [1, 5]                                                | `k8s.pod.status.phase` metric [0,1] with attribute `k8s.pod.phase` for the different phases           |
+
+<!-- prettier-ignore-end -->
+
+### K8s labels and annotations
+
+The K8s label and annotation attributes implemented by the Collector and specifically the
+[k8sattributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md)
+processor were introduced as semantic conventions in
+[#625](https://github.com/open-telemetry/semantic-conventions/pull/625) (Pod),
+[#2130](https://github.com/open-telemetry/semantic-conventions/pull/2130) (Node) and
+[#2166](https://github.com/open-telemetry/semantic-conventions/pull/2166) (Namespace).
+
+Unlike the receivers described above, the k8sattributes processor gates this transition behind
+its own feature gates, `processor.k8sattributes.EmitV1K8sConventions` and
+`processor.k8sattributes.DontEmitV0K8sConventions`, rather than the
+`OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. See the processor's
+[Semantic Conventions Compatibility](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md#semantic-conventions-compatibility)
+documentation for details.
+
+The changes in these attributes are the following:
+
+<!-- prettier-ignore-start -->
+
+| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New                              |
+| ---------------------------------------------------------------------------------- | -------------------------------- |
+| `k8s.pod.labels.<key>`                                                             | `k8s.pod.label.<key>`            |
+| `k8s.pod.annotations.<key>`                                                        | `k8s.pod.annotation.<key>`       |
+| `k8s.node.labels.<key>`                                                            | `k8s.node.label.<key>`           |
+| `k8s.node.annotations.<key>`                                                       | `k8s.node.annotation.<key>`      |
+| `k8s.namespace.labels.<key>`                                                       | `k8s.namespace.label.<key>`      |
+| `k8s.namespace.annotations.<key>`                                                  | `k8s.namespace.annotation.<key>` |
 
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
## Changes

I noticed that the migration guide did not contain the breaking changes for the now stable `k8s.*.label.*` and `k8s.*.annotation.*` semantics. This PR adds a section explaining the changes and how the k8sattributesprocessor is implementing them.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [x] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [ ] no AI used
  * [ ] AI-assisted
  * [x] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
