### PR TITLE
[chore] Update spec repo links in all markdown and YAML files

### DIFF
--- a/.github/scripts/update-spec-repo-links.sh
+++ b/.github/scripts/update-spec-repo-links.sh
@@ -25,9 +25,9 @@ fix_file() {
   " "$1"
 }
 
-important_files=("docs" "model" "README.md")
-
-# TODO - limit to markdown/yaml files?
-find "${important_files[@]}" -type f -not -path '*/.*' -not -path '*.png' -print0 | while read -d $'\0' file; do
+# Update every tracked markdown and YAML file so that new spec references cannot
+# be missed. CHANGELOG.md is excluded because it intentionally links to the spec
+# version that was current at the time of each release.
+git ls-files -z -- '*.md' '*.yaml' '*.yml' ':(exclude)CHANGELOG.md' | while read -d $'\0' file; do
   fix_file "$file"
 done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -515,6 +515,6 @@ exists in some form in ECS, consider the following guidelines:
   entirely. See the [ECS field reference] for existing namespaces.
 
 [nvm]: https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
-[stability guarantees]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.37.0/specification/versioning-and-stability.md#semantic-conventions-stability
+[stability guarantees]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/versioning-and-stability.md#semantic-conventions-stability
 [otep222]: https://github.com/open-telemetry/oteps/pull/222
 [ECS field reference]: https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html


### PR DESCRIPTION
The spec repo link updater only scanned `docs`, `model` and `README.md`, so references anywhere else silently went stale — the `stability guarantees` link in `CONTRIBUTING.md` was still pinned to `v1.37.0`, added in #1458 and never bumped since.

Follow-up to https://github.com/open-telemetry/semantic-conventions/pull/3987#discussion_r3737120346.