### PR TITLE
Restore AWSAccessKeyId and Signature to the default sensitive query parameter list

### DIFF
--- a/.chloggen/restore-sigv2-cloudfront-redaction.yaml
+++ b/.chloggen/restore-sigv2-cloudfront-redaction.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: url
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Restore `AWSAccessKeyId` and `Signature` to the default list of sensitive query parameter keys.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [3779]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/restore-sigv2-cloudfront-redaction.yaml
+++ b/.chloggen/restore-sigv2-cloudfront-redaction.yaml
@@ -14,7 +14,7 @@ note: Restore `AWSAccessKeyId` and `Signature` to the default list of sensitive 
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 # The values here must be integers.
-issues: [3779]
+issues: [3989]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/docs/db/elasticsearch.md
+++ b/docs/db/elasticsearch.md
@@ -97,8 +97,14 @@ value `REDACTED`:
 * [`X-Amz-Signature`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
 * [`X-Amz-Credential`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
 * [`X-Amz-Security-Token`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
+* [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/developerguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+* [`Signature`](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html)
 * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
 * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
+
+Several of these keys are used by more than one service or signing scheme. Each link
+points to one representative usage rather than an exhaustive list, and does not narrow
+the scope of the key to the linked service or signing scheme.
 
 This list is subject to change over time.
 

--- a/docs/http/http-spans.md
+++ b/docs/http/http-spans.md
@@ -229,8 +229,14 @@ value `REDACTED`:
 * [`X-Amz-Signature`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
 * [`X-Amz-Credential`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
 * [`X-Amz-Security-Token`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
+* [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/developerguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+* [`Signature`](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html)
 * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
 * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
+
+Several of these keys are used by more than one service or signing scheme. Each link
+points to one representative usage rather than an exhaustive list, and does not narrow
+the scope of the key to the linked service or signing scheme.
 
 This list is subject to change over time.
 
@@ -567,8 +573,14 @@ Query string values for the following keys SHOULD be redacted by default and rep
 * [`X-Amz-Signature`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
 * [`X-Amz-Credential`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
 * [`X-Amz-Security-Token`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
+* [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/developerguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+* [`Signature`](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html)
 * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
 * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
+
+Several of these keys are used by more than one service or signing scheme. Each link
+points to one representative usage rather than an exhaustive list, and does not narrow
+the scope of the key to the linked service or signing scheme.
 
 This list is subject to change over time.
 

--- a/docs/registry/attributes/url.md
+++ b/docs/registry/attributes/url.md
@@ -46,8 +46,14 @@ value `REDACTED`:
 * [`X-Amz-Signature`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
 * [`X-Amz-Credential`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
 * [`X-Amz-Security-Token`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
+* [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/developerguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+* [`Signature`](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html)
 * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
 * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
+
+Several of these keys are used by more than one service or signing scheme. Each link
+points to one representative usage rather than an exhaustive list, and does not narrow
+the scope of the key to the linked service or signing scheme.
 
 This list is subject to change over time.
 
@@ -77,8 +83,14 @@ Query string values for the following keys SHOULD be redacted by default and rep
 * [`X-Amz-Signature`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
 * [`X-Amz-Credential`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
 * [`X-Amz-Security-Token`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
+* [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/developerguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+* [`Signature`](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html)
 * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
 * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
+
+Several of these keys are used by more than one service or signing scheme. Each link
+points to one representative usage rather than an exhaustive list, and does not narrow
+the scope of the key to the linked service or signing scheme.
 
 This list is subject to change over time.
 

--- a/model/url/registry.yaml
+++ b/model/url/registry.yaml
@@ -58,8 +58,14 @@ groups:
           * [`X-Amz-Signature`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
           * [`X-Amz-Credential`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
           * [`X-Amz-Security-Token`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
+          * [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/developerguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+          * [`Signature`](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html)
           * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
           * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
+
+          Several of these keys are used by more than one service or signing scheme. Each link
+          points to one representative usage rather than an exhaustive list, and does not narrow
+          the scope of the key to the linked service or signing scheme.
 
           This list is subject to change over time.
 
@@ -122,8 +128,14 @@ groups:
           * [`X-Amz-Signature`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
           * [`X-Amz-Credential`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
           * [`X-Amz-Security-Token`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-authentication-methods.html)
+          * [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/developerguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+          * [`Signature`](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html)
           * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
           * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
+
+          Several of these keys are used by more than one service or signing scheme. Each link
+          points to one representative usage rather than an exhaustive list, and does not narrow
+          the scope of the key to the linked service or signing scheme.
 
           This list is subject to change over time.
 


### PR DESCRIPTION
## Changes

Restores `AWSAccessKeyId` and `Signature` to the default sensitive query parameter list.

#3779 removed these because AWS appeared to have deleted the pages documenting them. The pages moved rather than being deleted — `userguide` → `developerguide`, anchor intact. Both keys still match live traffic: `Signature` is also the signature in CloudFront signed URLs, which are unrelated to SigV2, and [SigV2 remains accepted](https://aws.amazon.com/blogs/aws/amazon-s3-update-sigv2-deprecation-period-extended-modified/) for S3 buckets in the eight regions launched before 2014 regardless of bucket creation date. Matching is exact and case-sensitive, so `X-Amz-Signature` does not cover `Signature`.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [ ] no AI used
  * [x] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
