### PR TITLE
Clarify otel.sdk.span.started does not count spans from a disabled Tracer

### DIFF
--- a/.chloggen/clarify-span-started-disabled-tracer.yaml
+++ b/.chloggen/clarify-span-started-disabled-tracer.yaml
@@ -1,0 +1,13 @@
+change_type: enhancement
+
+component: otel
+
+note: >
+  Clarify that `otel.sdk.span.started` does not count spans started on a
+  disabled `Tracer` (`TracerConfig.enabled` = `false`), since such a `Tracer` is
+  a No-op and does not create an SDK span. This mirrors the equivalent
+  clarification already made for disabled `Logger`s on `otel.sdk.log.created`.
+
+issues: [3954]
+
+subtext:

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -85,6 +85,8 @@ This metric is [recommended][MetricRecommended].
 | `otel.sdk.span.started` | Counter | `{span}` | The number of created spans. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
 
 **[1]:** Implementations MUST record this metric for all spans, even for non-recording ones.
+In OpenTelemetry SDKs a `Tracer` is enabled by default, and can be disabled via configuration i.e. `TracerConfig.enabled` = `false` when supported;
+a disabled `Tracer` is a No-op: starting a span on it does not create an SDK span, so those spans are not counted.
 
 **Attributes:**
 

--- a/model/otel/metrics.yaml
+++ b/model/otel/metrics.yaml
@@ -26,6 +26,8 @@ groups:
     unit: "{span}"
     note: |
       Implementations MUST record this metric for all spans, even for non-recording ones.
+      In OpenTelemetry SDKs a `Tracer` is enabled by default, and can be disabled via configuration i.e. `TracerConfig.enabled` = `false` when supported;
+      a disabled `Tracer` is a No-op: starting a span on it does not create an SDK span, so those spans are not counted.
     attributes:
       - ref: otel.span.sampling_result
       - ref: otel.span.parent.origin


### PR DESCRIPTION
`otel.sdk.span.started` does not say whether spans started on a disabled `Tracer` (`TracerConfig.enabled` = `false`) are counted.

Applies the same wording already merged for disabled `Logger`s on `otel.sdk.log.created` (#3939): a disabled `Tracer` is a No-op, so those spans are not counted. Documents existing behavior; no implementation changes.

Part of #3954.
