### PR TITLE
chore: Fix js approvers team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -198,7 +198,7 @@
 /model/oracle-cloud               @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-oracle-cloud-approvers
 
 # JavaScript semantic conventions
-/model/nodejs                     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approver
-/model/v8js                       @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approver
-/docs/runtime/v8js-metrics.md     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approver
-/docs/runtime/nodejs-metrics.md   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approver
+/model/nodejs                     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approvers
+/model/v8js                       @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approvers
+/docs/runtime/v8js-metrics.md     @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approvers
+/docs/runtime/nodejs-metrics.md   @open-telemetry/specs-semconv-approvers @open-telemetry/semconv-js-approvers


### PR DESCRIPTION
## Changes

I noticed that the js approvers team wasn't automatically added as reviewer in this PR https://github.com/open-telemetry/semantic-conventions/pull/4057 even though it should. Looking over the codeowners file, there are several teams there that don't exist or have a wrong name.

I'm sending this to fix the js one which is just wrong but we need to figure out about the others.

> [!IMPORTANT]
> Pull request acceptance is subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [x] no AI used
  * [ ] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
