### PR TITLE
RPC: Remove tracing-only method guidance from metrics

### DIFF
--- a/.chloggen/rpc-method-original-metrics.yaml
+++ b/.chloggen/rpc-method-original-metrics.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: rpc
+
+note: >
+  Remove tracing-only `rpc.method_original` guidance from the shared
+  `rpc.method` definition.
+
+issues: [3872]
+
+subtext:

--- a/docs/registry/attributes/rpc.md
+++ b/docs/registry/attributes/rpc.md
@@ -31,9 +31,7 @@ when the method is recognized by the framework or library.
 When the method is not recognized, for example, when the server receives
 a request for a method that is not predefined on the server, or when
 instrumentation is not able to reliably detect if the method is predefined,
-the attribute MUST be set to `_OTHER`. In such cases, tracing
-instrumentations MUST also set `rpc.method_original` attribute to
-the original method value.
+the attribute MUST be set to `_OTHER`.
 
 If the RPC instrumentation could end up converting valid RPC methods to
 `_OTHER`, then it SHOULD provide a way to configure the list of recognized

--- a/docs/rpc/connect-rpc.md
+++ b/docs/rpc/connect-rpc.md
@@ -80,9 +80,7 @@ when the method is recognized by the framework or library.
 When the method is not recognized, for example, when the server receives
 a request for a method that is not predefined on the server, or when
 instrumentation is not able to reliably detect if the method is predefined,
-the attribute MUST be set to `_OTHER`. In such cases, tracing
-instrumentations MUST also set `rpc.method_original` attribute to
-the original method value.
+the attribute MUST be set to `_OTHER`.
 
 If the RPC instrumentation could end up converting valid RPC methods to
 `_OTHER`, then it SHOULD provide a way to configure the list of recognized
@@ -190,9 +188,7 @@ when the method is recognized by the framework or library.
 When the method is not recognized, for example, when the server receives
 a request for a method that is not predefined on the server, or when
 instrumentation is not able to reliably detect if the method is predefined,
-the attribute MUST be set to `_OTHER`. In such cases, tracing
-instrumentations MUST also set `rpc.method_original` attribute to
-the original method value.
+the attribute MUST be set to `_OTHER`.
 
 If the RPC instrumentation could end up converting valid RPC methods to
 `_OTHER`, then it SHOULD provide a way to configure the list of recognized

--- a/docs/rpc/dubbo.md
+++ b/docs/rpc/dubbo.md
@@ -65,9 +65,7 @@ when the method is recognized by the framework or library.
 When the method is not recognized, for example, when the server receives
 a request for a method that is not predefined on the server, or when
 instrumentation is not able to reliably detect if the method is predefined,
-the attribute MUST be set to `_OTHER`. In such cases, tracing
-instrumentations MUST also set `rpc.method_original` attribute to
-the original method value.
+the attribute MUST be set to `_OTHER`.
 
 If the RPC instrumentation could end up converting valid RPC methods to
 `_OTHER`, then it SHOULD provide a way to configure the list of recognized
@@ -277,9 +275,7 @@ when the method is recognized by the framework or library.
 When the method is not recognized, for example, when the server receives
 a request for a method that is not predefined on the server, or when
 instrumentation is not able to reliably detect if the method is predefined,
-the attribute MUST be set to `_OTHER`. In such cases, tracing
-instrumentations MUST also set `rpc.method_original` attribute to
-the original method value.
+the attribute MUST be set to `_OTHER`.
 
 If the RPC instrumentation could end up converting valid RPC methods to
 `_OTHER`, then it SHOULD provide a way to configure the list of recognized

--- a/docs/rpc/grpc.md
+++ b/docs/rpc/grpc.md
@@ -73,9 +73,7 @@ when the method is recognized by the framework or library.
 When the method is not recognized, for example, when the server receives
 a request for a method that is not predefined on the server, or when
 instrumentation is not able to reliably detect if the method is predefined,
-the attribute MUST be set to `_OTHER`. In such cases, tracing
-instrumentations MUST also set `rpc.method_original` attribute to
-the original method value.
+the attribute MUST be set to `_OTHER`.
 
 If the RPC instrumentation could end up converting valid RPC methods to
 `_OTHER`, then it SHOULD provide a way to configure the list of recognized
