### PR TITLE
docs: fix moved Azure Functions manage-connections link

### DIFF
--- a/docs/faas/faas-spans.md
+++ b/docs/faas/faas-spans.md
@@ -119,7 +119,7 @@ The span attribute `faas.invocation_id` differs from the [resource attribute][Fa
 - `faas.instance` refers to the execution environment ID of the function.
 
 [AWS lambda]: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
-[Azure functions]: https://docs.microsoft.com/azure/azure-functions/manage-connections#static-clients
+[Azure functions]: https://learn.microsoft.com/azure/azure-functions/manage-connections#reuse-client-instances
 [Google functions]: https://cloud.google.com/functions/docs/concepts/execution-environment
 
 ## Incoming invocations


### PR DESCRIPTION
The FaaS semantic conventions link to the Azure Functions "static clients" section, which Azure removed when it reworked the manage-connections page. docs.microsoft.com now redirects to learn.microsoft.com.

Surfaced by the opentelemetry.io link checker in open-telemetry/opentelemetry.io#10943.

## What's in this PR

- Update the `[Azure functions]` reference in `docs/faas/faas-spans.md` to `learn.microsoft.com/azure/azure-functions/manage-connections#reuse-client-instances`

## Verification

- The target returns HTTP 200 and `#reuse-client-instances` resolves in the server-rendered HTML
- The section is the successor to the old "static clients" content: "create a single, shared client that every function invocation can reuse"

Editorial link fix, so no changelog entry (Skip Changelog).

---

> Co-authored with Claude Fable 5.
