### PR TITLE
Clarify already_shutdown is a value-only requirement for error.type

### DIFF
--- a/.chloggen/clarify-already-shutdown-error-type.yaml
+++ b/.chloggen/clarify-already-shutdown-error-type.yaml
@@ -1,0 +1,14 @@
+change_type: enhancement
+
+component: otel
+
+note: >
+  Clarify that `already_shutdown` on `otel.sdk.processor.span.processed` and
+  `otel.sdk.processor.log.processed` is a value-only requirement for the
+  `error.type` attribute: whether and when a processor drops records because it
+  has already been shut down is governed by the SDK specification, not by this
+  metric.
+
+issues: [3956]
+
+subtext:

--- a/.chloggen/clarify-already-shutdown-error-type.yaml
+++ b/.chloggen/clarify-already-shutdown-error-type.yaml
@@ -9,6 +9,6 @@ note: >
   has already been shut down is governed by the SDK specification, not by this
   metric.
 
-issues: [3956]
+issues: [3957]
 
 subtext:

--- a/.chloggen/clarify-already-shutdown-error-type.yaml
+++ b/.chloggen/clarify-already-shutdown-error-type.yaml
@@ -1,4 +1,4 @@
-change_type: enhancement
+change_type: bug_fix
 
 component: otel
 

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -264,7 +264,7 @@ This metric is [recommended][MetricRecommended].
 
 **[1]:** For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
 SDK Batching Span Processors MUST use `queue_full` as the value of `error.type` for spans dropped due to a full queue.
-SDK Span Processors MUST use `already_shutdown` as the value of `error.type` for spans dropped because the processor has already been shut down.
+If a processor reports a span dropped because it has already been shut down, `error.type` MUST be `already_shutdown`. Whether and when a processor drops such spans is governed by the SDK specification, not by this metric.
 For the SDK Simple and Batching Span Processor a span is considered to be processed already when it has been submitted to the exporter, not when the corresponding export call has finished.
 
 **Attributes:**
@@ -704,7 +704,7 @@ This metric is [recommended][MetricRecommended].
 
 **[1]:** For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
 SDK Batching Log Record Processors MUST use `queue_full` as the value of `error.type` for log records dropped due to a full queue.
-SDK Log Record Processors MUST use `already_shutdown` as the value of `error.type` for log records dropped because the processor has already been shut down.
+If a processor reports a log record dropped because it has already been shut down, `error.type` MUST be `already_shutdown`. Whether and when a processor drops such log records is governed by the SDK specification, not by this metric.
 For the SDK Simple and Batching Log Record Processor a log record is considered to be processed already when it has been submitted to the exporter,
 not when the corresponding export call has finished.
 

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -264,7 +264,8 @@ This metric is [recommended][MetricRecommended].
 
 **[1]:** For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
 SDK Batching Span Processors MUST use `queue_full` as the value of `error.type` for spans dropped due to a full queue.
-If a processor reports a span dropped because it has already been shut down, `error.type` MUST be `already_shutdown`. Whether and when a processor drops such spans is governed by the SDK specification, not by this metric.
+If a processor reports a span dropped because it has already been shut down, `error.type` MUST be `already_shutdown`.
+Whether and when a processor drops such spans is governed by the SDK specification, not by this metric.
 For the SDK Simple and Batching Span Processor a span is considered to be processed already when it has been submitted to the exporter, not when the corresponding export call has finished.
 
 **Attributes:**
@@ -704,7 +705,8 @@ This metric is [recommended][MetricRecommended].
 
 **[1]:** For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
 SDK Batching Log Record Processors MUST use `queue_full` as the value of `error.type` for log records dropped due to a full queue.
-If a processor reports a log record dropped because it has already been shut down, `error.type` MUST be `already_shutdown`. Whether and when a processor drops such log records is governed by the SDK specification, not by this metric.
+If a processor reports a log record dropped because it has already been shut down, `error.type` MUST be `already_shutdown`.
+Whether and when a processor drops such log records is governed by the SDK specification, not by this metric.
 For the SDK Simple and Batching Log Record Processor a log record is considered to be processed already when it has been submitted to the exporter,
 not when the corresponding export call has finished.
 

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -73,7 +73,8 @@ groups:
     note: |
       For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
       SDK Batching Span Processors MUST use `queue_full` as the value of `error.type` for spans dropped due to a full queue.
-      If a processor reports a span dropped because it has already been shut down, `error.type` MUST be `already_shutdown`. Whether and when a processor drops such spans is governed by the SDK specification, not by this metric.
+      If a processor reports a span dropped because it has already been shut down, `error.type` MUST be `already_shutdown`.
+      Whether and when a processor drops such spans is governed by the SDK specification, not by this metric.
       For the SDK Simple and Batching Span Processor a span is considered to be processed already when it has been submitted to the exporter, not when the corresponding export call has finished.
     instrument: counter
     unit: "{span}"
@@ -190,7 +191,8 @@ groups:
     note: |
       For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
       SDK Batching Log Record Processors MUST use `queue_full` as the value of `error.type` for log records dropped due to a full queue.
-      If a processor reports a log record dropped because it has already been shut down, `error.type` MUST be `already_shutdown`. Whether and when a processor drops such log records is governed by the SDK specification, not by this metric.
+      If a processor reports a log record dropped because it has already been shut down, `error.type` MUST be `already_shutdown`.
+      Whether and when a processor drops such log records is governed by the SDK specification, not by this metric.
       For the SDK Simple and Batching Log Record Processor a log record is considered to be processed already when it has been submitted to the exporter,
       not when the corresponding export call has finished.
     instrument: counter

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -73,7 +73,7 @@ groups:
     note: |
       For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
       SDK Batching Span Processors MUST use `queue_full` as the value of `error.type` for spans dropped due to a full queue.
-      SDK Span Processors MUST use `already_shutdown` as the value of `error.type` for spans dropped because the processor has already been shut down.
+      If a processor reports a span dropped because it has already been shut down, `error.type` MUST be `already_shutdown`. Whether and when a processor drops such spans is governed by the SDK specification, not by this metric.
       For the SDK Simple and Batching Span Processor a span is considered to be processed already when it has been submitted to the exporter, not when the corresponding export call has finished.
     instrument: counter
     unit: "{span}"
@@ -190,7 +190,7 @@ groups:
     note: |
       For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
       SDK Batching Log Record Processors MUST use `queue_full` as the value of `error.type` for log records dropped due to a full queue.
-      SDK Log Record Processors MUST use `already_shutdown` as the value of `error.type` for log records dropped because the processor has already been shut down.
+      If a processor reports a log record dropped because it has already been shut down, `error.type` MUST be `already_shutdown`. Whether and when a processor drops such log records is governed by the SDK specification, not by this metric.
       For the SDK Simple and Batching Log Record Processor a log record is considered to be processed already when it has been submitted to the exporter,
       not when the corresponding export call has finished.
     instrument: counter


### PR DESCRIPTION
Reframes the `already_shutdown` note on `otel.sdk.processor.{span,log}.processed` as a value-only requirement: `error.type` MUST be `already_shutdown` *if* a processor reports such a drop, while whether/when a processor drops post-shutdown records is governed by the SDK specification, not this metric. `queue_full` wording is unchanged.