### PR TITLE
Advise gRPC-specific duration histogram bucket boundaries

### DIFF
--- a/.chloggen/grpc-histogram-buckets.yaml
+++ b/.chloggen/grpc-histogram-buckets.yaml
@@ -3,8 +3,9 @@ change_type: enhancement
 component: rpc
 
 note: >
-  Document the default duration histogram bucket boundaries defined by the gRPC
-  project and how they compare to the boundaries advised by OpenTelemetry.
+  Advise gRPC-specific `ExplicitBucketBoundaries` for `rpc.client.call.duration`
+  and `rpc.server.call.duration`, matching the default histogram buckets defined
+  by the gRPC project.
 
 issues: [3869]
 

--- a/.chloggen/grpc-histogram-buckets.yaml
+++ b/.chloggen/grpc-histogram-buckets.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+
+component: rpc
+
+note: >
+  Document the default duration histogram bucket boundaries defined by the gRPC
+  project and how they compare to the boundaries advised by OpenTelemetry.
+
+issues: [3869]
+
+subtext:

--- a/docs/non-normative/compatibility/grpc.md
+++ b/docs/non-normative/compatibility/grpc.md
@@ -61,24 +61,9 @@ and the [OpenTelemetry conventions](/docs/rpc/rpc-metrics.md) for details.
 
 ### Histogram bucket boundaries
 
