### PR TITLE
Clarify otel.sdk.processor.span.processed and otel.sdk.processor.log.processed semantics for records a processor does not forward

### DIFF
--- a/.chloggen/clarify-processor-processed-recordonly.yaml
+++ b/.chloggen/clarify-processor-processed-recordonly.yaml
@@ -1,0 +1,13 @@
+change_type: enhancement
+
+component: otel
+
+note: >
+  Clarify that `otel.sdk.processor.span.processed` and `otel.sdk.processor.log.processed` count a record as successfully processed
+  when the processor completes its intended handling of it, and that for spans this includes `RECORD_ONLY` spans that the SDK
+  Simple and Batching Span Processors do not forward to an exporter (so a span counted as successfully processed is not necessarily
+  delivered to an exporter).
+
+issues: [3954]
+
+subtext:

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -262,12 +262,15 @@ This metric is [recommended][MetricRecommended].
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
 | `otel.sdk.processor.span.processed` | Counter | `{span}` | The number of spans for which the processing has finished, either successful or failed. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
 
-**[1]:** For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
+**[1]:** A span is counted as successfully processed once the processor completes its intended handling of it, in which case `error.type` MUST NOT be set.
+When the processor is unable to complete that handling, `error.type` MUST contain the failure cause.
 SDK Batching Span Processors MUST use `queue_full` as the value of `error.type` for spans dropped due to a full queue.
 If a processor reports a span dropped because it has already been shut down, `error.type` MUST be `already_shutdown`.
 Whether and when a processor drops such spans is governed by the SDK specification, not by this metric.
-For the SDK Simple and Batching Span Processors, a span MUST be counted as successfully processed at the point the processor
-invokes the export operation. For batching processors, all spans in the batch passed to the exporter are counted at that point;
+For the SDK Simple and Batching Span Processors, spans whose `otel.span.sampling_result` is `RECORD_ONLY` (recording but not sampled)
+are not forwarded to an exporter but MUST still be counted as successfully processed.
+A span that is forwarded to an exporter MUST be counted at the point the
+processor invokes the export operation. For batching processors, all spans in the batch passed to the exporter are counted at that point;
 spans accepted into the processor's queue but not yet passed to the exporter have not been processed.
 Implementations MUST NOT delay this count until the export operation concludes, and the outcome of the export operation,
 including an immediate failure of the invocation itself, MUST NOT affect this metric.
@@ -714,11 +717,12 @@ This metric is [recommended][MetricRecommended].
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
 | `otel.sdk.processor.log.processed` | Counter | `{log_record}` | The number of log records for which the processing has finished, either successful or failed. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
 
-**[1]:** For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
+**[1]:** A log record is counted as successfully processed once the processor completes its intended handling of it, in which case `error.type` MUST NOT be set.
+When the processor is unable to complete that handling, `error.type` MUST contain the failure cause.
 SDK Batching Log Record Processors MUST use `queue_full` as the value of `error.type` for log records dropped due to a full queue.
 If a processor reports a log record dropped because it has already been shut down, `error.type` MUST be `already_shutdown`.
 Whether and when a processor drops such log records is governed by the SDK specification, not by this metric.
-For the SDK Simple and Batching Log Record Processors, a log record MUST be counted as successfully processed at the point the
+For the SDK Simple and Batching Log Record Processors, a log record MUST be counted at the point the
 processor invokes the export operation. For batching processors, all log records in the batch passed to the exporter are counted
 at that point; log records accepted into the processor's queue but not yet passed to the exporter have not been processed.
 Implementations MUST NOT delay this count until the export operation concludes, and the outcome of the export operation,

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -71,12 +71,15 @@ groups:
     stability: development
     brief: "The number of spans for which the processing has finished, either successful or failed."
     note: |