@@ -246,9 +244,7 @@ when the method is recognized by the framework or library.
 When the method is not recognized, for example, when the server receives
 a request for a method that is not predefined on the server, or when
 instrumentation is not able to reliably detect if the method is predefined,
-the attribute MUST be set to `_OTHER`. In such cases, tracing
-instrumentations MUST also set `rpc.method_original` attribute to
-the original method value.
+the attribute MUST be set to `_OTHER`.
 
 If the RPC instrumentation could end up converting valid RPC methods to
 `_OTHER`, then it SHOULD provide a way to configure the list of recognized

--- a/docs/rpc/rpc-metrics.md
+++ b/docs/rpc/rpc-metrics.md
@@ -107,9 +107,7 @@ when the method is recognized by the framework or library.
 When the method is not recognized, for example, when the server receives
 a request for a method that is not predefined on the server, or when
 instrumentation is not able to reliably detect if the method is predefined,
-the attribute MUST be set to `_OTHER`. In such cases, tracing
-instrumentations MUST also set `rpc.method_original` attribute to
-the original method value.
+the attribute MUST be set to `_OTHER`.
 
 If the RPC instrumentation could end up converting valid RPC methods to
 `_OTHER`, then it SHOULD provide a way to configure the list of recognized
@@ -206,9 +204,7 @@ when the method is recognized by the framework or library.
 When the method is not recognized, for example, when the server receives
 a request for a method that is not predefined on the server, or when
 instrumentation is not able to reliably detect if the method is predefined,
-the attribute MUST be set to `_OTHER`. In such cases, tracing
-instrumentations MUST also set `rpc.method_original` attribute to
-the original method value.
+the attribute MUST be set to `_OTHER`.
 
 If the RPC instrumentation could end up converting valid RPC methods to
 `_OTHER`, then it SHOULD provide a way to configure the list of recognized

--- a/docs/rpc/rpc-spans.md
+++ b/docs/rpc/rpc-spans.md
@@ -123,9 +123,7 @@ when the method is recognized by the framework or library.
 When the method is not recognized, for example, when the server receives
 a request for a method that is not predefined on the server, or when
 instrumentation is not able to reliably detect if the method is predefined,
-the attribute MUST be set to `_OTHER`. In such cases, tracing
-instrumentations MUST also set `rpc.method_original` attribute to
-the original method value.
+the attribute MUST be set to `_OTHER`.
 
 If the RPC instrumentation could end up converting valid RPC methods to
 `_OTHER`, then it SHOULD provide a way to configure the list of recognized
@@ -244,9 +242,7 @@ when the method is recognized by the framework or library.
 When the method is not recognized, for example, when the server receives
 a request for a method that is not predefined on the server, or when
 instrumentation is not able to reliably detect if the method is predefined,
-the attribute MUST be set to `_OTHER`. In such cases, tracing
-instrumentations MUST also set `rpc.method_original` attribute to
-the original method value.
+the attribute MUST be set to `_OTHER`.
 
 If the RPC instrumentation could end up converting valid RPC methods to
 `_OTHER`, then it SHOULD provide a way to configure the list of recognized

--- a/model/rpc/registry.yaml
+++ b/model/rpc/registry.yaml
@@ -60,9 +60,7 @@ groups:
           When the method is not recognized, for example, when the server receives
           a request for a method that is not predefined on the server, or when
           instrumentation is not able to reliably detect if the method is predefined,
-          the attribute MUST be set to `_OTHER`. In such cases, tracing
-          instrumentations MUST also set `rpc.method_original` attribute to
-          the original method value.
+          the attribute MUST be set to `_OTHER`.
 
           If the RPC instrumentation could end up converting valid RPC methods to
           `_OTHER`, then it SHOULD provide a way to configure the list of recognized


### PR DESCRIPTION
Remove the tracing-only `rpc.method_original` instruction from the shared `rpc.method` guidance so it is no longer rendered in RPC metric documentation.

This does not lose span behavior: `rpc.method_original` remains conditionally required on RPC spans if and only if it differs from `rpc.method`, so instrumentations must still preserve the original method whenever normalization changes it.

Fixes #3872