-The gRPC and OpenTelemetry conventions recommend different default explicit
-bucket boundaries for their call duration histograms:
-
-| Convention    | Default bucket boundaries (seconds) |
-| :------------ | :---------------------------------- |
-| gRPC          | `0`, `0.00001`, `0.00005`, `0.0001`, `0.0003`, `0.0006`, `0.0008`, `0.001`, `0.002`, `0.003`, `0.004`, `0.005`, `0.006`, `0.008`, `0.01`, `0.013`, `0.016`, `0.02`, `0.025`, `0.03`, `0.04`, `0.05`, `0.065`, `0.08`, `0.1`, `0.13`, `0.16`, `0.2`, `0.25`, `0.3`, `0.4`, `0.5`, `0.65`, `0.8`, `1`, `2`, `5`, `10`, `20`, `50`, `100` |
-| OpenTelemetry | `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.25`, `0.5`, `0.75`, `1`, `2.5`, `5`, `7.5`, `10` |
-
-The gRPC boundaries were chosen to maintain compatibility with the
-[gRPC OpenCensus specification](https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/gRPC.md).
-Compared to the OpenTelemetry boundaries, they provide a much higher resolution
-below 5 ms and extend beyond 10 s, at the cost of a significantly higher number
-of buckets (and therefore higher cost) for every user.
-
-In both cases these boundaries are only defaults. Applications that need a
-different resolution can override them with their own explicit boundaries or
-switch to exponential histograms using an
-[OpenTelemetry SDK view](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view).
+The [OpenTelemetry gRPC conventions](/docs/rpc/grpc.md#metrics) advise the same
+duration histogram bucket boundaries as the gRPC conventions, except that the
+leading `0` boundary is omitted, so no conversion is needed.
 
 ## Spans
 

--- a/docs/non-normative/compatibility/grpc.md
+++ b/docs/non-normative/compatibility/grpc.md
@@ -12,6 +12,7 @@ linkTitle: gRPC
 - [Metrics](#metrics)
   - [Metric mapping](#metric-mapping)
   - [Attribute mapping](#attribute-mapping)
+  - [Histogram bucket boundaries](#histogram-bucket-boundaries)
 - [Spans](#spans)
   - [Mapping](#mapping)
   - [Additional attributes](#additional-attributes)
@@ -57,6 +58,27 @@ and the [OpenTelemetry conventions](/docs/rpc/rpc-metrics.md) for details.
 |                    | `server.address` and `server.port` | gRPC -> OTel: Parse the address and port from `grpc.target`<br>OTel -> gRPC: Drop |
 |                    | `rpc.system.name`                  | gRPC -> OTel: Set to `grpc`<br>OTel -> gRPC: Drop |
 |                    | `error.type`                       | gRPC -> OTel: Set to `rpc.response.status_code` when it indicates an error (see [gRPC OpenTelemetry conventions](/docs/rpc/grpc.md))<br>OTel -> gRPC: Drop |
+
+### Histogram bucket boundaries
+
+The gRPC and OpenTelemetry conventions recommend different default explicit
+bucket boundaries for their call duration histograms:
+
+| Convention    | Default bucket boundaries (seconds) |
+| :------------ | :---------------------------------- |
+| gRPC          | `0`, `0.00001`, `0.00005`, `0.0001`, `0.0003`, `0.0006`, `0.0008`, `0.001`, `0.002`, `0.003`, `0.004`, `0.005`, `0.006`, `0.008`, `0.01`, `0.013`, `0.016`, `0.02`, `0.025`, `0.03`, `0.04`, `0.05`, `0.065`, `0.08`, `0.1`, `0.13`, `0.16`, `0.2`, `0.25`, `0.3`, `0.4`, `0.5`, `0.65`, `0.8`, `1`, `2`, `5`, `10`, `20`, `50`, `100` |
+| OpenTelemetry | `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.25`, `0.5`, `0.75`, `1`, `2.5`, `5`, `7.5`, `10` |
+
+The gRPC boundaries were chosen to maintain compatibility with the
+[gRPC OpenCensus specification](https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/gRPC.md).
+Compared to the OpenTelemetry boundaries, they provide a much higher resolution
+below 5 ms and extend beyond 10 s, at the cost of a significantly higher number
+of buckets (and therefore higher cost) for every user.
+
+In both cases these boundaries are only defaults. Applications that need a
+different resolution can override them with their own explicit boundaries or
+switch to exponential histograms using an
+[OpenTelemetry SDK view](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view).
 
 ## Spans
 

--- a/docs/rpc/grpc.md
+++ b/docs/rpc/grpc.md
@@ -302,11 +302,18 @@ gRPC instrumentations SHOULD collect metrics according to the general
 
 `rpc.system.name` MUST be set to `"grpc"`.
 
-> [!NOTE]
-> The explicit bucket boundaries advised for `rpc.client.call.duration` and
-> `rpc.server.call.duration` differ from the default histogram buckets defined
-> by the gRPC project. See
-> [histogram bucket boundaries](/docs/non-normative/compatibility/grpc.md#histogram-bucket-boundaries)
-> in the gRPC compatibility document for a comparison.
+In place of the boundaries advised in the general RPC metrics conventions,
+`rpc.client.call.duration` and `rpc.server.call.duration` SHOULD be specified with
+[`ExplicitBucketBoundaries` advisory parameter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.59.0/specification/metrics/api.md#instrument-advisory-parameters)
+of `[ 0.00001, 0.00005, 0.0001, 0.0003, 0.0006, 0.0008, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.008, 0.01, 0.013, 0.016, 0.02, 0.025, 0.03, 0.04, 0.05, 0.065, 0.08, 0.1, 0.13, 0.16, 0.2, 0.25, 0.3, 0.4, 0.5, 0.65, 0.8, 1, 2, 5, 10, 20, 50, 100 ]`.
+
+These boundaries match the default histogram buckets defined by the gRPC project
+in [gRFC A66](https://github.com/grpc/proposal/blob/master/A66-otel-stats.md#units),
+which were chosen to maintain compatibility with the
+[gRPC OpenCensus specification](https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/gRPC.md).
+Compared to the general RPC boundaries, they provide a much higher resolution
+below 5 ms, which is where gRPC calls commonly fall, and they extend beyond 10 s.
+The leading `0` boundary of the gRPC set is omitted, since it only adds a bucket
+for non-positive durations.
 
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/rpc/grpc.md
+++ b/docs/rpc/grpc.md
@@ -302,4 +302,11 @@ gRPC instrumentations SHOULD collect metrics according to the general
 
 `rpc.system.name` MUST be set to `"grpc"`.
 
+> [!NOTE]
+> The explicit bucket boundaries advised for `rpc.client.call.duration` and
+> `rpc.server.call.duration` differ from the default histogram buckets defined
+> by the gRPC project. See
+> [histogram bucket boundaries](/docs/non-normative/compatibility/grpc.md#histogram-bucket-boundaries)
+> in the gRPC compatibility document for a comparison.
+
 [DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status


### PR DESCRIPTION
Fixes #3869

Advises gRPC-specific `ExplicitBucketBoundaries` for `rpc.client.call.duration` and `rpc.server.call.duration`, matching the default histogram buckets that gRPC defines in [gRFC A66](https://github.com/grpc/proposal/blob/master/A66-otel-stats.md#units) (the leading `0` boundary is omitted, since it only adds a bucket for non-positive durations).

`ExplicitBucketBoundaries` is an instrument advisory parameter supplied at instrument creation time, so a gRPC instrumentation can advise different boundaries than other RPC systems' instrumentations for the same metric.