-      For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
+      A span is counted as successfully processed once the processor completes its intended handling of it, in which case `error.type` MUST NOT be set.
+      When the processor is unable to complete that handling, `error.type` MUST contain the failure cause.
       SDK Batching Span Processors MUST use `queue_full` as the value of `error.type` for spans dropped due to a full queue.
       If a processor reports a span dropped because it has already been shut down, `error.type` MUST be `already_shutdown`.
       Whether and when a processor drops such spans is governed by the SDK specification, not by this metric.
-      For the SDK Simple and Batching Span Processors, a span MUST be counted as successfully processed at the point the processor
-      invokes the export operation. For batching processors, all spans in the batch passed to the exporter are counted at that point;
+      For the SDK Simple and Batching Span Processors, spans whose `otel.span.sampling_result` is `RECORD_ONLY` (recording but not sampled)
+      are not forwarded to an exporter but MUST still be counted as successfully processed.
+      A span that is forwarded to an exporter MUST be counted at the point the
+      processor invokes the export operation. For batching processors, all spans in the batch passed to the exporter are counted at that point;
       spans accepted into the processor's queue but not yet passed to the exporter have not been processed.
       Implementations MUST NOT delay this count until the export operation concludes, and the outcome of the export operation,
       including an immediate failure of the invocation itself, MUST NOT affect this metric.
@@ -200,11 +203,12 @@ groups:
     stability: development
     brief: "The number of log records for which the processing has finished, either successful or failed."
     note: |
-      For successful processing, `error.type` MUST NOT be set. For failed processing, `error.type` MUST contain the failure cause.
+      A log record is counted as successfully processed once the processor completes its intended handling of it, in which case `error.type` MUST NOT be set.
+      When the processor is unable to complete that handling, `error.type` MUST contain the failure cause.
       SDK Batching Log Record Processors MUST use `queue_full` as the value of `error.type` for log records dropped due to a full queue.
       If a processor reports a log record dropped because it has already been shut down, `error.type` MUST be `already_shutdown`.
       Whether and when a processor drops such log records is governed by the SDK specification, not by this metric.
-      For the SDK Simple and Batching Log Record Processors, a log record MUST be counted as successfully processed at the point the
+      For the SDK Simple and Batching Log Record Processors, a log record MUST be counted at the point the
       processor invokes the export operation. For batching processors, all log records in the batch passed to the exporter are counted
       at that point; log records accepted into the processor's queue but not yet passed to the exporter have not been processed.
       Implementations MUST NOT delay this count until the export operation concludes, and the outcome of the export operation,


### PR DESCRIPTION
The `otel.sdk.processor.span.processed` and `otel.sdk.processor.log.processed` metrics do not clearly define what "processed" means for a record a processor handles but does not forward to an exporter, for example `RECORD_ONLY` (recording, non-sampled) spans in the built-in Simple and Batching Span Processors.

This clarifies that a record is counted as successfully processed when the processor completes its intended handling of it (even if it is not forwarded to an exporter), and `error.type` is set only when the processor cannot complete that handling (for example `queue_full` or `already_shutdown`). `processed` is therefore an outcome metric and does not measure how many records reach an exporter, which is reported by `otel.sdk.exporter.{span,log}.exported`.

Measuring throughput or dataflow through a processor (how many records enter versus leave it) is intentionally out of scope, and could be a future dedicated pair of metrics, similar to the OpenTelemetry Collector's per-processor incoming/outgoing item counters. Alternatives such as adding that dataflow metric now, or adding an attribute to `processed` to separate forwarded from non-forwarded records, are considerably more disruptive: they expand the metric surface, require coordinated cross-language implementation, and take longer to settle. This clarification changes no metric shape and adds no attribute, so it is the least-disruptive way to remove the ambiguity and should let these long-standing metrics land as stable relatively soon.

If merged, most built-in span processor implementations will need small updates to conform. From a quick audit of Go, Python, and Java, the only one that already matches this clarification is Go's Simple Span Processor; the batch processors in all three, and Python's and Java's simple processors, currently drop non-forwarded `RECORD_ONLY` spans without counting them as processed.