### PR TITLE
Add nighly and before-release smoke test for codegen

### DIFF
--- a/.github/workflows/downstream-codegen-check.yml
+++ b/.github/workflows/downstream-codegen-check.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   java:
     name: java
@@ -96,7 +100,12 @@ jobs:
         run: |
           # The version the next release will use, e.g. "1.45.0-unreleased" -> "v1.45.0".
           version=$(sed -n 's|^schema_url: https://opentelemetry.io/schemas/\(.*\)$|\1|p' semantic-conventions/model/manifest.yaml)
-          echo "tag=v${version%-unreleased}" >> "$GITHUB_OUTPUT"
+          version=${version%-unreleased}
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::could not resolve version from model/manifest.yaml, got '$version'"
+            exit 1
+          fi
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
 
       # Mirrors the "semconv-generate" target of the opentelemetry-go Makefile, except
       # that the registry is the model in this repository rather than a released zip.

--- a/.github/workflows/downstream-codegen-check.yml
+++ b/.github/workflows/downstream-codegen-check.yml
@@ -28,9 +28,6 @@ jobs:
       github.repository_owner == 'open-telemetry' &&
       (github.event_name != 'pull_request' || startsWith(github.head_ref, 'otelbot/prepare-release-'))
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write # required to report scheduled failures
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -145,26 +142,15 @@ jobs:
           make "$PWD/.tools/golangci-lint"
           ./.tools/golangci-lint run --allow-serial-runners "./semconv/$TAG/..."
 
-      # Same as reusable-workflow-notification.yml, inlined so that pull requests get a
-      # single check. On release preparation PRs the failing job is signal enough.
-      - name: Open issue or add comment if issue already open
-        if: always() && github.event_name != 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          SUCCESS: ${{ job.status == 'success' }}
-        run: |
-          # TODO (trask) search doesn't support exact phrases, so it's possible that this could grab the wrong issue
-          number=$(gh issue list --search "in:title Workflow failed: $GITHUB_WORKFLOW" --limit 1 --json number -q .[].number)
-
-          if [[ $number ]]; then
-            if [[ "$SUCCESS" == "true" ]]; then
-              gh issue close $number
-            else
-              gh issue comment $number \
-                               --body "See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
-            fi
-          elif [[ "$SUCCESS" == "false" ]]; then
-            gh issue create --title "Workflow failed: $GITHUB_WORKFLOW (#$GITHUB_RUN_NUMBER)" \
-                            --body "See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
-          fi
+  # Scheduled runs open (or comment on) a tracking issue; on release preparation PRs
+  # the failing job is signal enough.
+  workflow-notification:
+    permissions: # required by the reusable workflow
+      contents: read
+      issues: write
+    needs:
+      - downstream-codegen
+    if: always() && github.event_name != 'pull_request' && github.repository_owner == 'open-telemetry'
+    uses: ./.github/workflows/reusable-workflow-notification.yml
+    with:
+      success: ${{ needs.downstream-codegen.result == 'success' }}

--- a/.github/workflows/downstream-codegen-check.yml
+++ b/.github/workflows/downstream-codegen-check.yml
@@ -2,6 +2,8 @@
 # model in this repository (instead of their pinned version of semconv), then compiles and
 # lints the result. This catches changes that break code generation before they
 # are released.
+#
+# Java and Go share a single job so that pull requests only get one check.
 name: Downstream codegen check
 
 on:
@@ -21,8 +23,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  java:
-    name: java
+  downstream-codegen:
+    name: downstream-codegen
     if: >-
       github.repository_owner == 'open-telemetry' &&
       (github.event_name != 'pull_request' || startsWith(github.head_ref, 'otelbot/prepare-release-'))
