### PR TITLE
[chore] Textlint fixes

### DIFF
--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -27,7 +27,13 @@ filters:
       - /\n\s*(-\s)?(\S+):/ # YAML keys, with optional list marker
       - /\n\s*(-\s)?(id|value|examples|metric_name|ref|component):\s(\[.+\]|.+)/ # Values for YAML keys in allowed list are not checked
       - /examples:\n?.+\[(.|\n)([^\]])*]/ # Examples YAML key with list of values, allowing for multi-line lists
-  comments: true
+  comments:
+    # enable comment directive
+    # if comment has the value, then enable textlint rule
+    enablingComment: "textlint-enable"
+    # disable comment directive
+    # if comment has the value, then disable textlint rule
+    disablingComment: "textlint-disable"
 rules:
   common-misspellings:
     # Misspellings to be ignored (case-insensitive)

--- a/docs/general/semantic-convention-groups.md
+++ b/docs/general/semantic-convention-groups.md
@@ -65,7 +65,7 @@ don't describe telemetry items.
 
 ### Groups with mixed stability
 
-Stability guarantees on a group apply to the group properties (such as type, id and
+Stability guarantees on a group apply to the group properties (such as `type`, `id` and
 signal-specific properties) as well as overridden properties of stable attributes
 referenced by this group.
 

--- a/docs/general/trace.md
+++ b/docs/general/trace.md
@@ -15,7 +15,7 @@ Depending on the protocol and the type of operation, additional information
 is needed to represent and analyze a span correctly in monitoring systems. It is
 also important to unify how this attribution is made in different languages.
 This way, the operator will not need to learn specifics of a language and
-telemetry collected from polyglot (multi-language) micro-service environments
+telemetry collected from polyglot (multi-language) microservice environments
 can still be easily correlated and cross-analyzed.
 
 The following semantic conventions for spans are defined:

--- a/docs/http/README.md
+++ b/docs/http/README.md
@@ -7,7 +7,7 @@ linkTitle: HTTP
 **Status**: [Mixed][DocumentStatus]
 
 This document defines semantic conventions for HTTP spans, metrics and logs.
-They can be used for http and https schemes
+They can be used for HTTP and HTTPS schemes
 and various HTTP versions like 1.1, 2 and SPDY.
 
 > [!IMPORTANT]

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -7,7 +7,7 @@ linkTitle: Spans
 **Status**: [Stable][DocumentStatus], Unless otherwise specified.
 
 This document defines semantic conventions for HTTP client and server Spans.
-They can be used for http and https schemes
+They can be used for HTTP and HTTPS schemes
 and various HTTP versions like 1.1, 2 and SPDY.
 
 <!-- START doctoc -->

--- a/docs/non-normative/groups/system/use-cases.md
+++ b/docs/non-normative/groups/system/use-cases.md
@@ -56,7 +56,7 @@ memory, CPU, etc.).
 ## Notes
 
 The alerts in particular should be capable of being uniformly applied to a
-heterogenous fleet of hosts. We will value the nature of cross-platform
+heterogeneous fleet of hosts. We will value the nature of cross-platform
 instrumentation to allow for effective alerting across a fleet regardless of the
 potential mixture of operating system platforms within it.
 

--- a/docs/non-normative/groups/system/use-cases.md
+++ b/docs/non-normative/groups/system/use-cases.md
@@ -56,7 +56,7 @@ memory, CPU, etc.).
 ## Notes
 
 The alerts in particular should be capable of being uniformly applied to a
-heterogeneous fleet of hosts. We will value the nature of cross-platform
+heterogenous fleet of hosts. We will value the nature of cross-platform
 instrumentation to allow for effective alerting across a fleet regardless of the
 potential mixture of operating system platforms within it.
 

--- a/docs/non-normative/k8s-migration.md
+++ b/docs/non-normative/k8s-migration.md
@@ -17,19 +17,19 @@ updated to the stable K8s semantic conventions, they:
 
 - SHOULD introduce an environment variable `OTEL_SEMCONV_STABILITY_OPT_IN` in
   their existing major version, which accepts:
-  - `k8s` - emit the stable k8s conventions, and stop emitting
-    the old k8s conventions that the instrumentation emitted previously.
-  - `k8s/dup` - emit both the old and the stable k8s conventions,
+  - `k8s` - emit the stable K8s conventions, and stop emitting
+    the old K8s conventions that the instrumentation emitted previously.
+  - `k8s/dup` - emit both the old and the stable K8s conventions,
     allowing for a phased rollout of the stable semantic conventions.
   - The default behavior (in the absence of one of these values) is to continue
-    emitting whatever version of the old k8s conventions the
+    emitting whatever version of the old K8s conventions the
     instrumentation was emitting previously.
 - Need to maintain (security patching at a minimum) their existing major version
   for at least six months after it starts emitting both sets of conventions.
 - May drop the environment variable in their next major version and emit only
-  the stable k8s conventions.
+  the stable K8s conventions.
 
-Specifically for the Opentelemetry Collector:
+Specifically for the OpenTelemetry Collector:
 
 The transition will happen through two different feature gates.
 One for enabling the new schema called `semconv.k8s.enableStable`,

--- a/docs/resource/service.md
+++ b/docs/resource/service.md
@@ -10,12 +10,12 @@ data (events, metrics, spans, etc.).
 In modern, distributed, application architectures:
 
 - A `service.namespace` is an entire system of components designed for
-  end-users or other applications to leverage.
+  end users or other applications to leverage.
 - A `service` is one of the logical, distinct components that make up the
   application, e.g. running as a bundle of the instances that run the same
   container image for load balancing.
 - A `service.instance` is a distinct instance of a service component, e.g. a
-  specific kubernetes container that is part of a kubernetes deployment which
+  specific Kubernetes container that is part of a Kubernetes deployment which
   offers a service.
 
 For example, suppose we have a Blog site that consists of a database

--- a/docs/runtime/v8js-metrics.md
+++ b/docs/runtime/v8js-metrics.md
@@ -6,7 +6,7 @@ linkTitle: V8 JS engine
 
 **Status**: [Development][DocumentStatus]
 
-This document describes semantic conventions for V8 JS Engine Runtime metrics in OpenTelemetry. This engine is used in some javascript runtime such as Node.js and Deno.
+This document describes semantic conventions for V8 JS Engine Runtime metrics in OpenTelemetry. This engine is used in some JavaScript runtime such as Node.js and Deno.
 
 <!-- START doctoc -->
 

--- a/docs/url/README.md
+++ b/docs/url/README.md
@@ -6,7 +6,7 @@ linkTitle: URL
 
 **Status**: [Development][DocumentStatus]
 
-This document defines semantic conventions for url.
+This document defines semantic conventions for URL.
 
 * [Attributes](../registry/attributes/url.md)
 


### PR DESCRIPTION
Fixes #

## Changes

This goes through and performs textlint fixes which are needed when valid front matter is used. Issue identified in #2971

Root cause of issue is the multiline html comment at the start. In docs with toc, or weaver snippet’s the start of those blocks triggers content to be checked hence content between top & that block is not currently checked.

> [!IMPORTANT]
> Pull request acceptance is subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [x] no AI used
  * [ ] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
