### PR TITLE
[k8s] Promote network metrics to release candidate

### DIFF
--- a/.chloggen/k8s_net_metrics_rc.yaml
+++ b/.chloggen/k8s_net_metrics_rc.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: k8s
+
+note: Promote `k8s.pod.network.io`, `k8s.pod.network.errors`, `k8s.node.network.io`, and `k8s.node.network.errors` metrics to `release_candidate`
+
+issues: [3946]
+
+subtext:

--- a/docs/system/k8s-metrics.md
+++ b/docs/system/k8s-metrics.md
@@ -420,7 +420,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name | Instrument Type | Unit (UCUM) | Description | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.network.io` | Counter | `By` | Network bytes for the Pod. | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.network.io` | Counter | `By` | Network bytes for the Pod. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **Attributes:**
 
@@ -453,7 +453,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name | Instrument Type | Unit (UCUM) | Description | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.pod.network.errors` | Counter | `{error}` | Pod network errors. | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
+| `k8s.pod.network.errors` | Counter | `{error}` | Pod network errors. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) | [`k8s.pod`](/docs/registry/entities/k8s.md#k8s-pod) |
 
 **Attributes:**
 
@@ -1198,7 +1198,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name | Instrument Type | Unit (UCUM) | Description | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.network.io` | Counter | `By` | Network bytes for the Node. | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.network.io` | Counter | `By` | Network bytes for the Node. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 **Attributes:**
 
@@ -1231,7 +1231,7 @@ This metric is [recommended][MetricRecommended].
 
 | Name | Instrument Type | Unit (UCUM) | Description | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `k8s.node.network.errors` | Counter | `{error}` | Node network errors. | ![Development](https://img.shields.io/badge/-development-blue) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
+| `k8s.node.network.errors` | Counter | `{error}` | Node network errors. | ![Release Candidate](https://img.shields.io/badge/-rc-mediumorchid) | [`k8s.node`](/docs/registry/entities/k8s.md#k8s-node) |
 
 **Attributes:**
 

--- a/model/k8s/metrics.yaml
+++ b/model/k8s/metrics.yaml
@@ -201,7 +201,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: int
-    stability: development
+    stability: release_candidate
     brief: "Network bytes for the Pod."
     instrument: counter
     unit: "By"
@@ -216,7 +216,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: int
-    stability: development
+    stability: release_candidate
     brief: "Pod network errors."
     instrument: counter
     entity_associations:
@@ -852,7 +852,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: int
-    stability: development
+    stability: release_candidate
     brief: "Network bytes for the Node."
     instrument: counter
     unit: "By"
@@ -867,7 +867,7 @@ groups:
     annotations:
       code_generation:
         metric_value_type: int
-    stability: development
+    stability: release_candidate
     brief: "Node network errors."
     instrument: counter
     unit: "{error}"


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/3946

## Changes

Please provide a brief description of the changes here.

This PR suggests the K8s pod network and Node network metrics from promotion to release candidate.

These metrics have been in use by the OTel Collector for quite some time now, without any issues:

- https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/documentation.md#k8snodenetworkerrors
- https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/documentation.md#k8snodenetworkio
- https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/documentation.md#k8spodnetworkerrors
- https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/documentation.md#k8spodnetworkio

Aligned with the respective system network metrics:

- [system.network.errors](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#metric-systemnetworkerrors)
- [system.network.io](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#metric-systemnetworkio)

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [ ] no AI used
  * [x] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