@@ -39,6 +41,12 @@ jobs:
           path: semantic-conventions-java
           persist-credentials: false
 
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: open-telemetry/opentelemetry-go
+          path: opentelemetry-go
+          persist-credentials: false
+
       - name: Set up Java
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
@@ -47,9 +55,14 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
-      # The build normally generates from the latest released semconv zip; point it at
-      # the model in this repository instead.
-      - name: Use local model
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: opentelemetry-go/go.mod
+          cache-dependency-path: opentelemetry-go/**/go.sum
+
+      # The Java build normally generates from the latest released semconv zip; point it
+      # at the model in this repository instead.
+      - name: Java - use local model
         working-directory: semantic-conventions-java
         run: |
           if ! grep -q 'val modelPath = layout.buildDirectory' build.gradle.kts; then
@@ -59,44 +72,23 @@ jobs:
           sed -i "s|^\( *val modelPath = \).*$|\1File(\"$GITHUB_WORKSPACE/semantic-conventions/model\")|" build.gradle.kts
           grep -n 'val modelPath' build.gradle.kts
 
-      - name: Generate
+      - name: Java - generate
         working-directory: semantic-conventions-java
         run: ./gradlew generateSemanticConventions --console=plain
 
       # Generated code is formatted by spotless, as in the downstream release workflow.
-      - name: Format
+      - name: Java - format
         working-directory: semantic-conventions-java
         run: ./gradlew spotlessApply
 
-      - name: Build
+      - name: Java - build
         working-directory: semantic-conventions-java
         run: ./gradlew build
 
-  go:
-    name: go
-    if: >-
-      github.repository_owner == 'open-telemetry' &&
-      (github.event_name != 'pull_request' || startsWith(github.head_ref, 'otelbot/prepare-release-'))
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          path: semantic-conventions
-          persist-credentials: false
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: open-telemetry/opentelemetry-go
-          path: opentelemetry-go
-          persist-credentials: false
-
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: opentelemetry-go/go.mod
-          cache-dependency-path: opentelemetry-go/**/go.sum
-
-      - name: Resolve version
+      # Go steps run even when Java failed, so that one run reports both languages.
+      - name: Go - resolve version
         id: version
+        if: ${{ !cancelled() }}
         run: |
           # The version the next release will use, e.g. "1.45.0-unreleased" -> "v1.45.0".
           version=$(sed -n 's|^schema_url: https://opentelemetry.io/schemas/\(.*\)$|\1|p' semantic-conventions/model/manifest.yaml)
@@ -109,8 +101,9 @@ jobs:
 
       # Mirrors the "semconv-generate" target of the opentelemetry-go Makefile, except
       # that the registry is the model in this repository rather than a released zip.
-      - name: Generate
+      - name: Go - generate
         working-directory: opentelemetry-go
+        if: ${{ !cancelled() && steps.version.outcome == 'success' }}
         env:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
@@ -132,16 +125,18 @@ jobs:
           (cd internal/tools && go build -o ../../.tools/semconvkit ./semconvkit)
           ./.tools/semconvkit -semconv semconv/ -tag "$TAG"
 
-      - name: Build
+      - name: Go - build
         working-directory: opentelemetry-go
+        if: ${{ !cancelled() && steps.version.outcome == 'success' }}
         env:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           go build "./semconv/$TAG/..."
           go vet "./semconv/$TAG/..."
 
-      - name: Lint
+      - name: Go - lint
         working-directory: opentelemetry-go
+        if: ${{ !cancelled() && steps.version.outcome == 'success' }}
         env:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
@@ -155,9 +150,8 @@ jobs:
       contents: read
       issues: write
     needs:
-      - java
-      - go
+      - downstream-codegen
     if: always() && github.event_name != 'pull_request' && github.repository_owner == 'open-telemetry'
     uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
-      success: ${{ needs.java.result == 'success' && needs.go.result == 'success' }}
+      success: ${{ needs.downstream-codegen.result == 'success' }}

--- a/.github/workflows/downstream-codegen-check.yml
+++ b/.github/workflows/downstream-codegen-check.yml
@@ -11,8 +11,7 @@ on:
     # Daily at 03:00 UTC
     - cron: "0 3 * * *"
   workflow_dispatch:
