### PR TITLE
Clarify SDK processor processed metric boundary

### DIFF
--- a/.chloggen/clarify-sdk-processor-processed-boundary.yaml
+++ b/.chloggen/clarify-sdk-processor-processed-boundary.yaml
@@ -1,0 +1,14 @@
+change_type: enhancement
+
+component: otel
+
+note: >
+  Clarify that `otel.sdk.processor.span.processed` and
+  `otel.sdk.processor.log.processed` are recorded when the processor passes
+  items to the exporter, not when an item is accepted into a queue or when the
+  export operation completes, and that the export outcome does not affect
+  these metrics.
+
+issues: [3902]
+
+subtext:

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -266,7 +266,12 @@ This metric is [recommended][MetricRecommended].
 SDK Batching Span Processors MUST use `queue_full` as the value of `error.type` for spans dropped due to a full queue.
 If a processor reports a span dropped because it has already been shut down, `error.type` MUST be `already_shutdown`.
 Whether and when a processor drops such spans is governed by the SDK specification, not by this metric.
-For the SDK Simple and Batching Span Processor a span is considered to be processed already when it has been submitted to the exporter, not when the corresponding export call has finished.
+For the SDK Simple and Batching Span Processors, a span MUST be counted as successfully processed at the point the processor
+invokes the export operation. For batching processors, all spans in the batch passed to the exporter are counted at that point;
+spans accepted into the processor's queue but not yet passed to the exporter have not been processed.
+Implementations MUST NOT delay this count until the export operation concludes, and the outcome of the export operation,
+including an immediate failure of the invocation itself, MUST NOT affect this metric.
+Export outcomes are reported by `otel.sdk.exporter.span.exported`.
 
 **Attributes:**
 
@@ -707,8 +712,12 @@ This metric is [recommended][MetricRecommended].
 SDK Batching Log Record Processors MUST use `queue_full` as the value of `error.type` for log records dropped due to a full queue.
 If a processor reports a log record dropped because it has already been shut down, `error.type` MUST be `already_shutdown`.
 Whether and when a processor drops such log records is governed by the SDK specification, not by this metric.
-For the SDK Simple and Batching Log Record Processor a log record is considered to be processed already when it has been submitted to the exporter,
-not when the corresponding export call has finished.
+For the SDK Simple and Batching Log Record Processors, a log record MUST be counted as successfully processed at the point the
+processor invokes the export operation. For batching processors, all log records in the batch passed to the exporter are counted
+at that point; log records accepted into the processor's queue but not yet passed to the exporter have not been processed.
+Implementations MUST NOT delay this count until the export operation concludes, and the outcome of the export operation,
+including an immediate failure of the invocation itself, MUST NOT affect this metric.
+Export outcomes are reported by `otel.sdk.exporter.log.exported`.
 
 **Attributes:**
 

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -75,7 +75,12 @@ groups:
       SDK Batching Span Processors MUST use `queue_full` as the value of `error.type` for spans dropped due to a full queue.
       If a processor reports a span dropped because it has already been shut down, `error.type` MUST be `already_shutdown`.
       Whether and when a processor drops such spans is governed by the SDK specification, not by this metric.
-      For the SDK Simple and Batching Span Processor a span is considered to be processed already when it has been submitted to the exporter, not when the corresponding export call has finished.
+      For the SDK Simple and Batching Span Processors, a span MUST be counted as successfully processed at the point the processor
+      invokes the export operation. For batching processors, all spans in the batch passed to the exporter are counted at that point;
+      spans accepted into the processor's queue but not yet passed to the exporter have not been processed.
+      Implementations MUST NOT delay this count until the export operation concludes, and the outcome of the export operation,
+      including an immediate failure of the invocation itself, MUST NOT affect this metric.
+      Export outcomes are reported by `otel.sdk.exporter.span.exported`.
     instrument: counter
     unit: "{span}"
     attributes:
@@ -193,8 +198,12 @@ groups:
       SDK Batching Log Record Processors MUST use `queue_full` as the value of `error.type` for log records dropped due to a full queue.
       If a processor reports a log record dropped because it has already been shut down, `error.type` MUST be `already_shutdown`.
       Whether and when a processor drops such log records is governed by the SDK specification, not by this metric.
-      For the SDK Simple and Batching Log Record Processor a log record is considered to be processed already when it has been submitted to the exporter,
-      not when the corresponding export call has finished.
+      For the SDK Simple and Batching Log Record Processors, a log record MUST be counted as successfully processed at the point the
+      processor invokes the export operation. For batching processors, all log records in the batch passed to the exporter are counted
+      at that point; log records accepted into the processor's queue but not yet passed to the exporter have not been processed.
+      Implementations MUST NOT delay this count until the export operation concludes, and the outcome of the export operation,
+      including an immediate failure of the invocation itself, MUST NOT affect this metric.
+      Export outcomes are reported by `otel.sdk.exporter.log.exported`.
     instrument: counter
     unit: "{log_record}"
     attributes:


### PR DESCRIPTION
Clarifies that `otel.sdk.processor.{span,log}.processed` records successful processing when the processor invokes the exporter, not when an item is accepted into a queue or when export completes.

Implementations currently differ in both directions, which is why this clarification matters:

- **Rust** ~counts too early: the log `BatchProcessor` increments the counter when a record is accepted into the queue, before the exporter is invoked.~ Fixed in https://github.com/open-telemetry/opentelemetry-rust/pull/3607
- **Java** and **Python** count too late: their batch processors increment the counter after `export()` completes, and additionally stamp the exporter's failure as `error.type` on this metric. Tracked in https://github.com/open-telemetry/opentelemetry-java/issues/8680 and https://github.com/open-telemetry/opentelemetry-python/pull/5472
- **Go** counts at the intended boundary (when the processor invokes the exporter).

Requesting feedback from @open-telemetry/java-maintainers, @open-telemetry/go-maintainers, and @open-telemetry/python-maintainers.