### PR TITLE
[k8s] Change memory.usage from gauge to updowncounter

### DIFF
--- a/.chloggen/fix_mem_usage_instr.yaml
+++ b/.chloggen/fix_mem_usage_instr.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: k8s
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change {container, k8s.pod, k8s.node}.memory.usage from gauge to updowncounter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [3889]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/fix_mem_usage_instr.yaml
+++ b/.chloggen/fix_mem_usage_instr.yaml
@@ -10,7 +10,7 @@ change_type: breaking
 component: k8s
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Change {container, k8s.pod, k8s.node}.memory.usage from gauge to updowncounter
+note: Change {container, k8s.pod, k8s.node}.memory.usage to updowncounter
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/docs/non-normative/k8s-migration.md
+++ b/docs/non-normative/k8s-migration.md
@@ -70,6 +70,7 @@ and one for disabling the old schema called `semconv.k8s.disableLegacy`. Then:
   - [Container Runtime](#container-runtime)
   - [K8s Pod Status Phase and Reason](#k8s-pod-status-phase-and-reason)
   - [K8s labels and annotations](#k8s-labels-and-annotations)
+  - [K8s Pod/Node and Container Memory Usage](#k8s-podnode-and-container-memory-usage)
 
 <!-- END doctoc -->
 
@@ -567,5 +568,25 @@ The changes in these attributes are the following:
 | `k8s.node.annotations.<key>`                                                       | `k8s.node.annotation.<key>`      |
 | `k8s.namespace.labels.<key>`                                                       | `k8s.namespace.label.<key>`      |
 | `k8s.namespace.annotations.<key>`                                                  | `k8s.namespace.annotation.<key>` |
+
+<!-- prettier-ignore-end -->
+
+### K8s Pod/Node and Container Memory Usage
+
+The memory usage metrics implemented by the Collector and specifically the
+[k8scluster](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.150.0/receiver/kubeletstatsreceiver/documentation.md)
+receiver changed their instrument types in
+[#3889](https://github.com/open-telemetry/semantic-conventions/pull/3889) in alignement with the rest
+of the project.
+
+The changes are the following:
+
+<!-- prettier-ignore-start -->
+
+| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New                                                                                                   |
+| ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `k8s.pod.memory.usage`    gauge                                            | `k8s.pod.memory.usage`    updowncounter |
+| `k8s.node.memory.usage`    gauge                                            | `k8s.node.memory.usage`    updowncounter |
+| `container.memory.usage`    gauge                                            | `container.memory.usage`    updowncounter |
 
 <!-- prettier-ignore-end -->

--- a/docs/non-normative/k8s-migration.md
+++ b/docs/non-normative/k8s-migration.md
@@ -242,12 +242,14 @@ The changes in their metric types are the following:
 
 <!-- prettier-ignore-start -->
 
-| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New |
-| ------------------------------------------------------ | --- |
-| `k8s.job.active_pods`                  (type: `gauge`) | `k8s.job.pod.active` (type: `updowncounter`) |
-| `k8s.job.failed_pods`                  (type: `gauge`) | `k8s.job.pod.failed` (type: `updowncounter`) |
-| `k8s.job.desired_successful_pods`      (type: `gauge`) | `k8s.job.pod.desired_successful`  (type: `updowncounter`) |
-| `k8s.job.max_parallel_pods`            (type: `gauge`) | `k8s.job.pod.max_parallel`   (type: `updowncounter`) |
+| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New                                                      |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `k8s.job.active_pods`             (type: `gauge`)                                  | `k8s.job.pod.active` (type: `updowncounter`)             |
+| `k8s.job.failed_pods`             (type: `gauge`)                                  | `k8s.job.pod.failed` (type: `updowncounter`)             |
+| `k8s.job.desired_successful_pods` (type: `gauge`)                                  | `k8s.job.pod.desired_successful` (type: `updowncounter`) |
+| `k8s.job.max_parallel_pods`       (type: `gauge`)                                  | `k8s.job.pod.max_parallel` (type: `updowncounter`)       |
+
+<!-- prettier-ignore-end -->
 
 ### K8s Cronjob metrics
 
@@ -260,9 +262,9 @@ The changes in their metric types are the following:
 
 <!-- prettier-ignore-start -->
 
-| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New |
-| ------------------------------------------------ | ---- |
-| `k8s.cronjob.active_jobs`                  (type: `gauge`) | `k8s.cronjob.job.active` (type: `updowncounter`) |
+| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New                                              |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `k8s.cronjob.active_jobs` (type: `gauge`)                                          | `k8s.cronjob.job.active` (type: `updowncounter`) |
 
 <!-- prettier-ignore-end -->
 
@@ -314,6 +316,8 @@ The changes are the following:
 | Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New                                    |
 | ---------------------------------------------------------------------------------- | -------------------------------------- |
 | `k8s.replication_controller.{name,uid}`                                            | `k8s.replicationcontroller.{name,uid}` |
+
+<!-- prettier-ignore-end -->
 
 ### K8s Container metrics
 
@@ -574,19 +578,19 @@ The changes in these attributes are the following:
 ### K8s Pod/Node and Container Memory Usage
 
 The memory usage metrics implemented by the Collector and specifically the
-[k8scluster](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.150.0/receiver/kubeletstatsreceiver/documentation.md)
+[kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.150.0/receiver/kubeletstatsreceiver/documentation.md)
 receiver changed their instrument types in
-[#3889](https://github.com/open-telemetry/semantic-conventions/pull/3889) in alignement with the rest
+[#3889](https://github.com/open-telemetry/semantic-conventions/pull/3889) in alignment with the rest
 of the project.
 
 The changes are the following:
 
 <!-- prettier-ignore-start -->
 
-| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New                                                                                                   |
-| ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `k8s.pod.memory.usage`    gauge                                            | `k8s.pod.memory.usage`    updowncounter |
-| `k8s.node.memory.usage`    gauge                                            | `k8s.node.memory.usage`    updowncounter |
-| `container.memory.usage`    gauge                                            | `container.memory.usage`    updowncounter |
+| Old (Collector) ![changed](https://img.shields.io/badge/changed-orange?style=flat) | New                                      |
+| ---------------------------------------------------------------------------------- | ---------------------------------------- |
+| `k8s.pod.memory.usage`   gauge                                                     | `k8s.pod.memory.usage`   updowncounter   |
+| `k8s.node.memory.usage`  gauge                                                     | `k8s.node.memory.usage`  updowncounter   |
+| `container.memory.usage` counter                                                   | `container.memory.usage` updowncounter   |
 
 <!-- prettier-ignore-end -->

--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -150,7 +150,7 @@ This metric is [opt-in][MetricOptIn].
 
 | Name | Instrument Type | Unit (UCUM) | Description | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `container.memory.usage` | Counter | `By` | Memory usage of the container. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`container`](/docs/registry/entities/container.md#container) |
+| `container.memory.usage` | UpDownCounter | `By` | Memory usage of the container. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`container`](/docs/registry/entities/container.md#container) |
 
 **[1]:** Memory usage of the container.
 

--- a/docs/system/k8s-metrics.md
+++ b/docs/system/k8s-metrics.md
@@ -303,7 +303,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name | Instrument Type | Unit (UCUM) | Description | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.memory.usage` | Gauge | `By` | Memory usage of the Pod. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.memory.usage` | UpDownCounter | `By` | Memory usage of the Pod. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **[1]:** Total memory usage of the Pod
 
@@ -1080,7 +1080,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name | Instrument Type | Unit (UCUM) | Description | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.memory.usage` | Gauge | `By` | Memory usage of the Node. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.memory.usage` | UpDownCounter | `By` | Memory usage of the Node. [1] | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 **[1]:** Total memory usage of the Node
 

--- a/model/container/metrics.yaml
+++ b/model/container/metrics.yaml
@@ -92,7 +92,7 @@ groups:
     brief: "Memory usage of the container."
     note: >
       Memory usage of the container.
-    instrument: counter
+    instrument: updowncounter
     entity_associations:
       - container
     unit: "By"

--- a/model/k8s/metrics.yaml
+++ b/model/k8s/metrics.yaml
@@ -97,7 +97,7 @@ groups:
       - k8s.pod
     note: >
       Total memory usage of the Pod
-    instrument: gauge
+    instrument: updowncounter
     unit: "By"
   - id: metric.k8s.pod.memory.available
     type: metric
@@ -700,7 +700,7 @@ groups:
     brief: "Memory usage of the Node."
     note: >
       Total memory usage of the Node
-    instrument: gauge
+    instrument: updowncounter
     entity_associations:
       - k8s.node
     unit: "By"


### PR DESCRIPTION
## Changes

As highlighted at https://github.com/open-telemetry/semantic-conventions/pull/3883#pullrequestreview-4687893398 this changes the instrument type to updowncounter for the following metrics:
- `container.memory.usage` from counter to updowncounter
- `k8s.pod.memory.usage` from gauge to updowncounter
- `k8s.node.memory.usage` from gauge to updowncounter

> [!IMPORTANT]
> Pull request acceptance is subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [x] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [x] no AI used
  * [ ] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
