### PR TITLE
[chore] Update .textlintignore to include .chloggen directory

### DIFF
--- a/.textlintignore
+++ b/.textlintignore
@@ -6,4 +6,4 @@ templates/**
 docs/registry/**
 CHANGELOG.md
 areas.yaml
-.chloggen/config.yaml
+.chloggen/**


### PR DESCRIPTION
Fixes #3927 
Closes #3928 
Closes #3930

## Changes

> [!NOTE]
> see #3930 for alternative solution which just addresses the violation without a config change hence keeps textlint running on the .chloggen directory.

This resolves the ci issue by ignoring the entire .chloggen directory which is ok given we don’t check the changelog.

> [!IMPORTANT]
> Pull request acceptance is subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [ ] no AI used
  * [ ] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
