### PR TITLE
[chore] Fix K8s casing in rc_mem_metrics changelog note

### DIFF
--- a/.chloggen/rc_mem_metrics.yaml
+++ b/.chloggen/rc_mem_metrics.yaml
@@ -10,7 +10,7 @@ change_type: enhancement
 component: k8s
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Promote a selection of container and k8s memory metrics to release_candidate
+note: Promote a selection of container and K8s memory metrics to release_candidate
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.


### PR DESCRIPTION
Corrects a lowercase `k8s` to `K8s` in the `note:` of `.chloggen/rc_mem_metrics.yaml`.

This is currently the only textlint violation on `main`, so the `textlint` job is red repo-wide and every open PR inherits it.