-  # Runs on all pull requests so that it can be a required check, but only actually
-  # executes on release preparation PRs.
+  # Only release preparation PRs are checked, other pull requests skip the job.
   pull_request:
 
 permissions:
@@ -29,6 +28,9 @@ jobs:
       github.repository_owner == 'open-telemetry' &&
       (github.event_name != 'pull_request' || startsWith(github.head_ref, 'otelbot/prepare-release-'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # required to report scheduled failures
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -143,15 +145,26 @@ jobs:
           make "$PWD/.tools/golangci-lint"
           ./.tools/golangci-lint run --allow-serial-runners "./semconv/$TAG/..."
 
-  # Scheduled runs open (or comment on) a tracking issue; on release preparation PRs
-  # the failing job is signal enough.
-  workflow-notification:
-    permissions: # required by the reusable workflow
-      contents: read
-      issues: write
-    needs:
-      - downstream-codegen
-    if: always() && github.event_name != 'pull_request' && github.repository_owner == 'open-telemetry'
-    uses: ./.github/workflows/reusable-workflow-notification.yml
-    with:
-      success: ${{ needs.downstream-codegen.result == 'success' }}
+      # Same as reusable-workflow-notification.yml, inlined so that pull requests get a
+      # single check. On release preparation PRs the failing job is signal enough.
+      - name: Open issue or add comment if issue already open
+        if: always() && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          SUCCESS: ${{ job.status == 'success' }}
+        run: |
+          # TODO (trask) search doesn't support exact phrases, so it's possible that this could grab the wrong issue
+          number=$(gh issue list --search "in:title Workflow failed: $GITHUB_WORKFLOW" --limit 1 --json number -q .[].number)
+
+          if [[ $number ]]; then
+            if [[ "$SUCCESS" == "true" ]]; then
+              gh issue close $number
+            else
+              gh issue comment $number \
+                               --body "See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+            fi
+          elif [[ "$SUCCESS" == "false" ]]; then
+            gh issue create --title "Workflow failed: $GITHUB_WORKFLOW (#$GITHUB_RUN_NUMBER)" \
+                            --body "See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+          fi

--- a/.github/workflows/downstream-codegen-check.yml
+++ b/.github/workflows/downstream-codegen-check.yml
@@ -1,0 +1,154 @@
+# Generates semantic convention code in downstream language repositories from the
+# model in this repository (instead of their pinned version of semconv), then compiles and
+# lints the result. This catches changes that break code generation before they
+# are released.
+name: Downstream codegen check
+
+on:
+  schedule:
+    # Daily at 03:00 UTC
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+  # Runs on all pull requests so that it can be a required check, but only actually
+  # executes on release preparation PRs.
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  java:
+    name: java
+    if: >-
+      github.repository_owner == 'open-telemetry' &&
+      (github.event_name != 'pull_request' || startsWith(github.head_ref, 'otelbot/prepare-release-'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: semantic-conventions
+          persist-credentials: false
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: open-telemetry/semantic-conventions-java
+          path: semantic-conventions-java
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      # The build normally generates from the latest released semconv zip; point it at
+      # the model in this repository instead.
+      - name: Use local model
+        working-directory: semantic-conventions-java
+        run: |
+          if ! grep -q 'val modelPath = layout.buildDirectory' build.gradle.kts; then
+            echo "::error::semantic-conventions-java build.gradle.kts no longer defines modelPath as expected, update this workflow"
+            exit 1
+          fi
+          sed -i "s|^\( *val modelPath = \).*$|\1File(\"$GITHUB_WORKSPACE/semantic-conventions/model\")|" build.gradle.kts
+          grep -n 'val modelPath' build.gradle.kts
+
+      - name: Generate
+        working-directory: semantic-conventions-java
+        run: ./gradlew generateSemanticConventions --console=plain
+
+      # Generated code is formatted by spotless, as in the downstream release workflow.
+      - name: Format
+        working-directory: semantic-conventions-java
+        run: ./gradlew spotlessApply
+
+      - name: Build
+        working-directory: semantic-conventions-java
+        run: ./gradlew build
+
+  go:
+    name: go
+    if: >-
+      github.repository_owner == 'open-telemetry' &&
+      (github.event_name != 'pull_request' || startsWith(github.head_ref, 'otelbot/prepare-release-'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: semantic-conventions
+          persist-credentials: false
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: open-telemetry/opentelemetry-go
+          path: opentelemetry-go
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: opentelemetry-go/go.mod
+          cache-dependency-path: opentelemetry-go/**/go.sum
+
+      - name: Resolve version
+        id: version
+        run: |
+          # The version the next release will use, e.g. "1.45.0-unreleased" -> "v1.45.0".
+          version=$(sed -n 's|^schema_url: https://opentelemetry.io/schemas/\(.*\)$|\1|p' semantic-conventions/model/manifest.yaml)
+          echo "tag=v${version%-unreleased}" >> "$GITHUB_OUTPUT"
+
+      # Mirrors the "semconv-generate" target of the opentelemetry-go Makefile, except
+      # that the registry is the model in this repository rather than a released zip.
+      - name: Generate
+        working-directory: opentelemetry-go
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          weaver_image=$(awk '$4=="weaver" {print $2}' dependencies.Dockerfile)
+          mkdir -p "semconv/$TAG" ~/.weaver
+          docker run --rm \
+            -u "$(id -u):$(id -g)" \
+            --env HOME=/tmp/weaver \
+            --mount "type=bind,source=$PWD/semconv/templates,target=/home/weaver/templates,readonly" \
+            --mount "type=bind,source=$PWD/semconv/$TAG,target=/home/weaver/target" \
+            --mount "type=bind,source=$GITHUB_WORKSPACE/semantic-conventions/model,target=/home/weaver/source,readonly" \
+            --mount "type=bind,source=$HOME/.weaver,target=/tmp/weaver/.weaver" \
+            "$weaver_image" registry generate \
+            --registry=/home/weaver/source \
+            --templates=/home/weaver/templates \
+            --param tag="$TAG" \
+            go \
+            /home/weaver/target
+          (cd internal/tools && go build -o ../../.tools/semconvkit ./semconvkit)
+          ./.tools/semconvkit -semconv semconv/ -tag "$TAG"
+
+      - name: Build
+        working-directory: opentelemetry-go
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          go build "./semconv/$TAG/..."
+          go vet "./semconv/$TAG/..."
+
+      - name: Lint
+        working-directory: opentelemetry-go
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          make "$PWD/.tools/golangci-lint"
+          ./.tools/golangci-lint run --allow-serial-runners "./semconv/$TAG/..."
+
+  # Scheduled runs open (or comment on) a tracking issue; on release preparation PRs
+  # the failing job is signal enough.
+  workflow-notification:
+    permissions: # required by the reusable workflow
+      contents: read
+      issues: write
+    needs:
+      - java
+      - go
+    if: always() && github.event_name != 'pull_request' && github.repository_owner == 'open-telemetry'
+    uses: ./.github/workflows/reusable-workflow-notification.yml
+    with:
+      success: ${{ needs.java.result == 'success' && needs.go.result == 'success' }}


### PR DESCRIPTION
Add workflow that runs codegen for [semconv-java](https://github.com/open-telemetry/semantic-conventions-java) and [go](https://github.com/open-telemetry/opentelemetry-go/blob/bfae1e0df9eb818770705fc7a7fb3bed3a91c027/Makefile#L276) against current semconv.

Success criteria: codegen does not fail, the result compiles and passes linters.

It runs daily and creates an issue when it fails (or updates existing one).
It also runs in prepare-release, so next time we catch something like https://github.com/open-telemetry/semantic-conventions-java/actions/runs/30947243982/job/92120233270 before it is released.

Language selection can be changed. Added Java because it's compiled, Go because it's compiled and has metric generation. Eventually once codegen templates for compiled languages are added to https://github.com/open-telemetry/opentelemetry-weaver-packages, we should switch to them.