### PR TITLE
ci: use checkout credentials for git pushes

### DIFF
--- a/.github/workflows/auto-update-spec-repo-links.yml
+++ b/.github/workflows/auto-update-spec-repo-links.yml
@@ -81,7 +81,7 @@ jobs:
           body="Update spec repo links to \`$VERSION\`."
           branch="otelbot/update-spec-repo-links-to-$VERSION"
 
-          git checkout -b $branch
+          git checkout -b "$branch"
           git commit -a -m "$message"
           git push --set-upstream origin "$branch"
           gh pr create --title "[chore] $message" \

--- a/.github/workflows/auto-update-spec-repo-links.yml
+++ b/.github/workflows/auto-update-spec-repo-links.yml
@@ -18,8 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
-          persist-credentials: true
+          persist-credentials: false
 
       - id: check-versions
         name: Check versions
@@ -54,7 +53,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          persist-credentials: false
+          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
+          persist-credentials: true
 
       - name: Use CLA approved github bot
         run: .github/scripts/use-cla-approved-github-bot.sh

--- a/.github/workflows/auto-update-spec-repo-links.yml
+++ b/.github/workflows/auto-update-spec-repo-links.yml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          persist-credentials: false
+          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
+          persist-credentials: true
 
       - id: check-versions
         name: Check versions
@@ -73,7 +74,6 @@ jobs:
       - name: Create pull request
         env:
           VERSION: ${{ needs.check-versions.outputs.latest-version }}
-          GITHUB_TOKEN: ${{ github.token }}
           # Use the App token for PR creation so the pull request runs workflows.
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
@@ -83,7 +83,7 @@ jobs:
 
           git checkout -b $branch
           git commit -a -m "$message"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" $branch
+          git push --set-upstream origin "$branch"
           gh pr create --title "[chore] $message" \
                        --body "$body" \
                        --head "$branch" \

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -17,7 +17,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
-          persist-credentials: false
+          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
+          persist-credentials: true
 
       # only bump the development schema_url for minor/major releases,
       # patch releases are cut from a release branch and don't move main forward.
@@ -69,7 +70,6 @@ jobs:
         env:
           # Use the App token for PR creation so the pull request runs workflows.
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-          GITHUB_TOKEN: ${{ github.token }}
           VERSION: ${{ github.event.release.tag_name }}
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
         run: |
@@ -83,7 +83,7 @@ jobs:
             exit 0
           fi
           git commit -a -m "$message"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$branch"
+          git push --set-upstream origin "$branch"
           gh pr create --title "$message" \
                        --body "$body" \
                        --head "$branch" \

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          persist-credentials: false
+          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
+          persist-credentials: true
 
       - name: Validate version
         env:
@@ -57,7 +58,6 @@ jobs:
         env:
           # Use the App token for PR creation so the pull request runs workflows.
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-          GITHUB_TOKEN: ${{ github.token }}
           INPUTS_VERSION: ${{ inputs.version }}
         run: |
           version=${INPUTS_VERSION}
@@ -67,7 +67,7 @@ jobs:
 
           git checkout -b $branch
           git commit -a -m "$message"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" $branch
+          git push --set-upstream origin "$branch"
           gh pr create --title "$message" \
                        --body "$body" \
                        --head "$branch" \

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -65,7 +65,7 @@ jobs:
           body="Prepare release \`v${version}\`."
           branch="otelbot/prepare-release-v${version}"
 
-          git checkout -b $branch
+          git checkout -b "$branch"
           git commit -a -m "$message"
           git push --set-upstream origin "$branch"
           gh pr create --title "$message" \


### PR DESCRIPTION
Follow-up to #3895.

The three affected workflows intentionally push branches using the job `GITHUB_TOKEN`. Make that requirement explicit with `persist-credentials: true`, and use ordinary `git push` instead of embedding the token in the push URL.

This follows zizmor's documented [`artipacked` remediation](https://docs.zizmor.sh/audits/#artipacked): disable persisted credentials when they are not needed, and explicitly retain them when later Git operations require authentication. `actions/checkout` v6 and later store the credential under `RUNNER_TEMP` and remove it during post-job cleanup.

The GitHub App token remains scoped to pull-request creation only.