### PR TITLE
[k8s] Add k8s.<entity>.creation_time attributes

### DIFF
--- a/.chloggen/k8s_entity_creation_time.yaml
+++ b/.chloggen/k8s_entity_creation_time.yaml
@@ -1,0 +1,13 @@
+change_type: enhancement
+
+component: k8s
+
+note: Add `k8s.<entity>.creation_time` attributes carrying the object's `metadata.creationTimestamp`
+
+issues: [3958]
+
+subtext: |
+  The attributes are opt-in and added with `development` stability on the following entities:
+    - k8s.node, k8s.namespace
+    - k8s.deployment, k8s.statefulset, k8s.daemonset, k8s.replicaset, k8s.job, k8s.cronjob
+    - k8s.persistentvolume, k8s.persistentvolumeclaim

--- a/docs/registry/attributes/k8s.md
+++ b/docs/registry/attributes/k8s.md
@@ -23,81 +23,91 @@ Kubernetes resource attributes.
 | <a id="k8s-container-status-reason" href="#k8s-container-status-reason">`k8s.container.status.reason`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The reason for the container state. Corresponds to the `reason` field of the: [K8s ContainerStateWaiting](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#containerstatewaiting-v1-core) or [K8s ContainerStateTerminated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#containerstateterminated-v1-core) | `ContainerCreating`; `CrashLoopBackOff`; `CreateContainerConfigError`; `ErrImagePull`; `ImagePullBackOff`; `OOMKilled`; `Completed`; `Error`; `ContainerCannotRun` |
 | <a id="k8s-container-status-state" href="#k8s-container-status-state">`k8s.container.status.state`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The state of the container. [K8s ContainerState](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#containerstate-v1-core) | `terminated`; `running`; `waiting` |
 | <a id="k8s-cronjob-annotation" href="#k8s-cronjob-annotation">`k8s.cronjob.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The cronjob annotation placed on the CronJob, the `<key>` being the annotation name, the value being the annotation value. [3] | `4`; `` |
-| <a id="k8s-cronjob-label" href="#k8s-cronjob-label">`k8s.cronjob.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the CronJob, the `<key>` being the label name, the value being the label value. [4] | `weekly`; `` |
+| <a id="k8s-cronjob-creation-time" href="#k8s-cronjob-creation-time">`k8s.cronjob.creation_time`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The creation timestamp of the CronJob. [4] | `2025-12-04T08:41:03Z` |
+| <a id="k8s-cronjob-label" href="#k8s-cronjob-label">`k8s.cronjob.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the CronJob, the `<key>` being the label name, the value being the label value. [5] | `weekly`; `` |
 | <a id="k8s-cronjob-name" href="#k8s-cronjob-name">`k8s.cronjob.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The name of the CronJob. | `opentelemetry` |
 | <a id="k8s-cronjob-uid" href="#k8s-cronjob-uid">`k8s.cronjob.uid`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The UID of the CronJob. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
-| <a id="k8s-daemonset-annotation" href="#k8s-daemonset-annotation">`k8s.daemonset.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the DaemonSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [5] | `1`; `` |
-| <a id="k8s-daemonset-label" href="#k8s-daemonset-label">`k8s.daemonset.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the DaemonSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [6] | `guestbook`; `` |
+| <a id="k8s-daemonset-annotation" href="#k8s-daemonset-annotation">`k8s.daemonset.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the DaemonSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [6] | `1`; `` |
+| <a id="k8s-daemonset-creation-time" href="#k8s-daemonset-creation-time">`k8s.daemonset.creation_time`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The creation timestamp of the DaemonSet. [7] | `2025-12-04T08:41:03Z` |
+| <a id="k8s-daemonset-label" href="#k8s-daemonset-label">`k8s.daemonset.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the DaemonSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [8] | `guestbook`; `` |
 | <a id="k8s-daemonset-name" href="#k8s-daemonset-name">`k8s.daemonset.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The name of the DaemonSet. | `opentelemetry` |
 | <a id="k8s-daemonset-uid" href="#k8s-daemonset-uid">`k8s.daemonset.uid`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The UID of the DaemonSet. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
-| <a id="k8s-deployment-annotation" href="#k8s-deployment-annotation">`k8s.deployment.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the Deployment, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [7] | `1`; `` |
-| <a id="k8s-deployment-label" href="#k8s-deployment-label">`k8s.deployment.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the Deployment, the `<key>` being the label name, the value being the label value, even if the value is empty. [8] | `guestbook`; `` |
+| <a id="k8s-deployment-annotation" href="#k8s-deployment-annotation">`k8s.deployment.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the Deployment, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [9] | `1`; `` |
+| <a id="k8s-deployment-creation-time" href="#k8s-deployment-creation-time">`k8s.deployment.creation_time`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The creation timestamp of the Deployment. [10] | `2025-12-04T08:41:03Z` |
+| <a id="k8s-deployment-label" href="#k8s-deployment-label">`k8s.deployment.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the Deployment, the `<key>` being the label name, the value being the label value, even if the value is empty. [11] | `guestbook`; `` |
 | <a id="k8s-deployment-name" href="#k8s-deployment-name">`k8s.deployment.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The name of the Deployment. | `opentelemetry` |
 | <a id="k8s-deployment-uid" href="#k8s-deployment-uid">`k8s.deployment.uid`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The UID of the Deployment. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
-| <a id="k8s-hpa-metric-type" href="#k8s-hpa-metric-type">`k8s.hpa.metric.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The type of metric source for the horizontal pod autoscaler. [9] | `Resource`; `ContainerResource` |
+| <a id="k8s-hpa-metric-type" href="#k8s-hpa-metric-type">`k8s.hpa.metric.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The type of metric source for the horizontal pod autoscaler. [12] | `Resource`; `ContainerResource` |
 | <a id="k8s-hpa-name" href="#k8s-hpa-name">`k8s.hpa.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the horizontal pod autoscaler. | `opentelemetry` |
-| <a id="k8s-hpa-scaletargetref-api-version" href="#k8s-hpa-scaletargetref-api-version">`k8s.hpa.scaletargetref.api_version`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [10] | `apps/v1`; `autoscaling/v2` |
-| <a id="k8s-hpa-scaletargetref-kind" href="#k8s-hpa-scaletargetref-kind">`k8s.hpa.scaletargetref.kind`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [11] | `Deployment`; `StatefulSet` |
-| <a id="k8s-hpa-scaletargetref-name" href="#k8s-hpa-scaletargetref-name">`k8s.hpa.scaletargetref.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [12] | `my-deployment`; `my-statefulset` |
+| <a id="k8s-hpa-scaletargetref-api-version" href="#k8s-hpa-scaletargetref-api-version">`k8s.hpa.scaletargetref.api_version`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [13] | `apps/v1`; `autoscaling/v2` |
+| <a id="k8s-hpa-scaletargetref-kind" href="#k8s-hpa-scaletargetref-kind">`k8s.hpa.scaletargetref.kind`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [14] | `Deployment`; `StatefulSet` |
+| <a id="k8s-hpa-scaletargetref-name" href="#k8s-hpa-scaletargetref-name">`k8s.hpa.scaletargetref.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [15] | `my-deployment`; `my-statefulset` |
 | <a id="k8s-hpa-uid" href="#k8s-hpa-uid">`k8s.hpa.uid`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The UID of the horizontal pod autoscaler. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | <a id="k8s-hugepage-size" href="#k8s-hugepage-size">`k8s.hugepage.size`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The size (identifier) of the K8s huge page. | `2Mi` |
-| <a id="k8s-job-annotation" href="#k8s-job-annotation">`k8s.job.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the Job, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [13] | `1`; `` |
-| <a id="k8s-job-label" href="#k8s-job-label">`k8s.job.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the Job, the `<key>` being the label name, the value being the label value, even if the value is empty. [14] | `ci`; `` |
+| <a id="k8s-job-annotation" href="#k8s-job-annotation">`k8s.job.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the Job, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [16] | `1`; `` |
+| <a id="k8s-job-creation-time" href="#k8s-job-creation-time">`k8s.job.creation_time`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The creation timestamp of the Job. [17] | `2025-12-04T08:41:03Z` |
+| <a id="k8s-job-label" href="#k8s-job-label">`k8s.job.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the Job, the `<key>` being the label name, the value being the label value, even if the value is empty. [18] | `ci`; `` |
 | <a id="k8s-job-name" href="#k8s-job-name">`k8s.job.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The name of the Job. | `opentelemetry` |
 | <a id="k8s-job-uid" href="#k8s-job-uid">`k8s.job.uid`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The UID of the Job. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
-| <a id="k8s-namespace-annotation" href="#k8s-namespace-annotation">`k8s.namespace.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the Namespace, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [15] | `0`; `` |
-| <a id="k8s-namespace-label" href="#k8s-namespace-label">`k8s.namespace.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the Namespace, the `<key>` being the label name, the value being the label value, even if the value is empty. [16] | `default`; `` |
+| <a id="k8s-namespace-annotation" href="#k8s-namespace-annotation">`k8s.namespace.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the Namespace, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [19] | `0`; `` |
+| <a id="k8s-namespace-creation-time" href="#k8s-namespace-creation-time">`k8s.namespace.creation_time`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The creation timestamp of the Namespace. [20] | `2025-12-04T08:41:03Z` |
+| <a id="k8s-namespace-label" href="#k8s-namespace-label">`k8s.namespace.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the Namespace, the `<key>` being the label name, the value being the label value, even if the value is empty. [21] | `default`; `` |
 | <a id="k8s-namespace-name" href="#k8s-namespace-name">`k8s.namespace.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The name of the namespace that the pod is running in. | `default` |
-| <a id="k8s-namespace-phase" href="#k8s-namespace-phase">`k8s.namespace.phase`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The phase of the K8s namespace. [17] | `active`; `terminating` |
-| <a id="k8s-node-annotation" href="#k8s-node-annotation">`k8s.node.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the Node, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [18] | `0`; `` |
-| <a id="k8s-node-condition-status" href="#k8s-node-condition-status">`k8s.node.condition.status`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The status of the condition, one of True, False, Unknown. [19] | `true`; `false`; `unknown` |
-| <a id="k8s-node-condition-type" href="#k8s-node-condition-type">`k8s.node.condition.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The condition type of a K8s Node. [20] | `Ready`; `DiskPressure` |
-| <a id="k8s-node-label" href="#k8s-node-label">`k8s.node.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the Node, the `<key>` being the label name, the value being the label value, even if the value is empty. [21] | `arm64`; `` |
+| <a id="k8s-namespace-phase" href="#k8s-namespace-phase">`k8s.namespace.phase`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The phase of the K8s namespace. [22] | `active`; `terminating` |
+| <a id="k8s-node-annotation" href="#k8s-node-annotation">`k8s.node.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the Node, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [23] | `0`; `` |
+| <a id="k8s-node-condition-status" href="#k8s-node-condition-status">`k8s.node.condition.status`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The status of the condition, one of True, False, Unknown. [24] | `true`; `false`; `unknown` |
+| <a id="k8s-node-condition-type" href="#k8s-node-condition-type">`k8s.node.condition.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The condition type of a K8s Node. [25] | `Ready`; `DiskPressure` |
+| <a id="k8s-node-creation-time" href="#k8s-node-creation-time">`k8s.node.creation_time`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The creation timestamp of the Node. [26] | `2025-12-04T08:41:03Z` |
+| <a id="k8s-node-label" href="#k8s-node-label">`k8s.node.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the Node, the `<key>` being the label name, the value being the label value, even if the value is empty. [27] | `arm64`; `` |
 | <a id="k8s-node-name" href="#k8s-node-name">`k8s.node.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The name of the Node. | `node-1` |
 | <a id="k8s-node-system-container-name" href="#k8s-node-system-container-name">`k8s.node.system_container.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the system container running on the K8s Node. | `kubelet`; `runtime`; `pods`; `misc` |
 | <a id="k8s-node-uid" href="#k8s-node-uid">`k8s.node.uid`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The UID of the Node. | `1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2` |
-| <a id="k8s-persistentvolume-annotation" href="#k8s-persistentvolume-annotation">`k8s.persistentvolume.annotation.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The annotation placed on the PersistentVolume, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [22] | `kubernetes.io/aws-ebs`; `` |
-| <a id="k8s-persistentvolume-label" href="#k8s-persistentvolume-label">`k8s.persistentvolume.label.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The label placed on the PersistentVolume, the `<key>` being the label name, the value being the label value, even if the value is empty. [23] | `ssd`; `` |
+| <a id="k8s-persistentvolume-annotation" href="#k8s-persistentvolume-annotation">`k8s.persistentvolume.annotation.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The annotation placed on the PersistentVolume, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [28] | `kubernetes.io/aws-ebs`; `` |
+| <a id="k8s-persistentvolume-creation-time" href="#k8s-persistentvolume-creation-time">`k8s.persistentvolume.creation_time`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The creation timestamp of the PersistentVolume. [29] | `2025-12-04T08:41:03Z` |
+| <a id="k8s-persistentvolume-label" href="#k8s-persistentvolume-label">`k8s.persistentvolume.label.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The label placed on the PersistentVolume, the `<key>` being the label name, the value being the label value, even if the value is empty. [30] | `ssd`; `` |
 | <a id="k8s-persistentvolume-name" href="#k8s-persistentvolume-name">`k8s.persistentvolume.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the PersistentVolume. | `pv-data-01` |
-| <a id="k8s-persistentvolume-reclaim-policy" href="#k8s-persistentvolume-reclaim-policy">`k8s.persistentvolume.reclaim_policy`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The reclaim policy of the PersistentVolume. [24] | `Delete`; `Retain`; `Recycle` |
-| <a id="k8s-persistentvolume-status-phase" href="#k8s-persistentvolume-status-phase">`k8s.persistentvolume.status.phase`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The phase of the PersistentVolume. [25] | `Pending`; `Available`; `Bound`; `Released`; `Failed` |
+| <a id="k8s-persistentvolume-reclaim-policy" href="#k8s-persistentvolume-reclaim-policy">`k8s.persistentvolume.reclaim_policy`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The reclaim policy of the PersistentVolume. [31] | `Delete`; `Retain`; `Recycle` |
+| <a id="k8s-persistentvolume-status-phase" href="#k8s-persistentvolume-status-phase">`k8s.persistentvolume.status.phase`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The phase of the PersistentVolume. [32] | `Pending`; `Available`; `Bound`; `Released`; `Failed` |
 | <a id="k8s-persistentvolume-uid" href="#k8s-persistentvolume-uid">`k8s.persistentvolume.uid`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The UID of the PersistentVolume. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
-| <a id="k8s-persistentvolumeclaim-annotation" href="#k8s-persistentvolumeclaim-annotation">`k8s.persistentvolumeclaim.annotation.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The annotation placed on the PersistentVolumeClaim, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [26] | `kubernetes.io/aws-ebs`; `` |
-| <a id="k8s-persistentvolumeclaim-label" href="#k8s-persistentvolumeclaim-label">`k8s.persistentvolumeclaim.label.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The label placed on the PersistentVolumeClaim, the `<key>` being the label name, the value being the label value, even if the value is empty. [27] | `my-app`; `` |
+| <a id="k8s-persistentvolumeclaim-annotation" href="#k8s-persistentvolumeclaim-annotation">`k8s.persistentvolumeclaim.annotation.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The annotation placed on the PersistentVolumeClaim, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [33] | `kubernetes.io/aws-ebs`; `` |
+| <a id="k8s-persistentvolumeclaim-creation-time" href="#k8s-persistentvolumeclaim-creation-time">`k8s.persistentvolumeclaim.creation_time`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The creation timestamp of the PersistentVolumeClaim. [34] | `2025-12-04T08:41:03Z` |
+| <a id="k8s-persistentvolumeclaim-label" href="#k8s-persistentvolumeclaim-label">`k8s.persistentvolumeclaim.label.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The label placed on the PersistentVolumeClaim, the `<key>` being the label name, the value being the label value, even if the value is empty. [35] | `my-app`; `` |
 | <a id="k8s-persistentvolumeclaim-name" href="#k8s-persistentvolumeclaim-name">`k8s.persistentvolumeclaim.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the PersistentVolumeClaim. | `pvc-data-01` |
-| <a id="k8s-persistentvolumeclaim-status-phase" href="#k8s-persistentvolumeclaim-status-phase">`k8s.persistentvolumeclaim.status.phase`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The phase of the PersistentVolumeClaim. [28] | `Pending`; `Bound`; `Lost` |
+| <a id="k8s-persistentvolumeclaim-status-phase" href="#k8s-persistentvolumeclaim-status-phase">`k8s.persistentvolumeclaim.status.phase`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The phase of the PersistentVolumeClaim. [36] | `Pending`; `Bound`; `Lost` |
 | <a id="k8s-persistentvolumeclaim-uid" href="#k8s-persistentvolumeclaim-uid">`k8s.persistentvolumeclaim.uid`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The UID of the PersistentVolumeClaim. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
-| <a id="k8s-pod-annotation" href="#k8s-pod-annotation">`k8s.pod.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the Pod, the `<key>` being the annotation name, the value being the annotation value. [29] | `true`; `x64`; `` |
-| <a id="k8s-pod-hostname" href="#k8s-pod-hostname">`k8s.pod.hostname`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | Specifies the hostname of the Pod. [30] | `collector-gateway` |
-| <a id="k8s-pod-ip" href="#k8s-pod-ip">`k8s.pod.ip`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | IP address allocated to the Pod. [31] | `172.18.0.2` |
-| <a id="k8s-pod-label" href="#k8s-pod-label">`k8s.pod.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the Pod, the `<key>` being the label name, the value being the label value. [32] | `my-app`; `x64`; `` |
+| <a id="k8s-pod-annotation" href="#k8s-pod-annotation">`k8s.pod.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the Pod, the `<key>` being the annotation name, the value being the annotation value. [37] | `true`; `x64`; `` |
+| <a id="k8s-pod-hostname" href="#k8s-pod-hostname">`k8s.pod.hostname`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | Specifies the hostname of the Pod. [38] | `collector-gateway` |
+| <a id="k8s-pod-ip" href="#k8s-pod-ip">`k8s.pod.ip`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | IP address allocated to the Pod. [39] | `172.18.0.2` |
+| <a id="k8s-pod-label" href="#k8s-pod-label">`k8s.pod.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the Pod, the `<key>` being the label name, the value being the label value. [40] | `my-app`; `x64`; `` |
 | <a id="k8s-pod-name" href="#k8s-pod-name">`k8s.pod.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The name of the Pod. | `opentelemetry-pod-autoconf` |
-| <a id="k8s-pod-start-time" href="#k8s-pod-start-time">`k8s.pod.start_time`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The start timestamp of the Pod. [33] | `2025-12-04T08:41:03Z` |
+| <a id="k8s-pod-start-time" href="#k8s-pod-start-time">`k8s.pod.start_time`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The start timestamp of the Pod. [41] | `2025-12-04T08:41:03Z` |
 | <a id="k8s-pod-status-phase" href="#k8s-pod-status-phase">`k8s.pod.status.phase`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The phase for the pod. Corresponds to the `phase` field of the: [K8s PodStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podstatus-v1-core) | `Pending`; `Running` |
 | <a id="k8s-pod-status-reason" href="#k8s-pod-status-reason">`k8s.pod.status.reason`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The reason for the pod state. Corresponds to the `reason` field of the: [K8s PodStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podstatus-v1-core) | `Evicted`; `NodeAffinity` |
 | <a id="k8s-pod-uid" href="#k8s-pod-uid">`k8s.pod.uid`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The UID of the Pod. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
-| <a id="k8s-replicaset-annotation" href="#k8s-replicaset-annotation">`k8s.replicaset.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the ReplicaSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [34] | `0`; `` |
-| <a id="k8s-replicaset-label" href="#k8s-replicaset-label">`k8s.replicaset.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the ReplicaSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [35] | `guestbook`; `` |
+| <a id="k8s-replicaset-annotation" href="#k8s-replicaset-annotation">`k8s.replicaset.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the ReplicaSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [42] | `0`; `` |
+| <a id="k8s-replicaset-creation-time" href="#k8s-replicaset-creation-time">`k8s.replicaset.creation_time`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The creation timestamp of the ReplicaSet. [43] | `2025-12-04T08:41:03Z` |
+| <a id="k8s-replicaset-label" href="#k8s-replicaset-label">`k8s.replicaset.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the ReplicaSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [44] | `guestbook`; `` |
 | <a id="k8s-replicaset-name" href="#k8s-replicaset-name">`k8s.replicaset.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The name of the ReplicaSet. | `opentelemetry` |
 | <a id="k8s-replicaset-uid" href="#k8s-replicaset-uid">`k8s.replicaset.uid`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The UID of the ReplicaSet. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | <a id="k8s-replicationcontroller-name" href="#k8s-replicationcontroller-name">`k8s.replicationcontroller.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the replication controller. | `opentelemetry` |
 | <a id="k8s-replicationcontroller-uid" href="#k8s-replicationcontroller-uid">`k8s.replicationcontroller.uid`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The UID of the replication controller. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | <a id="k8s-resourcequota-name" href="#k8s-resourcequota-name">`k8s.resourcequota.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the resource quota. | `opentelemetry` |
-| <a id="k8s-resourcequota-resource-name" href="#k8s-resourcequota-resource-name">`k8s.resourcequota.resource_name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the K8s resource a resource quota defines. [36] | `count/replicationcontrollers` |
+| <a id="k8s-resourcequota-resource-name" href="#k8s-resourcequota-resource-name">`k8s.resourcequota.resource_name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the K8s resource a resource quota defines. [45] | `count/replicationcontrollers` |
 | <a id="k8s-resourcequota-uid" href="#k8s-resourcequota-uid">`k8s.resourcequota.uid`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The UID of the resource quota. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
-| <a id="k8s-service-annotation" href="#k8s-service-annotation">`k8s.service.annotation.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The annotation placed on the Service, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [37] | `true`; `` |
-| <a id="k8s-service-endpoint-address-type" href="#k8s-service-endpoint-address-type">`k8s.service.endpoint.address_type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The address type of the service endpoint. [38] | `IPv4`; `IPv6` |
-| <a id="k8s-service-endpoint-condition" href="#k8s-service-endpoint-condition">`k8s.service.endpoint.condition`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The condition of the service endpoint. [39] | `ready`; `serving`; `terminating` |
-| <a id="k8s-service-endpoint-zone" href="#k8s-service-endpoint-zone">`k8s.service.endpoint.zone`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The zone of the service endpoint. [40] | `us-east-1a`; `us-west-2b`; `zone-a`; `` |
-| <a id="k8s-service-label" href="#k8s-service-label">`k8s.service.label.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The label placed on the Service, the `<key>` being the label name, the value being the label value, even if the value is empty. [41] | `my-service`; `` |
+| <a id="k8s-service-annotation" href="#k8s-service-annotation">`k8s.service.annotation.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The annotation placed on the Service, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [46] | `true`; `` |
+| <a id="k8s-service-endpoint-address-type" href="#k8s-service-endpoint-address-type">`k8s.service.endpoint.address_type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The address type of the service endpoint. [47] | `IPv4`; `IPv6` |
+| <a id="k8s-service-endpoint-condition" href="#k8s-service-endpoint-condition">`k8s.service.endpoint.condition`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The condition of the service endpoint. [48] | `ready`; `serving`; `terminating` |
+| <a id="k8s-service-endpoint-zone" href="#k8s-service-endpoint-zone">`k8s.service.endpoint.zone`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The zone of the service endpoint. [49] | `us-east-1a`; `us-west-2b`; `zone-a`; `` |
+| <a id="k8s-service-label" href="#k8s-service-label">`k8s.service.label.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The label placed on the Service, the `<key>` being the label name, the value being the label value, even if the value is empty. [50] | `my-service`; `` |
 | <a id="k8s-service-name" href="#k8s-service-name">`k8s.service.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the Service. | `my-service` |
-| <a id="k8s-service-publish-not-ready-addresses" href="#k8s-service-publish-not-ready-addresses">`k8s.service.publish_not_ready_addresses`</a> | ![Development](https://img.shields.io/badge/-development-blue) | boolean | Whether the Service publishes not-ready endpoints. [42] | `true`; `false` |
-| <a id="k8s-service-selector" href="#k8s-service-selector">`k8s.service.selector.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The selector key-value pair placed on the Service, the `<key>` being the selector key, the value being the selector value. [43] | `my-app`; `v1` |
-| <a id="k8s-service-traffic-distribution" href="#k8s-service-traffic-distribution">`k8s.service.traffic_distribution`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The traffic distribution policy for the Service. [44] | `PreferSameZone`; `PreferSameNode` |
-| <a id="k8s-service-type" href="#k8s-service-type">`k8s.service.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The type of the Kubernetes Service. [45] | `ClusterIP`; `NodePort`; `LoadBalancer` |
+| <a id="k8s-service-publish-not-ready-addresses" href="#k8s-service-publish-not-ready-addresses">`k8s.service.publish_not_ready_addresses`</a> | ![Development](https://img.shields.io/badge/-development-blue) | boolean | Whether the Service publishes not-ready endpoints. [51] | `true`; `false` |
+| <a id="k8s-service-selector" href="#k8s-service-selector">`k8s.service.selector.<key>`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The selector key-value pair placed on the Service, the `<key>` being the selector key, the value being the selector value. [52] | `my-app`; `v1` |
+| <a id="k8s-service-traffic-distribution" href="#k8s-service-traffic-distribution">`k8s.service.traffic_distribution`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The traffic distribution policy for the Service. [53] | `PreferSameZone`; `PreferSameNode` |
+| <a id="k8s-service-type" href="#k8s-service-type">`k8s.service.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The type of the Kubernetes Service. [54] | `ClusterIP`; `NodePort`; `LoadBalancer` |
 | <a id="k8s-service-uid" href="#k8s-service-uid">`k8s.service.uid`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The UID of the Service. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
-| <a id="k8s-statefulset-annotation" href="#k8s-statefulset-annotation">`k8s.statefulset.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the StatefulSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [46] | `1`; `` |
-| <a id="k8s-statefulset-label" href="#k8s-statefulset-label">`k8s.statefulset.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the StatefulSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [47] | `guestbook`; `` |
+| <a id="k8s-statefulset-annotation" href="#k8s-statefulset-annotation">`k8s.statefulset.annotation.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The annotation placed on the StatefulSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [55] | `1`; `` |
+| <a id="k8s-statefulset-creation-time" href="#k8s-statefulset-creation-time">`k8s.statefulset.creation_time`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The creation timestamp of the StatefulSet. [56] | `2025-12-04T08:41:03Z` |
+| <a id="k8s-statefulset-label" href="#k8s-statefulset-label">`k8s.statefulset.label.<key>`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The label placed on the StatefulSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [57] | `guestbook`; `` |
 | <a id="k8s-statefulset-name" href="#k8s-statefulset-name">`k8s.statefulset.name`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The name of the StatefulSet. | `opentelemetry` |
 | <a id="k8s-statefulset-uid" href="#k8s-statefulset-uid">`k8s.statefulset.uid`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | The UID of the StatefulSet. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | <a id="k8s-storageclass-name" href="#k8s-storageclass-name">`k8s.storageclass.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of K8s [StorageClass](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#storageclass-v1-storage-k8s-io) object. | `gold.storageclass.storage.k8s.io` |
@@ -136,91 +146,121 @@ conflict.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.cronjob.annotation.data` attribute with value `""`.
 
-**[4] `k8s.cronjob.label.<key>`:** Examples:
+**[4] `k8s.cronjob.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[5] `k8s.cronjob.label.<key>`:** Examples:
 
 - A label `type` with value `weekly` SHOULD be recorded as the
   `k8s.cronjob.label.type` attribute with value `"weekly"`.
 - A label `automated` with empty string value SHOULD be recorded as
   the `k8s.cronjob.label.automated` attribute with value `""`.
 
-**[5] `k8s.daemonset.annotation.<key>`:** Examples:
+**[6] `k8s.daemonset.annotation.<key>`:** Examples:
 
 - An annotation `replicas` with value `1` SHOULD be recorded
   as the `k8s.daemonset.annotation.replicas` attribute with value `"1"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.daemonset.annotation.data` attribute with value `""`.
 
-**[6] `k8s.daemonset.label.<key>`:** Examples:
+**[7] `k8s.daemonset.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[8] `k8s.daemonset.label.<key>`:** Examples:
 
 - A label `app` with value `guestbook` SHOULD be recorded
   as the `k8s.daemonset.label.app` attribute with value `"guestbook"`.
 - A label `injected` with empty string value SHOULD be recorded as
   the `k8s.daemonset.label.injected` attribute with value `""`.
 
-**[7] `k8s.deployment.annotation.<key>`:** Examples:
+**[9] `k8s.deployment.annotation.<key>`:** Examples:
 
 - An annotation `replicas` with value `1` SHOULD be recorded
   as the `k8s.deployment.annotation.replicas` attribute with value `"1"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.deployment.annotation.data` attribute with value `""`.
 
-**[8] `k8s.deployment.label.<key>`:** Examples:
+**[10] `k8s.deployment.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[11] `k8s.deployment.label.<key>`:** Examples:
 
 - A label `app` with value `guestbook` SHOULD be recorded
   as the `k8s.deployment.label.app` attribute with value `"guestbook"`.
 - A label `injected` with empty string value SHOULD be recorded as
   the `k8s.deployment.label.injected` attribute with value `""`.
 
-**[9] `k8s.hpa.metric.type`:** This attribute reflects the `type` field of spec.metrics[] in the HPA.
+**[12] `k8s.hpa.metric.type`:** This attribute reflects the `type` field of spec.metrics[] in the HPA.
 
-**[10] `k8s.hpa.scaletargetref.api_version`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
+**[13] `k8s.hpa.scaletargetref.api_version`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
 
-**[11] `k8s.hpa.scaletargetref.kind`:** This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
+**[14] `k8s.hpa.scaletargetref.kind`:** This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
 
-**[12] `k8s.hpa.scaletargetref.name`:** This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
+**[15] `k8s.hpa.scaletargetref.name`:** This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
 
-**[13] `k8s.job.annotation.<key>`:** Examples:
+**[16] `k8s.job.annotation.<key>`:** Examples:
 
 - An annotation `number` with value `1` SHOULD be recorded
   as the `k8s.job.annotation.number` attribute with value `"1"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.job.annotation.data` attribute with value `""`.
 
-**[14] `k8s.job.label.<key>`:** Examples:
+**[17] `k8s.job.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[18] `k8s.job.label.<key>`:** Examples:
 
 - A label `jobtype` with value `ci` SHOULD be recorded
   as the `k8s.job.label.jobtype` attribute with value `"ci"`.
 - A label `automated` with empty string value SHOULD be recorded as
   the `k8s.job.label.automated` attribute with value `""`.
 
-**[15] `k8s.namespace.annotation.<key>`:** Examples:
+**[19] `k8s.namespace.annotation.<key>`:** Examples:
 
 - An annotation `ttl` with value `0` SHOULD be recorded
   as the `k8s.namespace.annotation.ttl` attribute with value `"0"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.namespace.annotation.data` attribute with value `""`.
 
-**[16] `k8s.namespace.label.<key>`:** Examples:
+**[20] `k8s.namespace.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[21] `k8s.namespace.label.<key>`:** Examples:
 
 - A label `kubernetes.io/metadata.name` with value `default` SHOULD be recorded
   as the `k8s.namespace.label.kubernetes.io/metadata.name` attribute with value `"default"`.
 - A label `data` with empty string value SHOULD be recorded as
   the `k8s.namespace.label.data` attribute with value `""`.
 
-**[17] `k8s.namespace.phase`:** This attribute aligns with the `phase` field of the
+**[22] `k8s.namespace.phase`:** This attribute aligns with the `phase` field of the
 [K8s NamespaceStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#namespacestatus-v1-core)
 
-**[18] `k8s.node.annotation.<key>`:** Examples:
+**[23] `k8s.node.annotation.<key>`:** Examples:
 
 - An annotation `node.alpha.kubernetes.io/ttl` with value `0` SHOULD be recorded as
   the `k8s.node.annotation.node.alpha.kubernetes.io/ttl` attribute with value `"0"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.node.annotation.data` attribute with value `""`.
 
-**[19] `k8s.node.condition.status`:** This attribute aligns with the `status` field of the
+**[24] `k8s.node.condition.status`:** This attribute aligns with the `status` field of the
 [NodeCondition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#nodecondition-v1-core)
 
-**[20] `k8s.node.condition.type`:** K8s Node conditions as described
+**[25] `k8s.node.condition.type`:** K8s Node conditions as described
 by [K8s documentation](https://kubernetes.io/docs/reference/node/node-status/#condition).
 
 This attribute aligns with the `type` field of the
@@ -230,51 +270,69 @@ The set of possible values is not limited to those listed here. Managed Kubernet
 or custom controllers MAY introduce additional node condition types.
 When this occurs, the exact value as reported by the Kubernetes API SHOULD be used.
 
-**[21] `k8s.node.label.<key>`:** Examples:
+**[26] `k8s.node.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[27] `k8s.node.label.<key>`:** Examples:
 
 - A label `kubernetes.io/arch` with value `arm64` SHOULD be recorded
   as the `k8s.node.label.kubernetes.io/arch` attribute with value `"arm64"`.
 - A label `data` with empty string value SHOULD be recorded as
   the `k8s.node.label.data` attribute with value `""`.
 
-**[22] `k8s.persistentvolume.annotation.<key>`:** Examples:
+**[28] `k8s.persistentvolume.annotation.<key>`:** Examples:
 
 - An annotation `pv.kubernetes.io/provisioned-by` with value `kubernetes.io/aws-ebs` SHOULD be recorded as
   the `k8s.persistentvolume.annotation.pv.kubernetes.io/provisioned-by` attribute with value `"kubernetes.io/aws-ebs"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.persistentvolume.annotation.data` attribute with value `""`.
 
-**[23] `k8s.persistentvolume.label.<key>`:** Examples:
+**[29] `k8s.persistentvolume.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[30] `k8s.persistentvolume.label.<key>`:** Examples:
 
 - A label `type` with value `ssd` SHOULD be recorded as
   the `k8s.persistentvolume.label.type` attribute with value `"ssd"`.
 - A label `data` with empty string value SHOULD be recorded as
   the `k8s.persistentvolume.label.data` attribute with value `""`.
 
-**[24] `k8s.persistentvolume.reclaim_policy`:** This attribute aligns with the `persistentVolumeReclaimPolicy` field of the
+**[31] `k8s.persistentvolume.reclaim_policy`:** This attribute aligns with the `persistentVolumeReclaimPolicy` field of the
 [K8s PersistentVolumeSpec](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/#PersistentVolumeSpec).
 
-**[25] `k8s.persistentvolume.status.phase`:** This attribute aligns with the `phase` field of the
+**[32] `k8s.persistentvolume.status.phase`:** This attribute aligns with the `phase` field of the
 [K8s PersistentVolumeStatus](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/#PersistentVolumeStatus).
 
-**[26] `k8s.persistentvolumeclaim.annotation.<key>`:** Examples:
+**[33] `k8s.persistentvolumeclaim.annotation.<key>`:** Examples:
 
 - An annotation `volume.beta.kubernetes.io/storage-provisioner` with value `kubernetes.io/aws-ebs` SHOULD be recorded as
   the `k8s.persistentvolumeclaim.annotation.volume.beta.kubernetes.io/storage-provisioner` attribute with value `"kubernetes.io/aws-ebs"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.persistentvolumeclaim.annotation.data` attribute with value `""`.
 
-**[27] `k8s.persistentvolumeclaim.label.<key>`:** Examples:
+**[34] `k8s.persistentvolumeclaim.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[35] `k8s.persistentvolumeclaim.label.<key>`:** Examples:
 
 - A label `app` with value `my-app` SHOULD be recorded as
   the `k8s.persistentvolumeclaim.label.app` attribute with value `"my-app"`.
 - A label `data` with empty string value SHOULD be recorded as
   the `k8s.persistentvolumeclaim.label.data` attribute with value `""`.
 
-**[28] `k8s.persistentvolumeclaim.status.phase`:** This attribute aligns with the `phase` field of the
+**[36] `k8s.persistentvolumeclaim.status.phase`:** This attribute aligns with the `phase` field of the
 [K8s PersistentVolumeClaimStatus](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimStatus).
 
-**[29] `k8s.pod.annotation.<key>`:** Examples:
+**[37] `k8s.pod.annotation.<key>`:** Examples:
 
 - An annotation `kubernetes.io/enforce-mountable-secrets` with value `true` SHOULD be recorded as
   the `k8s.pod.annotation.kubernetes.io/enforce-mountable-secrets` attribute with value `"true"`.
@@ -283,17 +341,17 @@ When this occurs, the exact value as reported by the Kubernetes API SHOULD be us
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.pod.annotation.data` attribute with value `""`.
 
-**[30] `k8s.pod.hostname`:** The K8s Pod spec has an optional hostname field, which can be used to specify a hostname.
+**[38] `k8s.pod.hostname`:** The K8s Pod spec has an optional hostname field, which can be used to specify a hostname.
 Refer to [K8s docs](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-hostname-and-subdomain-field)
 for more information about this field.
 
 This attribute aligns with the `hostname` field of the
 [K8s PodSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#podspec-v1-core).
 
-**[31] `k8s.pod.ip`:** This attribute aligns with the `podIP` field of the
+**[39] `k8s.pod.ip`:** This attribute aligns with the `podIP` field of the
 [K8s PodStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#podstatus-v1-core).
 
-**[32] `k8s.pod.label.<key>`:** Examples:
+**[40] `k8s.pod.label.<key>`:** Examples:
 
 - A label `app` with value `my-app` SHOULD be recorded as
   the `k8s.pod.label.app` attribute with value `"my-app"`.
@@ -302,47 +360,53 @@ This attribute aligns with the `hostname` field of the
 - A label `data` with empty string value SHOULD be recorded as
   the `k8s.pod.label.data` attribute with value `""`.
 
-**[33] `k8s.pod.start_time`:** Date and time at which the object was acknowledged by the Kubelet.
+**[41] `k8s.pod.start_time`:** Date and time at which the object was acknowledged by the Kubelet.
 This is before the Kubelet pulled the container image(s) for the pod.
 
 This attribute aligns with the `startTime` field of the
 [K8s PodStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#podstatus-v1-core),
 in ISO 8601 (RFC 3339 compatible) format.
 
-**[34] `k8s.replicaset.annotation.<key>`:** Examples:
+**[42] `k8s.replicaset.annotation.<key>`:** Examples:
 
 - An annotation `replicas` with value `0` SHOULD be recorded
   as the `k8s.replicaset.annotation.replicas` attribute with value `"0"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.replicaset.annotation.data` attribute with value `""`.
 
-**[35] `k8s.replicaset.label.<key>`:** Examples:
+**[43] `k8s.replicaset.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[44] `k8s.replicaset.label.<key>`:** Examples:
 
 - A label `app` with value `guestbook` SHOULD be recorded
   as the `k8s.replicaset.label.app` attribute with value `"guestbook"`.
 - A label `injected` with empty string value SHOULD be recorded as
   the `k8s.replicaset.label.injected` attribute with value `""`.
 
-**[36] `k8s.resourcequota.resource_name`:** The value for this attribute can be either the full `count/<resource>[.<group>]` string (e.g., count/deployments.apps, count/pods), or, for certain core Kubernetes resources, just the resource name (e.g., pods, services, configmaps). Both forms are supported by Kubernetes for object count quotas. See [Kubernetes Resource Quotas documentation](https://kubernetes.io/docs/concepts/policy/resource-quotas/#quota-on-object-count) for more details.
+**[45] `k8s.resourcequota.resource_name`:** The value for this attribute can be either the full `count/<resource>[.<group>]` string (e.g., count/deployments.apps, count/pods), or, for certain core Kubernetes resources, just the resource name (e.g., pods, services, configmaps). Both forms are supported by Kubernetes for object count quotas. See [Kubernetes Resource Quotas documentation](https://kubernetes.io/docs/concepts/policy/resource-quotas/#quota-on-object-count) for more details.
 
-**[37] `k8s.service.annotation.<key>`:** Examples:
+**[46] `k8s.service.annotation.<key>`:** Examples:
 
 - An annotation `prometheus.io/scrape` with value `true` SHOULD be recorded as
   the `k8s.service.annotation.prometheus.io/scrape` attribute with value `"true"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.service.annotation.data` attribute with value `""`.
 
-**[38] `k8s.service.endpoint.address_type`:** The network address family or type of the endpoint.
+**[47] `k8s.service.endpoint.address_type`:** The network address family or type of the endpoint.
 This attribute aligns with the `addressType` field of the
 [K8s EndpointSlice](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1/).
 It is used to differentiate metrics when a Service is backed by multiple address types
 (e.g., in dual-stack clusters).
 
-**[39] `k8s.service.endpoint.condition`:** The current operational condition of the service endpoint.
+**[48] `k8s.service.endpoint.condition`:** The current operational condition of the service endpoint.
 An endpoint can have multiple conditions set at once (e.g., both `serving` and `terminating` during rollout).
 This attribute aligns with the condition fields in the [K8s EndpointSlice](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1/).
 
-**[40] `k8s.service.endpoint.zone`:** The zone where the endpoint is located, typically corresponding to a failure domain.
+**[49] `k8s.service.endpoint.zone`:** The zone where the endpoint is located, typically corresponding to a failure domain.
 This attribute aligns with the `zone` field of endpoints in the
 [K8s EndpointSlice](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1/).
 It enables zone-aware monitoring of service endpoint distribution and supports
@@ -351,20 +415,20 @@ features like [Topology Aware Routing](https://kubernetes.io/docs/concepts/servi
 If the zone is not populated (e.g., nodes without the `topology.kubernetes.io/zone` label),
 the attribute value will be an empty string.
 
-**[41] `k8s.service.label.<key>`:** Examples:
+**[50] `k8s.service.label.<key>`:** Examples:
 
 - A label `app` with value `my-service` SHOULD be recorded as
   the `k8s.service.label.app` attribute with value `"my-service"`.
 - A label `data` with empty string value SHOULD be recorded as
   the `k8s.service.label.data` attribute with value `""`.
 
-**[42] `k8s.service.publish_not_ready_addresses`:** Whether the Service is configured to publish endpoints before the pods are ready.
+**[51] `k8s.service.publish_not_ready_addresses`:** Whether the Service is configured to publish endpoints before the pods are ready.
 This attribute is typically used to indicate that a Service (such as a headless
 Service for a StatefulSet) allows peer discovery before pods pass their readiness probes.
 It aligns with the `publishNotReadyAddresses` field of the
 [K8s ServiceSpec](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec).
 
-**[43] `k8s.service.selector.<key>`:** These selectors are used to correlate with pod labels. Each selector key-value pair becomes a separate attribute.
+**[52] `k8s.service.selector.<key>`:** These selectors are used to correlate with pod labels. Each selector key-value pair becomes a separate attribute.
 
 Examples:
 
@@ -373,7 +437,7 @@ Examples:
 - A selector `version=v1` SHOULD be recorded as
   the `k8s.service.selector.version` attribute with value `"v1"`.
 
-**[44] `k8s.service.traffic_distribution`:** Specifies how traffic is distributed to endpoints for this Service.
+**[53] `k8s.service.traffic_distribution`:** Specifies how traffic is distributed to endpoints for this Service.
 This attribute aligns with the `trafficDistribution` field of the
 [K8s ServiceSpec](https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution).
 Known values include `PreferSameZone` (prefer endpoints in the same zone as the client) and
@@ -381,17 +445,23 @@ Known values include `PreferSameZone` (prefer endpoints in the same zone as the 
 If this field is not set on the Service, the attribute SHOULD NOT be emitted.
 When not set, Kubernetes distributes traffic evenly across all endpoints cluster-wide.
 
-**[45] `k8s.service.type`:** This attribute aligns with the `type` field of the
+**[54] `k8s.service.type`:** This attribute aligns with the `type` field of the
 [K8s ServiceSpec](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec).
 
-**[46] `k8s.statefulset.annotation.<key>`:** Examples:
+**[55] `k8s.statefulset.annotation.<key>`:** Examples:
 
 - An annotation `replicas` with value `1` SHOULD be recorded
   as the `k8s.statefulset.annotation.replicas` attribute with value `"1"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.statefulset.annotation.data` attribute with value `""`.
 
-**[47] `k8s.statefulset.label.<key>`:** Examples:
+**[56] `k8s.statefulset.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[57] `k8s.statefulset.label.<key>`:** Examples:
 
 - A label `app` with value `guestbook` SHOULD be recorded
   as the `k8s.statefulset.label.app` attribute with value `"guestbook"`.

--- a/docs/registry/entities/k8s.md
+++ b/docs/registry/entities/k8s.md
@@ -72,7 +72,8 @@ conflict.
 | Identity | [`k8s.cronjob.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the CronJob. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.cronjob.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the CronJob. | `opentelemetry` |
 | Description | [`k8s.cronjob.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The cronjob annotation placed on the CronJob, the `<key>` being the annotation name, the value being the annotation value. [2] | `4`; `` |
-| Description | [`k8s.cronjob.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the CronJob, the `<key>` being the label name, the value being the label value. [3] | `weekly`; `` |
+| Description | [`k8s.cronjob.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the CronJob. [3] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.cronjob.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the CronJob, the `<key>` being the label name, the value being the label value. [4] | `weekly`; `` |
 
 **[2] `k8s.cronjob.annotation.<key>`:** Examples:
 
@@ -81,7 +82,13 @@ conflict.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.cronjob.annotation.data` attribute with value `""`.
 
-**[3] `k8s.cronjob.label.<key>`:** Examples:
+**[3] `k8s.cronjob.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[4] `k8s.cronjob.label.<key>`:** Examples:
 
 - A label `type` with value `weekly` SHOULD be recorded as the
   `k8s.cronjob.label.type` attribute with value `"weekly"`.
@@ -102,17 +109,24 @@ conflict.
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`k8s.daemonset.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the DaemonSet. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.daemonset.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the DaemonSet. | `opentelemetry` |
-| Description | [`k8s.daemonset.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the DaemonSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [4] | `1`; `` |
-| Description | [`k8s.daemonset.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the DaemonSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [5] | `guestbook`; `` |
+| Description | [`k8s.daemonset.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the DaemonSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [5] | `1`; `` |
+| Description | [`k8s.daemonset.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the DaemonSet. [6] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.daemonset.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the DaemonSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [7] | `guestbook`; `` |
 
-**[4] `k8s.daemonset.annotation.<key>`:** Examples:
+**[5] `k8s.daemonset.annotation.<key>`:** Examples:
 
 - An annotation `replicas` with value `1` SHOULD be recorded
   as the `k8s.daemonset.annotation.replicas` attribute with value `"1"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.daemonset.annotation.data` attribute with value `""`.
 
-**[5] `k8s.daemonset.label.<key>`:** Examples:
+**[6] `k8s.daemonset.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[7] `k8s.daemonset.label.<key>`:** Examples:
 
 - A label `app` with value `guestbook` SHOULD be recorded
   as the `k8s.daemonset.label.app` attribute with value `"guestbook"`.
@@ -133,17 +147,24 @@ conflict.
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`k8s.deployment.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the Deployment. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.deployment.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the Deployment. | `opentelemetry` |
-| Description | [`k8s.deployment.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Deployment, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [6] | `1`; `` |
-| Description | [`k8s.deployment.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Deployment, the `<key>` being the label name, the value being the label value, even if the value is empty. [7] | `guestbook`; `` |
+| Description | [`k8s.deployment.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Deployment, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [8] | `1`; `` |
+| Description | [`k8s.deployment.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the Deployment. [9] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.deployment.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Deployment, the `<key>` being the label name, the value being the label value, even if the value is empty. [10] | `guestbook`; `` |
 
-**[6] `k8s.deployment.annotation.<key>`:** Examples:
+**[8] `k8s.deployment.annotation.<key>`:** Examples:
 
 - An annotation `replicas` with value `1` SHOULD be recorded
   as the `k8s.deployment.annotation.replicas` attribute with value `"1"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.deployment.annotation.data` attribute with value `""`.
 
-**[7] `k8s.deployment.label.<key>`:** Examples:
+**[9] `k8s.deployment.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[10] `k8s.deployment.label.<key>`:** Examples:
 
 - A label `app` with value `guestbook` SHOULD be recorded
   as the `k8s.deployment.label.app` attribute with value `"guestbook"`.
@@ -164,15 +185,15 @@ conflict.
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`k8s.hpa.uid`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The UID of the horizontal pod autoscaler. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.hpa.name`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the horizontal pod autoscaler. | `opentelemetry` |
-| Description | [`k8s.hpa.scaletargetref.api_version`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [8] | `apps/v1`; `autoscaling/v2` |
-| Description | [`k8s.hpa.scaletargetref.kind`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [9] | `Deployment`; `StatefulSet` |
-| Description | [`k8s.hpa.scaletargetref.name`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [10] | `my-deployment`; `my-statefulset` |
+| Description | [`k8s.hpa.scaletargetref.api_version`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The API version of the target resource to scale for the HorizontalPodAutoscaler. [11] | `apps/v1`; `autoscaling/v2` |
+| Description | [`k8s.hpa.scaletargetref.kind`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The kind of the target resource to scale for the HorizontalPodAutoscaler. [12] | `Deployment`; `StatefulSet` |
+| Description | [`k8s.hpa.scaletargetref.name`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the target resource to scale for the HorizontalPodAutoscaler. [13] | `my-deployment`; `my-statefulset` |
 
-**[8] `k8s.hpa.scaletargetref.api_version`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
+**[11] `k8s.hpa.scaletargetref.api_version`:** This maps to the `apiVersion` field in the `scaleTargetRef` of the HPA spec.
 
-**[9] `k8s.hpa.scaletargetref.kind`:** This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
+**[12] `k8s.hpa.scaletargetref.kind`:** This maps to the `kind` field in the `scaleTargetRef` of the HPA spec.
 
-**[10] `k8s.hpa.scaletargetref.name`:** This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
+**[13] `k8s.hpa.scaletargetref.name`:** This maps to the `name` field in the `scaleTargetRef` of the HPA spec.
 
 ## K8s Job
 
@@ -188,17 +209,24 @@ conflict.
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`k8s.job.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the Job. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.job.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the Job. | `opentelemetry` |
-| Description | [`k8s.job.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Job, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [11] | `1`; `` |
-| Description | [`k8s.job.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Job, the `<key>` being the label name, the value being the label value, even if the value is empty. [12] | `ci`; `` |
+| Description | [`k8s.job.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Job, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [14] | `1`; `` |
+| Description | [`k8s.job.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the Job. [15] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.job.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Job, the `<key>` being the label name, the value being the label value, even if the value is empty. [16] | `ci`; `` |
 
-**[11] `k8s.job.annotation.<key>`:** Examples:
+**[14] `k8s.job.annotation.<key>`:** Examples:
 
 - An annotation `number` with value `1` SHOULD be recorded
   as the `k8s.job.annotation.number` attribute with value `"1"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.job.annotation.data` attribute with value `""`.
 
-**[12] `k8s.job.label.<key>`:** Examples:
+**[15] `k8s.job.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[16] `k8s.job.label.<key>`:** Examples:
 
 - A label `jobtype` with value `ci` SHOULD be recorded
   as the `k8s.job.label.jobtype` attribute with value `"ci"`.
@@ -218,17 +246,24 @@ conflict.
 | Role | Key | Stability | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`k8s.namespace.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the namespace that the pod is running in. | `default` |
-| Description | [`k8s.namespace.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Namespace, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [13] | `0`; `` |
-| Description | [`k8s.namespace.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Namespace, the `<key>` being the label name, the value being the label value, even if the value is empty. [14] | `default`; `` |
+| Description | [`k8s.namespace.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Namespace, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [17] | `0`; `` |
+| Description | [`k8s.namespace.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the Namespace. [18] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.namespace.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Namespace, the `<key>` being the label name, the value being the label value, even if the value is empty. [19] | `default`; `` |
 
-**[13] `k8s.namespace.annotation.<key>`:** Examples:
+**[17] `k8s.namespace.annotation.<key>`:** Examples:
 
 - An annotation `ttl` with value `0` SHOULD be recorded
   as the `k8s.namespace.annotation.ttl` attribute with value `"0"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.namespace.annotation.data` attribute with value `""`.
 
-**[14] `k8s.namespace.label.<key>`:** Examples:
+**[18] `k8s.namespace.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[19] `k8s.namespace.label.<key>`:** Examples:
 
 - A label `kubernetes.io/metadata.name` with value `default` SHOULD be recorded
   as the `k8s.namespace.label.kubernetes.io/metadata.name` attribute with value `"default"`.
@@ -249,17 +284,24 @@ conflict.
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`k8s.node.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the Node. | `1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2` |
 | Description | [`k8s.node.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the Node. | `node-1` |
-| Description | [`k8s.node.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Node, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [15] | `0`; `` |
-| Description | [`k8s.node.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Node, the `<key>` being the label name, the value being the label value, even if the value is empty. [16] | `arm64`; `` |
+| Description | [`k8s.node.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Node, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [20] | `0`; `` |
+| Description | [`k8s.node.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the Node. [21] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.node.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Node, the `<key>` being the label name, the value being the label value, even if the value is empty. [22] | `arm64`; `` |
 
-**[15] `k8s.node.annotation.<key>`:** Examples:
+**[20] `k8s.node.annotation.<key>`:** Examples:
 
 - An annotation `node.alpha.kubernetes.io/ttl` with value `0` SHOULD be recorded as
   the `k8s.node.annotation.node.alpha.kubernetes.io/ttl` attribute with value `"0"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.node.annotation.data` attribute with value `""`.
 
-**[16] `k8s.node.label.<key>`:** Examples:
+**[21] `k8s.node.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[22] `k8s.node.label.<key>`:** Examples:
 
 - A label `kubernetes.io/arch` with value `arm64` SHOULD be recorded
   as the `k8s.node.label.kubernetes.io/arch` attribute with value `"arm64"`.
@@ -295,25 +337,32 @@ conflict.
 | Identity | [`k8s.persistentvolume.uid`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Required` | string | The UID of the PersistentVolume. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.persistentvolume.name`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the PersistentVolume. | `pv-data-01` |
 | Description | [`k8s.storageclass.name`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of K8s [StorageClass](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#storageclass-v1-storage-k8s-io) object. | `gold.storageclass.storage.k8s.io` |
-| Description | [`k8s.persistentvolume.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The annotation placed on the PersistentVolume, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [17] | `kubernetes.io/aws-ebs`; `` |
-| Description | [`k8s.persistentvolume.label.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The label placed on the PersistentVolume, the `<key>` being the label name, the value being the label value, even if the value is empty. [18] | `ssd`; `` |
-| Description | [`k8s.persistentvolume.reclaim_policy`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The reclaim policy of the PersistentVolume. [19] | `Delete`; `Retain`; `Recycle` |
+| Description | [`k8s.persistentvolume.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The annotation placed on the PersistentVolume, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [23] | `kubernetes.io/aws-ebs`; `` |
+| Description | [`k8s.persistentvolume.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the PersistentVolume. [24] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.persistentvolume.label.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The label placed on the PersistentVolume, the `<key>` being the label name, the value being the label value, even if the value is empty. [25] | `ssd`; `` |
+| Description | [`k8s.persistentvolume.reclaim_policy`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The reclaim policy of the PersistentVolume. [26] | `Delete`; `Retain`; `Recycle` |
 
-**[17] `k8s.persistentvolume.annotation.<key>`:** Examples:
+**[23] `k8s.persistentvolume.annotation.<key>`:** Examples:
 
 - An annotation `pv.kubernetes.io/provisioned-by` with value `kubernetes.io/aws-ebs` SHOULD be recorded as
   the `k8s.persistentvolume.annotation.pv.kubernetes.io/provisioned-by` attribute with value `"kubernetes.io/aws-ebs"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.persistentvolume.annotation.data` attribute with value `""`.
 
-**[18] `k8s.persistentvolume.label.<key>`:** Examples:
+**[24] `k8s.persistentvolume.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[25] `k8s.persistentvolume.label.<key>`:** Examples:
 
 - A label `type` with value `ssd` SHOULD be recorded as
   the `k8s.persistentvolume.label.type` attribute with value `"ssd"`.
 - A label `data` with empty string value SHOULD be recorded as
   the `k8s.persistentvolume.label.data` attribute with value `""`.
 
-**[19] `k8s.persistentvolume.reclaim_policy`:** This attribute aligns with the `persistentVolumeReclaimPolicy` field of the
+**[26] `k8s.persistentvolume.reclaim_policy`:** This attribute aligns with the `persistentVolumeReclaimPolicy` field of the
 [K8s PersistentVolumeSpec](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/#PersistentVolumeSpec).
 
 ---
@@ -341,17 +390,24 @@ conflict.
 | Identity | [`k8s.persistentvolumeclaim.uid`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Required` | string | The UID of the PersistentVolumeClaim. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.persistentvolumeclaim.name`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the PersistentVolumeClaim. | `pvc-data-01` |
 | Description | [`k8s.storageclass.name`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of K8s [StorageClass](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#storageclass-v1-storage-k8s-io) object. | `gold.storageclass.storage.k8s.io` |
-| Description | [`k8s.persistentvolumeclaim.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The annotation placed on the PersistentVolumeClaim, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [20] | `kubernetes.io/aws-ebs`; `` |
-| Description | [`k8s.persistentvolumeclaim.label.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The label placed on the PersistentVolumeClaim, the `<key>` being the label name, the value being the label value, even if the value is empty. [21] | `my-app`; `` |
+| Description | [`k8s.persistentvolumeclaim.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The annotation placed on the PersistentVolumeClaim, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [27] | `kubernetes.io/aws-ebs`; `` |
+| Description | [`k8s.persistentvolumeclaim.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the PersistentVolumeClaim. [28] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.persistentvolumeclaim.label.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The label placed on the PersistentVolumeClaim, the `<key>` being the label name, the value being the label value, even if the value is empty. [29] | `my-app`; `` |
 
-**[20] `k8s.persistentvolumeclaim.annotation.<key>`:** Examples:
+**[27] `k8s.persistentvolumeclaim.annotation.<key>`:** Examples:
 
 - An annotation `volume.beta.kubernetes.io/storage-provisioner` with value `kubernetes.io/aws-ebs` SHOULD be recorded as
   the `k8s.persistentvolumeclaim.annotation.volume.beta.kubernetes.io/storage-provisioner` attribute with value `"kubernetes.io/aws-ebs"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.persistentvolumeclaim.annotation.data` attribute with value `""`.
 
-**[21] `k8s.persistentvolumeclaim.label.<key>`:** Examples:
+**[28] `k8s.persistentvolumeclaim.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[29] `k8s.persistentvolumeclaim.label.<key>`:** Examples:
 
 - A label `app` with value `my-app` SHOULD be recorded as
   the `k8s.persistentvolumeclaim.label.app` attribute with value `"my-app"`.
@@ -372,13 +428,13 @@ conflict.
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`k8s.pod.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the Pod. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.pod.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the Pod. | `opentelemetry-pod-autoconf` |
-| Description | [`k8s.pod.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Pod, the `<key>` being the annotation name, the value being the annotation value. [22] | `true`; `x64`; `` |
-| Description | [`k8s.pod.hostname`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | Specifies the hostname of the Pod. [23] | `collector-gateway` |
-| Description | [`k8s.pod.ip`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | IP address allocated to the Pod. [24] | `172.18.0.2` |
-| Description | [`k8s.pod.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Pod, the `<key>` being the label name, the value being the label value. [25] | `my-app`; `x64`; `` |
-| Description | [`k8s.pod.start_time`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The start timestamp of the Pod. [26] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.pod.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Pod, the `<key>` being the annotation name, the value being the annotation value. [30] | `true`; `x64`; `` |
+| Description | [`k8s.pod.hostname`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | Specifies the hostname of the Pod. [31] | `collector-gateway` |
+| Description | [`k8s.pod.ip`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | IP address allocated to the Pod. [32] | `172.18.0.2` |
+| Description | [`k8s.pod.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Pod, the `<key>` being the label name, the value being the label value. [33] | `my-app`; `x64`; `` |
+| Description | [`k8s.pod.start_time`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The start timestamp of the Pod. [34] | `2025-12-04T08:41:03Z` |
 
-**[22] `k8s.pod.annotation.<key>`:** Examples:
+**[30] `k8s.pod.annotation.<key>`:** Examples:
 
 - An annotation `kubernetes.io/enforce-mountable-secrets` with value `true` SHOULD be recorded as
   the `k8s.pod.annotation.kubernetes.io/enforce-mountable-secrets` attribute with value `"true"`.
@@ -387,17 +443,17 @@ conflict.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.pod.annotation.data` attribute with value `""`.
 
-**[23] `k8s.pod.hostname`:** The K8s Pod spec has an optional hostname field, which can be used to specify a hostname.
+**[31] `k8s.pod.hostname`:** The K8s Pod spec has an optional hostname field, which can be used to specify a hostname.
 Refer to [K8s docs](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-hostname-and-subdomain-field)
 for more information about this field.
 
 This attribute aligns with the `hostname` field of the
 [K8s PodSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#podspec-v1-core).
 
-**[24] `k8s.pod.ip`:** This attribute aligns with the `podIP` field of the
+**[32] `k8s.pod.ip`:** This attribute aligns with the `podIP` field of the
 [K8s PodStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#podstatus-v1-core).
 
-**[25] `k8s.pod.label.<key>`:** Examples:
+**[33] `k8s.pod.label.<key>`:** Examples:
 
 - A label `app` with value `my-app` SHOULD be recorded as
   the `k8s.pod.label.app` attribute with value `"my-app"`.
@@ -406,7 +462,7 @@ This attribute aligns with the `hostname` field of the
 - A label `data` with empty string value SHOULD be recorded as
   the `k8s.pod.label.data` attribute with value `""`.
 
-**[26] `k8s.pod.start_time`:** Date and time at which the object was acknowledged by the Kubelet.
+**[34] `k8s.pod.start_time`:** Date and time at which the object was acknowledged by the Kubelet.
 This is before the Kubelet pulled the container image(s) for the pod.
 
 This attribute aligns with the `startTime` field of the
@@ -427,17 +483,24 @@ in ISO 8601 (RFC 3339 compatible) format.
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`k8s.replicaset.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the ReplicaSet. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.replicaset.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the ReplicaSet. | `opentelemetry` |
-| Description | [`k8s.replicaset.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the ReplicaSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [27] | `0`; `` |
-| Description | [`k8s.replicaset.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the ReplicaSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [28] | `guestbook`; `` |
+| Description | [`k8s.replicaset.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the ReplicaSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [35] | `0`; `` |
+| Description | [`k8s.replicaset.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the ReplicaSet. [36] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.replicaset.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the ReplicaSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [37] | `guestbook`; `` |
 
-**[27] `k8s.replicaset.annotation.<key>`:** Examples:
+**[35] `k8s.replicaset.annotation.<key>`:** Examples:
 
 - An annotation `replicas` with value `0` SHOULD be recorded
   as the `k8s.replicaset.annotation.replicas` attribute with value `"0"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.replicaset.annotation.data` attribute with value `""`.
 
-**[28] `k8s.replicaset.label.<key>`:** Examples:
+**[36] `k8s.replicaset.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[37] `k8s.replicaset.label.<key>`:** Examples:
 
 - A label `app` with value `guestbook` SHOULD be recorded
   as the `k8s.replicaset.label.app` attribute with value `"guestbook"`.
@@ -488,37 +551,37 @@ in ISO 8601 (RFC 3339 compatible) format.
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`k8s.service.uid`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The UID of the Service. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.service.name`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the Service. | `my-service` |
-| Description | [`k8s.service.type`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The type of the Kubernetes Service. [29] | `ClusterIP`; `NodePort`; `LoadBalancer` |
-| Description | [`k8s.service.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The annotation placed on the Service, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [30] | `true`; `` |
-| Description | [`k8s.service.label.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The label placed on the Service, the `<key>` being the label name, the value being the label value, even if the value is empty. [31] | `my-service`; `` |
-| Description | [`k8s.service.publish_not_ready_addresses`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | boolean | Whether the Service publishes not-ready endpoints. [32] | `true`; `false` |
-| Description | [`k8s.service.selector.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The selector key-value pair placed on the Service, the `<key>` being the selector key, the value being the selector value. [33] | `my-app`; `v1` |
-| Description | [`k8s.service.traffic_distribution`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The traffic distribution policy for the Service. [34] | `PreferSameZone`; `PreferSameNode` |
+| Description | [`k8s.service.type`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The type of the Kubernetes Service. [38] | `ClusterIP`; `NodePort`; `LoadBalancer` |
+| Description | [`k8s.service.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The annotation placed on the Service, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [39] | `true`; `` |
+| Description | [`k8s.service.label.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The label placed on the Service, the `<key>` being the label name, the value being the label value, even if the value is empty. [40] | `my-service`; `` |
+| Description | [`k8s.service.publish_not_ready_addresses`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | boolean | Whether the Service publishes not-ready endpoints. [41] | `true`; `false` |
+| Description | [`k8s.service.selector.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The selector key-value pair placed on the Service, the `<key>` being the selector key, the value being the selector value. [42] | `my-app`; `v1` |
+| Description | [`k8s.service.traffic_distribution`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The traffic distribution policy for the Service. [43] | `PreferSameZone`; `PreferSameNode` |
 
-**[29] `k8s.service.type`:** This attribute aligns with the `type` field of the
+**[38] `k8s.service.type`:** This attribute aligns with the `type` field of the
 [K8s ServiceSpec](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec).
 
-**[30] `k8s.service.annotation.<key>`:** Examples:
+**[39] `k8s.service.annotation.<key>`:** Examples:
 
 - An annotation `prometheus.io/scrape` with value `true` SHOULD be recorded as
   the `k8s.service.annotation.prometheus.io/scrape` attribute with value `"true"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.service.annotation.data` attribute with value `""`.
 
-**[31] `k8s.service.label.<key>`:** Examples:
+**[40] `k8s.service.label.<key>`:** Examples:
 
 - A label `app` with value `my-service` SHOULD be recorded as
   the `k8s.service.label.app` attribute with value `"my-service"`.
 - A label `data` with empty string value SHOULD be recorded as
   the `k8s.service.label.data` attribute with value `""`.
 
-**[32] `k8s.service.publish_not_ready_addresses`:** Whether the Service is configured to publish endpoints before the pods are ready.
+**[41] `k8s.service.publish_not_ready_addresses`:** Whether the Service is configured to publish endpoints before the pods are ready.
 This attribute is typically used to indicate that a Service (such as a headless
 Service for a StatefulSet) allows peer discovery before pods pass their readiness probes.
 It aligns with the `publishNotReadyAddresses` field of the
 [K8s ServiceSpec](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec).
 
-**[33] `k8s.service.selector.<key>`:** These selectors are used to correlate with pod labels. Each selector key-value pair becomes a separate attribute.
+**[42] `k8s.service.selector.<key>`:** These selectors are used to correlate with pod labels. Each selector key-value pair becomes a separate attribute.
 
 Examples:
 
@@ -527,7 +590,7 @@ Examples:
 - A selector `version=v1` SHOULD be recorded as
   the `k8s.service.selector.version` attribute with value `"v1"`.
 
-**[34] `k8s.service.traffic_distribution`:** Specifies how traffic is distributed to endpoints for this Service.
+**[43] `k8s.service.traffic_distribution`:** Specifies how traffic is distributed to endpoints for this Service.
 This attribute aligns with the `trafficDistribution` field of the
 [K8s ServiceSpec](https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution).
 Known values include `PreferSameZone` (prefer endpoints in the same zone as the client) and
@@ -560,17 +623,24 @@ When not set, Kubernetes distributes traffic evenly across all endpoints cluster
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`k8s.statefulset.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the StatefulSet. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.statefulset.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the StatefulSet. | `opentelemetry` |
-| Description | [`k8s.statefulset.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the StatefulSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [35] | `1`; `` |
-| Description | [`k8s.statefulset.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the StatefulSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [36] | `guestbook`; `` |
+| Description | [`k8s.statefulset.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the StatefulSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [44] | `1`; `` |
+| Description | [`k8s.statefulset.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the StatefulSet. [45] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.statefulset.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the StatefulSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [46] | `guestbook`; `` |
 
-**[35] `k8s.statefulset.annotation.<key>`:** Examples:
+**[44] `k8s.statefulset.annotation.<key>`:** Examples:
 
 - An annotation `replicas` with value `1` SHOULD be recorded
   as the `k8s.statefulset.annotation.replicas` attribute with value `"1"`.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.statefulset.annotation.data` attribute with value `""`.
 
-**[36] `k8s.statefulset.label.<key>`:** Examples:
+**[45] `k8s.statefulset.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[46] `k8s.statefulset.label.<key>`:** Examples:
 
 - A label `app` with value `guestbook` SHOULD be recorded
   as the `k8s.statefulset.label.app` attribute with value `"guestbook"`.

--- a/docs/resource/k8s/README.md
+++ b/docs/resource/k8s/README.md
@@ -81,7 +81,8 @@ conflict.
 | Identity | [`k8s.node.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the Node. | `1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2` |
 | Description | [`k8s.node.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the Node. | `node-1` |
 | Description | [`k8s.node.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Node, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [1] | `0`; `` |
-| Description | [`k8s.node.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Node, the `<key>` being the label name, the value being the label value, even if the value is empty. [2] | `arm64`; `` |
+| Description | [`k8s.node.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the Node. [2] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.node.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Node, the `<key>` being the label name, the value being the label value, even if the value is empty. [3] | `arm64`; `` |
 
 **[1] `k8s.node.annotation.<key>`:** Examples:
 
@@ -90,7 +91,13 @@ conflict.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.node.annotation.data` attribute with value `""`.
 
-**[2] `k8s.node.label.<key>`:** Examples:
+**[2] `k8s.node.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[3] `k8s.node.label.<key>`:** Examples:
 
 - A label `kubernetes.io/arch` with value `arm64` SHOULD be recorded
   as the `k8s.node.label.kubernetes.io/arch` attribute with value `"arm64"`.
@@ -122,7 +129,8 @@ a namespace, but not across namespaces.
 | --- | --- | --- | --- | --- | --- | --- |
 | Identity | [`k8s.namespace.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the namespace that the pod is running in. | `default` |
 | Description | [`k8s.namespace.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Namespace, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [1] | `0`; `` |
-| Description | [`k8s.namespace.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Namespace, the `<key>` being the label name, the value being the label value, even if the value is empty. [2] | `default`; `` |
+| Description | [`k8s.namespace.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the Namespace. [2] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.namespace.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Namespace, the `<key>` being the label name, the value being the label value, even if the value is empty. [3] | `default`; `` |
 
 **[1] `k8s.namespace.annotation.<key>`:** Examples:
 
@@ -131,7 +139,13 @@ a namespace, but not across namespaces.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.namespace.annotation.data` attribute with value `""`.
 
-**[2] `k8s.namespace.label.<key>`:** Examples:
+**[2] `k8s.namespace.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[3] `k8s.namespace.label.<key>`:** Examples:
 
 - A label `kubernetes.io/metadata.name` with value `default` SHOULD be recorded
   as the `k8s.namespace.label.kubernetes.io/metadata.name` attribute with value `"default"`.
@@ -258,7 +272,8 @@ to a running container.
 | Identity | [`k8s.replicaset.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the ReplicaSet. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.replicaset.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the ReplicaSet. | `opentelemetry` |
 | Description | [`k8s.replicaset.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the ReplicaSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [1] | `0`; `` |
-| Description | [`k8s.replicaset.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the ReplicaSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [2] | `guestbook`; `` |
+| Description | [`k8s.replicaset.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the ReplicaSet. [2] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.replicaset.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the ReplicaSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [3] | `guestbook`; `` |
 
 **[1] `k8s.replicaset.annotation.<key>`:** Examples:
 
@@ -267,7 +282,13 @@ to a running container.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.replicaset.annotation.data` attribute with value `""`.
 
-**[2] `k8s.replicaset.label.<key>`:** Examples:
+**[2] `k8s.replicaset.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[3] `k8s.replicaset.label.<key>`:** Examples:
 
 - A label `app` with value `guestbook` SHOULD be recorded
   as the `k8s.replicaset.label.app` attribute with value `"guestbook"`.
@@ -301,7 +322,8 @@ distributed among the nodes of a cluster.
 | Identity | [`k8s.deployment.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the Deployment. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.deployment.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the Deployment. | `opentelemetry` |
 | Description | [`k8s.deployment.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Deployment, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [1] | `1`; `` |
-| Description | [`k8s.deployment.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Deployment, the `<key>` being the label name, the value being the label value, even if the value is empty. [2] | `guestbook`; `` |
+| Description | [`k8s.deployment.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the Deployment. [2] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.deployment.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Deployment, the `<key>` being the label name, the value being the label value, even if the value is empty. [3] | `guestbook`; `` |
 
 **[1] `k8s.deployment.annotation.<key>`:** Examples:
 
@@ -310,7 +332,13 @@ distributed among the nodes of a cluster.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.deployment.annotation.data` attribute with value `""`.
 
-**[2] `k8s.deployment.label.<key>`:** Examples:
+**[2] `k8s.deployment.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[3] `k8s.deployment.label.<key>`:** Examples:
 
 - A label `app` with value `guestbook` SHOULD be recorded
   as the `k8s.deployment.label.app` attribute with value `"guestbook"`.
@@ -343,7 +371,8 @@ about the ordering and uniqueness of these Pods.
 | Identity | [`k8s.statefulset.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the StatefulSet. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.statefulset.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the StatefulSet. | `opentelemetry` |
 | Description | [`k8s.statefulset.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the StatefulSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [1] | `1`; `` |
-| Description | [`k8s.statefulset.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the StatefulSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [2] | `guestbook`; `` |
+| Description | [`k8s.statefulset.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the StatefulSet. [2] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.statefulset.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the StatefulSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [3] | `guestbook`; `` |
 
 **[1] `k8s.statefulset.annotation.<key>`:** Examples:
 
@@ -352,7 +381,13 @@ about the ordering and uniqueness of these Pods.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.statefulset.annotation.data` attribute with value `""`.
 
-**[2] `k8s.statefulset.label.<key>`:** Examples:
+**[2] `k8s.statefulset.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[3] `k8s.statefulset.label.<key>`:** Examples:
 
 - A label `app` with value `guestbook` SHOULD be recorded
   as the `k8s.statefulset.label.app` attribute with value `"guestbook"`.
@@ -384,7 +419,8 @@ A DaemonSet ensures that all (or some) Nodes run a copy of a Pod.
 | Identity | [`k8s.daemonset.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the DaemonSet. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.daemonset.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the DaemonSet. | `opentelemetry` |
 | Description | [`k8s.daemonset.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the DaemonSet, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [1] | `1`; `` |
-| Description | [`k8s.daemonset.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the DaemonSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [2] | `guestbook`; `` |
+| Description | [`k8s.daemonset.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the DaemonSet. [2] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.daemonset.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the DaemonSet, the `<key>` being the label name, the value being the label value, even if the value is empty. [3] | `guestbook`; `` |
 
 **[1] `k8s.daemonset.annotation.<key>`:** Examples:
 
@@ -393,7 +429,13 @@ A DaemonSet ensures that all (or some) Nodes run a copy of a Pod.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.daemonset.annotation.data` attribute with value `""`.
 
-**[2] `k8s.daemonset.label.<key>`:** Examples:
+**[2] `k8s.daemonset.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[3] `k8s.daemonset.label.<key>`:** Examples:
 
 - A label `app` with value `guestbook` SHOULD be recorded
   as the `k8s.daemonset.label.app` attribute with value `"guestbook"`.
@@ -426,7 +468,8 @@ successfully terminate.
 | Identity | [`k8s.job.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the Job. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.job.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the Job. | `opentelemetry` |
 | Description | [`k8s.job.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The annotation placed on the Job, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [1] | `1`; `` |
-| Description | [`k8s.job.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Job, the `<key>` being the label name, the value being the label value, even if the value is empty. [2] | `ci`; `` |
+| Description | [`k8s.job.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the Job. [2] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.job.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the Job, the `<key>` being the label name, the value being the label value, even if the value is empty. [3] | `ci`; `` |
 
 **[1] `k8s.job.annotation.<key>`:** Examples:
 
@@ -435,7 +478,13 @@ successfully terminate.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.job.annotation.data` attribute with value `""`.
 
-**[2] `k8s.job.label.<key>`:** Examples:
+**[2] `k8s.job.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[3] `k8s.job.label.<key>`:** Examples:
 
 - A label `jobtype` with value `ci` SHOULD be recorded
   as the `k8s.job.label.jobtype` attribute with value `"ci"`.
@@ -467,7 +516,8 @@ A CronJob creates Jobs on a repeating schedule.
 | Identity | [`k8s.cronjob.uid`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The UID of the CronJob. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | Description | [`k8s.cronjob.name`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Recommended` | string | The name of the CronJob. | `opentelemetry` |
 | Description | [`k8s.cronjob.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The cronjob annotation placed on the CronJob, the `<key>` being the annotation name, the value being the annotation value. [1] | `4`; `` |
-| Description | [`k8s.cronjob.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the CronJob, the `<key>` being the label name, the value being the label value. [2] | `weekly`; `` |
+| Description | [`k8s.cronjob.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the CronJob. [2] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.cronjob.label.<key>`](/docs/registry/attributes/k8s.md) | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | `Opt-In` | string | The label placed on the CronJob, the `<key>` being the label name, the value being the label value. [3] | `weekly`; `` |
 
 **[1] `k8s.cronjob.annotation.<key>`:** Examples:
 
@@ -476,7 +526,13 @@ A CronJob creates Jobs on a repeating schedule.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.cronjob.annotation.data` attribute with value `""`.
 
-**[2] `k8s.cronjob.label.<key>`:** Examples:
+**[2] `k8s.cronjob.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[3] `k8s.cronjob.label.<key>`:** Examples:
 
 - A label `type` with value `weekly` SHOULD be recorded as the
   `k8s.cronjob.label.type` attribute with value `"weekly"`.
@@ -595,8 +651,9 @@ provisioned by an administrator or dynamically provisioned using StorageClasses.
 | Description | [`k8s.persistentvolume.name`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the PersistentVolume. | `pv-data-01` |
 | Description | [`k8s.storageclass.name`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of K8s [StorageClass](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#storageclass-v1-storage-k8s-io) object. | `gold.storageclass.storage.k8s.io` |
 | Description | [`k8s.persistentvolume.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The annotation placed on the PersistentVolume, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [1] | `kubernetes.io/aws-ebs`; `` |
-| Description | [`k8s.persistentvolume.label.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The label placed on the PersistentVolume, the `<key>` being the label name, the value being the label value, even if the value is empty. [2] | `ssd`; `` |
-| Description | [`k8s.persistentvolume.reclaim_policy`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The reclaim policy of the PersistentVolume. [3] | `Delete`; `Retain`; `Recycle` |
+| Description | [`k8s.persistentvolume.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the PersistentVolume. [2] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.persistentvolume.label.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The label placed on the PersistentVolume, the `<key>` being the label name, the value being the label value, even if the value is empty. [3] | `ssd`; `` |
+| Description | [`k8s.persistentvolume.reclaim_policy`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The reclaim policy of the PersistentVolume. [4] | `Delete`; `Retain`; `Recycle` |
 
 **[1] `k8s.persistentvolume.annotation.<key>`:** Examples:
 
@@ -605,14 +662,20 @@ provisioned by an administrator or dynamically provisioned using StorageClasses.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.persistentvolume.annotation.data` attribute with value `""`.
 
-**[2] `k8s.persistentvolume.label.<key>`:** Examples:
+**[2] `k8s.persistentvolume.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[3] `k8s.persistentvolume.label.<key>`:** Examples:
 
 - A label `type` with value `ssd` SHOULD be recorded as
   the `k8s.persistentvolume.label.type` attribute with value `"ssd"`.
 - A label `data` with empty string value SHOULD be recorded as
   the `k8s.persistentvolume.label.data` attribute with value `""`.
 
-**[3] `k8s.persistentvolume.reclaim_policy`:** This attribute aligns with the `persistentVolumeReclaimPolicy` field of the
+**[4] `k8s.persistentvolume.reclaim_policy`:** This attribute aligns with the `persistentVolumeReclaimPolicy` field of the
 [K8s PersistentVolumeSpec](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/#PersistentVolumeSpec).
 
 ---
@@ -652,7 +715,8 @@ to a Pod in that Pods consume node resources and PVCs consume PV resources.
 | Description | [`k8s.persistentvolumeclaim.name`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of the PersistentVolumeClaim. | `pvc-data-01` |
 | Description | [`k8s.storageclass.name`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Recommended` | string | The name of K8s [StorageClass](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#storageclass-v1-storage-k8s-io) object. | `gold.storageclass.storage.k8s.io` |
 | Description | [`k8s.persistentvolumeclaim.annotation.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The annotation placed on the PersistentVolumeClaim, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty. [1] | `kubernetes.io/aws-ebs`; `` |
-| Description | [`k8s.persistentvolumeclaim.label.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The label placed on the PersistentVolumeClaim, the `<key>` being the label name, the value being the label value, even if the value is empty. [2] | `my-app`; `` |
+| Description | [`k8s.persistentvolumeclaim.creation_time`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The creation timestamp of the PersistentVolumeClaim. [2] | `2025-12-04T08:41:03Z` |
+| Description | [`k8s.persistentvolumeclaim.label.<key>`](/docs/registry/attributes/k8s.md) | ![Development](https://img.shields.io/badge/-development-blue) | `Opt-In` | string | The label placed on the PersistentVolumeClaim, the `<key>` being the label name, the value being the label value, even if the value is empty. [3] | `my-app`; `` |
 
 **[1] `k8s.persistentvolumeclaim.annotation.<key>`:** Examples:
 
@@ -661,7 +725,13 @@ to a Pod in that Pods consume node resources and PVCs consume PV resources.
 - An annotation `data` with empty string value SHOULD be recorded as
   the `k8s.persistentvolumeclaim.annotation.data` attribute with value `""`.
 
-**[2] `k8s.persistentvolumeclaim.label.<key>`:** Examples:
+**[2] `k8s.persistentvolumeclaim.creation_time`:** Date and time at which the object was created in the K8s API server.
+
+This attribute aligns with the `creationTimestamp` field of the
+[K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+in ISO 8601 (RFC 3339 compatible) format.
+
+**[3] `k8s.persistentvolumeclaim.label.<key>`:** Examples:
 
 - A label `app` with value `my-app` SHOULD be recorded as
   the `k8s.persistentvolumeclaim.label.app` attribute with value `"my-app"`.

--- a/model/k8s/entities.yaml
+++ b/model/k8s/entities.yaml
@@ -28,6 +28,9 @@ groups:
       - ref: k8s.node.annotation
         role: descriptive
         requirement_level: opt_in
+      - ref: k8s.node.creation_time
+        role: descriptive
+        requirement_level: opt_in
 
   - id: entity.k8s.node.system_container
     type: entity
@@ -52,6 +55,9 @@ groups:
         role: descriptive
         requirement_level: opt_in
       - ref: k8s.namespace.annotation
+        role: descriptive
+        requirement_level: opt_in
+      - ref: k8s.namespace.creation_time
         role: descriptive
         requirement_level: opt_in
 
@@ -113,6 +119,9 @@ groups:
       - ref: k8s.replicaset.annotation
         role: descriptive
         requirement_level: opt_in
+      - ref: k8s.replicaset.creation_time
+        role: descriptive
+        requirement_level: opt_in
 
   - id: entity.k8s.deployment
     type: entity
@@ -129,6 +138,9 @@ groups:
         role: descriptive
         requirement_level: opt_in
       - ref: k8s.deployment.annotation
+        role: descriptive
+        requirement_level: opt_in
+      - ref: k8s.deployment.creation_time
         role: descriptive
         requirement_level: opt_in
 
@@ -149,6 +161,9 @@ groups:
       - ref: k8s.statefulset.annotation
         role: descriptive
         requirement_level: opt_in
+      - ref: k8s.statefulset.creation_time
+        role: descriptive
+        requirement_level: opt_in
 
   - id: entity.k8s.daemonset
     type: entity
@@ -165,6 +180,9 @@ groups:
         role: descriptive
         requirement_level: opt_in
       - ref: k8s.daemonset.annotation
+        role: descriptive
+        requirement_level: opt_in
+      - ref: k8s.daemonset.creation_time
         role: descriptive
         requirement_level: opt_in
 
@@ -185,6 +203,9 @@ groups:
       - ref: k8s.job.annotation
         role: descriptive
         requirement_level: opt_in
+      - ref: k8s.job.creation_time
+        role: descriptive
+        requirement_level: opt_in
 
   - id: entity.k8s.cronjob
     type: entity
@@ -201,6 +222,9 @@ groups:
         role: descriptive
         requirement_level: opt_in
       - ref: k8s.cronjob.annotation
+        role: descriptive
+        requirement_level: opt_in
+      - ref: k8s.cronjob.creation_time
         role: descriptive
         requirement_level: opt_in
 
@@ -302,6 +326,9 @@ groups:
       - ref: k8s.persistentvolume.annotation
         role: descriptive
         requirement_level: opt_in
+      - ref: k8s.persistentvolume.creation_time
+        role: descriptive
+        requirement_level: opt_in
 
   - id: entity.k8s.persistentvolumeclaim
     type: entity
@@ -322,5 +349,8 @@ groups:
         role: descriptive
         requirement_level: opt_in
       - ref: k8s.persistentvolumeclaim.annotation
+        role: descriptive
+        requirement_level: opt_in
+      - ref: k8s.persistentvolumeclaim.creation_time
         role: descriptive
         requirement_level: opt_in

--- a/model/k8s/registry.yaml
+++ b/model/k8s/registry.yaml
@@ -53,6 +53,18 @@ groups:
         brief: >
           The UID of the Node.
         examples: ['1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2']
+      - id: k8s.node.creation_time
+        type: string
+        stability: development
+        brief: >
+          The creation timestamp of the Node.
+        examples: ['2025-12-04T08:41:03Z']
+        note: |
+          Date and time at which the object was created in the K8s API server.
+
+          This attribute aligns with the `creationTimestamp` field of the
+          [K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+          in ISO 8601 (RFC 3339 compatible) format.
       - id: k8s.node.label
         type: template[string]
         stability: stable
@@ -91,6 +103,18 @@ groups:
         brief: >
           The name of the namespace that the pod is running in.
         examples: ['default']
+      - id: k8s.namespace.creation_time
+        type: string
+        stability: development
+        brief: >
+          The creation timestamp of the Namespace.
+        examples: ['2025-12-04T08:41:03Z']
+        note: |
+          Date and time at which the object was created in the K8s API server.
+
+          This attribute aligns with the `creationTimestamp` field of the
+          [K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+          in ISO 8601 (RFC 3339 compatible) format.
       - id: k8s.namespace.label
         type: template[string]
         stability: stable
@@ -247,6 +271,18 @@ groups:
         brief: >
           The name of the ReplicaSet.
         examples: ['opentelemetry']
+      - id: k8s.replicaset.creation_time
+        type: string
+        stability: development
+        brief: >
+          The creation timestamp of the ReplicaSet.
+        examples: ['2025-12-04T08:41:03Z']
+        note: |
+          Date and time at which the object was created in the K8s API server.
+
+          This attribute aligns with the `creationTimestamp` field of the
+          [K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+          in ISO 8601 (RFC 3339 compatible) format.
       - id: k8s.replicaset.label
         type: template[string]
         stability: stable
@@ -311,6 +347,18 @@ groups:
         brief: >
           The name of the Deployment.
         examples: ['opentelemetry']
+      - id: k8s.deployment.creation_time
+        type: string
+        stability: development
+        brief: >
+          The creation timestamp of the Deployment.
+        examples: ['2025-12-04T08:41:03Z']
+        note: |
+          Date and time at which the object was created in the K8s API server.
+
+          This attribute aligns with the `creationTimestamp` field of the
+          [K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+          in ISO 8601 (RFC 3339 compatible) format.
       - id: k8s.deployment.label
         type: template[string]
         stability: stable
@@ -351,6 +399,18 @@ groups:
         brief: >
           The name of the StatefulSet.
         examples: ['opentelemetry']
+      - id: k8s.statefulset.creation_time
+        type: string
+        stability: development
+        brief: >
+          The creation timestamp of the StatefulSet.
+        examples: ['2025-12-04T08:41:03Z']
+        note: |
+          Date and time at which the object was created in the K8s API server.
+
+          This attribute aligns with the `creationTimestamp` field of the
+          [K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+          in ISO 8601 (RFC 3339 compatible) format.
       - id: k8s.statefulset.label
         type: template[string]
         stability: stable
@@ -391,6 +451,18 @@ groups:
         brief: >
           The name of the DaemonSet.
         examples: ['opentelemetry']
+      - id: k8s.daemonset.creation_time
+        type: string
+        stability: development
+        brief: >
+          The creation timestamp of the DaemonSet.
+        examples: ['2025-12-04T08:41:03Z']
+        note: |
+          Date and time at which the object was created in the K8s API server.
+
+          This attribute aligns with the `creationTimestamp` field of the
+          [K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+          in ISO 8601 (RFC 3339 compatible) format.
       - id: k8s.daemonset.label
         type: template[string]
         stability: stable
@@ -475,6 +547,18 @@ groups:
         brief: >
           The name of the Job.
         examples: ['opentelemetry']
+      - id: k8s.job.creation_time
+        type: string
+        stability: development
+        brief: >
+          The creation timestamp of the Job.
+        examples: ['2025-12-04T08:41:03Z']
+        note: |
+          Date and time at which the object was created in the K8s API server.
+
+          This attribute aligns with the `creationTimestamp` field of the
+          [K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+          in ISO 8601 (RFC 3339 compatible) format.
       - id: k8s.job.label
         type: template[string]
         stability: stable
@@ -515,6 +599,18 @@ groups:
         brief: >
           The name of the CronJob.
         examples: ['opentelemetry']
+      - id: k8s.cronjob.creation_time
+        type: string
+        stability: development
+        brief: >
+          The creation timestamp of the CronJob.
+        examples: ['2025-12-04T08:41:03Z']
+        note: |
+          Date and time at which the object was created in the K8s API server.
+
+          This attribute aligns with the `creationTimestamp` field of the
+          [K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+          in ISO 8601 (RFC 3339 compatible) format.
       - id: k8s.cronjob.label
         type: template[string]
         stability: stable
@@ -998,6 +1094,18 @@ groups:
         brief: >
           The name of the PersistentVolume.
         examples: ['pv-data-01']
+      - id: k8s.persistentvolume.creation_time
+        type: string
+        stability: development
+        brief: >
+          The creation timestamp of the PersistentVolume.
+        examples: ['2025-12-04T08:41:03Z']
+        note: |
+          Date and time at which the object was created in the K8s API server.
+
+          This attribute aligns with the `creationTimestamp` field of the
+          [K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+          in ISO 8601 (RFC 3339 compatible) format.
       - id: k8s.persistentvolume.label
         type: template[string]
         stability: development
@@ -1090,6 +1198,18 @@ groups:
         brief: >
           The name of the PersistentVolumeClaim.
         examples: ['pvc-data-01']
+      - id: k8s.persistentvolumeclaim.creation_time
+        type: string
+        stability: development
+        brief: >
+          The creation timestamp of the PersistentVolumeClaim.
+        examples: ['2025-12-04T08:41:03Z']
+        note: |
+          Date and time at which the object was created in the K8s API server.
+
+          This attribute aligns with the `creationTimestamp` field of the
+          [K8s ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta),
+          in ISO 8601 (RFC 3339 compatible) format.
       - id: k8s.persistentvolumeclaim.label
         type: template[string]
         stability: development


### PR DESCRIPTION
Fixes #3958

## Changes

- Adds a new attribute `k8s.<entity>.creation_time` that carries the object's `metadata.creationTimestamp`, so consumers can tell when a Kubernetes object was created and derive its age.
- Covers eleven entities: `k8s.node`, `k8s.namespace`, `k8s.pod`, `k8s.deployment`, `k8s.statefulset`, `k8s.daemonset`, `k8s.replicaset`, `k8s.job`, `k8s.cronjob`, `k8s.persistentvolume` and `k8s.persistentvolumeclaim`.
- Each attribute is a string holding an RFC 3339 timestamp, defined with `development` stability, and referenced from its entity with `role: descriptive` and `requirement_level: opt_in`. This follows what `k8s.pod.start_time` already does on `entity.k8s.pod`, and matches the opt-in requirement agreed in #3958.
- `k8s.pod.creation_time` was added after review feedback. It is a separate value from the stable `k8s.pod.start_time` and can deviate significantly from it, so the note on the attribute spells out the difference.
- Regenerated docs and added a changelog entry.

## Why

- There is currently no way to express when a Kubernetes object was created. `k8s.pod.start_time` is bound to `PodStatus.startTime`, which is the time the Kubelet acknowledged the Pod, and it exists only for Pods.
- The `k8s.pod.uptime` and `k8s.node.uptime` metrics measure how long something has been running and reset on sandbox recreation or node reboot, so they do not answer the same question and do not cover workload objects.
- Today users run kube-state-metrics alongside the collector purely for `kube_<entity>_created`, or they guess the age from when the data first showed up in their backend, which is not a creation time.

## Prototype

- Intended consumer: the `k8scluster` receiver in the Collector, tracked in open-telemetry/opentelemetry-collector-contrib#49548. The receiver already holds these objects in its informers, so it can populate the attribute with no extra API calls, and the value never changes for the lifetime of the object.
- Existing instrumentation with the same data: kube-state-metrics exposes `kube_<entity>_created` for these objects.

## Review notes

- Discussed at the K8s Semantic Conventions SIG on 2026-09-15 and considered a good addition.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [ ] no AI used
  * [x] AI-assisted
  * [ ] bulk AI-generated
* [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.
