### PR TITLE
Migrate session to schema v2

### DIFF
--- a/docs/general/session.md
+++ b/docs/general/session.md
@@ -26,6 +26,10 @@ backends can link the two sessions (see [Session Start Event](#event-sessionstar
 <!-- see templates/registry/markdown/snippet.md.j2 -->
 <!-- prettier-ignore-start -->
 
+**Status:** ![Development](https://img.shields.io/badge/-development-blue)
+
+These attributes may be used to identify a user session.
+
 **Attributes:**
 
 | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |

--- a/docs/general/session.md
+++ b/docs/general/session.md
@@ -8,17 +8,6 @@ linkTitle: Session
 
 This document defines semantic conventions to apply to client-side applications when tracking sessions.
 
-Session is defined as the period of time encompassing all activities performed by the application and the actions
-executed by the end user.
-
-Consequently, a Session is represented as a collection of Logs, Events, and Spans emitted by the Client Application
-throughout the Session's duration. Each Session is assigned a unique identifier, which is included as an attribute in
-the Logs, Events, and Spans generated during the Session's lifecycle.
-
-When a session reaches end of life, typically due to user inactivity or session timeout, a new session identifier
-will be assigned. The previous session identifier may be provided by the instrumentation so that telemetry
-backends can link the two sessions (see [Session Start Event](#event-sessionstart) below).
-
 ## Attributes
 
 <!-- semconv session-id -->
@@ -28,7 +17,11 @@ backends can link the two sessions (see [Session Start Event](#event-sessionstar
 
 **Status:** ![Development](https://img.shields.io/badge/-development-blue)
 
-These attributes may be used to identify a user session.
+Session is defined as the period of time encompassing all activities performed by the application and the actions executed by the end user.
+
+Consequently, a Session is represented as a collection of Logs, Events, and Spans emitted by the Client Application throughout the Session's duration. Each Session is assigned a unique identifier, which is included as an attribute in the Logs, Events, and Spans generated during the Session's lifecycle.
+
+When a session reaches end of life, typically due to user inactivity or session timeout, a new session identifier will be assigned. The previous session identifier may be provided by the instrumentation so that telemetry backends can link the two sessions.
 
 **Attributes:**
 

--- a/docs/registry/attributes/session.md
+++ b/docs/registry/attributes/session.md
@@ -5,10 +5,6 @@
 
 ## Session Attributes
 
-Session is defined as the period of time encompassing all activities performed by the application and the actions executed by the end user.
-Consequently, a Session is represented as a collection of Logs, Events, and Spans emitted by the Client Application throughout the Session's duration. Each Session is assigned a unique identifier, which is included as an attribute in the Logs, Events, and Spans generated during the Session's lifecycle.
-When a session reaches end of life, typically due to user inactivity or session timeout, a new session identifier will be assigned. The previous session identifier may be provided by the instrumentation so that telemetry backends can link the two sessions.
-
 **Attributes:**
 
 | Key | Stability | Value Type | Description | Example Values |

--- a/model/session/common.yaml
+++ b/model/session/common.yaml
@@ -8,9 +8,11 @@ attribute_groups:
       Session is defined as the period of time encompassing all activities performed by the application and the actions
       executed by the end user.
 
+
       Consequently, a Session is represented as a collection of Logs, Events, and Spans emitted by the Client Application
       throughout the Session's duration. Each Session is assigned a unique identifier, which is included as an attribute in
       the Logs, Events, and Spans generated during the Session's lifecycle.
+
 
       When a session reaches end of life, typically due to user inactivity or session timeout, a new session identifier
       will be assigned. The previous session identifier may be provided by the instrumentation so that telemetry

--- a/model/session/common.yaml
+++ b/model/session/common.yaml
@@ -1,17 +1,11 @@
-groups:
+# yaml-language-server: $schema=https://raw.githubusercontent.com/open-telemetry/weaver/v0.25.1/schemas/semconv.schema.v2.json
+file_format: definition/2
+attribute_groups:
   - id: session-id
-    type: attribute_group
+    visibility: public
+    stability: development
     brief: >
-      Session is defined as the period of time encompassing all activities performed by the application and the actions
-      executed by the end user.
-
-      Consequently, a Session is represented as a collection of Logs, Events, and Spans emitted by the Client Application
-      throughout the Session's duration. Each Session is assigned a unique identifier, which is included as an attribute in
-      the Logs, Events, and Spans generated during the Session's lifecycle.
-
-      When a session reaches end of life, typically due to user inactivity or session timeout, a new session identifier
-      will be assigned. The previous session identifier may be provided by the instrumentation so that telemetry
-      backends can link the two sessions.
+      These attributes may be used to identify a user session.
     attributes:
       - ref: session.id
         requirement_level: opt_in

--- a/model/session/common.yaml
+++ b/model/session/common.yaml
@@ -5,7 +5,16 @@ attribute_groups:
     visibility: public
     stability: development
     brief: >
-      These attributes may be used to identify a user session.
+      Session is defined as the period of time encompassing all activities performed by the application and the actions
+      executed by the end user.
+
+      Consequently, a Session is represented as a collection of Logs, Events, and Spans emitted by the Client Application
+      throughout the Session's duration. Each Session is assigned a unique identifier, which is included as an attribute in
+      the Logs, Events, and Spans generated during the Session's lifecycle.
+
+      When a session reaches end of life, typically due to user inactivity or session timeout, a new session identifier
+      will be assigned. The previous session identifier may be provided by the instrumentation so that telemetry
+      backends can link the two sessions.
     attributes:
       - ref: session.id
         requirement_level: opt_in

--- a/model/session/events.yaml
+++ b/model/session/events.yaml
@@ -1,8 +1,8 @@
-groups:
-  - id: event.session.start
+# yaml-language-server: $schema=https://raw.githubusercontent.com/open-telemetry/weaver/v0.25.1/schemas/semconv.schema.v2.json
+file_format: definition/2
+events:
+  - name: session.start
     stability: development
-    type: event
-    name: session.start
     brief: >
       Indicates that a new session has been started, optionally linking to the prior session.
     note: >
@@ -26,10 +26,9 @@ groups:
             the `session.previous_id` SHOULD be included in the event. The `session.id` and `session.previous_id`
             attributes MUST have different values.
         brief: The previous `session.id` for this user, when known.
-  - id: event.session.end
+
+  - name: session.end
     stability: development
-    type: event
-    name: session.end
     brief: >
       Indicates that a session has ended.
     note: >

--- a/model/session/registry.yaml
+++ b/model/session/registry.yaml
@@ -1,26 +1,13 @@
-groups:
-  - id: registry.session
-    type: attribute_group
-    display_name: Session Attributes
-    brief: >
-      Session is defined as the period of time encompassing all activities performed by the application and the actions
-      executed by the end user.
-
-      Consequently, a Session is represented as a collection of Logs, Events, and Spans emitted by the Client Application
-      throughout the Session's duration. Each Session is assigned a unique identifier, which is included as an attribute in
-      the Logs, Events, and Spans generated during the Session's lifecycle.
-
-      When a session reaches end of life, typically due to user inactivity or session timeout, a new session identifier
-      will be assigned. The previous session identifier may be provided by the instrumentation so that telemetry
-      backends can link the two sessions.
-    attributes:
-      - id: session.id
-        type: string
-        stability: development
-        brief: "A unique ID to identify a session."
-        examples: "00112233-4455-6677-8899-aabbccddeeff"
-      - id: session.previous_id
-        type: string
-        stability: development
-        brief: "The previous `session.id` for this user, when known."
-        examples: "00112233-4455-6677-8899-aabbccddeeff"
+# yaml-language-server: $schema=https://raw.githubusercontent.com/open-telemetry/weaver/v0.25.1/schemas/semconv.schema.v2.json
+file_format: definition/2
+attributes:
+  - key: session.id
+    type: string
+    stability: development
+    brief: "A unique ID to identify a session."
+    examples: ['00112233-4455-6677-8899-aabbccddeeff']
+  - key: session.previous_id
+    type: string
+    stability: development
+    brief: "The previous `session.id` for this user, when known."
+    examples: ['00112233-4455-6677-8899-aabbccddeeff']


### PR DESCRIPTION
Part of #3808

## Changes

Migrate `session.*` to schema v2.

> [!IMPORTANT]
> Pull request acceptance is subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [x] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [ ] no AI used
  * [ ] AI-assisted
  * [x] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
