### PR TITLE
[chore] address textlint issue

### DIFF
--- a/.chloggen/web_vital-attributes.yaml
+++ b/.chloggen/web_vital-attributes.yaml
@@ -10,7 +10,7 @@ change_type: 'breaking'
 component: browser
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Reworked the browser.web_vital event - moved name/value/delta/id from the event body to browser.web_vital.* attributes, and added new attributes per current instrumentation.
+note: Reworked the `browser.web_vital` event - moved `name`/`value`/`delta`/id from the event body to `browser.web_vital.*` attributes, and added new attributes per current instrumentation.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.

--- a/.chloggen/web_vital-attributes.yaml
+++ b/.chloggen/web_vital-attributes.yaml
@@ -10,7 +10,7 @@ change_type: 'breaking'
 component: browser
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Reworked the `browser.web_vital` event - moved `name`/`value`/`delta`/id from the event body to `browser.web_vital.*` attributes, and added new attributes per current instrumentation.
+note: Reworked the `browser.web_vital` event - moved `name`/`value`/`delta`/`id` from the event body to `browser.web_vital.*` attributes, and added new attributes per current instrumentation.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.


### PR DESCRIPTION
Fixes #3927 
Closes #3929

Related #3928

## Changes

> [!NOTE]
> see #3929 which rather than change the text excludes the directory.

Update note for browser.web_vital event changes to use backticks to indicate names of attributes/fields.

> [!IMPORTANT]
> Pull request acceptance is subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [ ] no AI used
  * [ ] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
