### PR TITLE
model/profile: add frame.type for CUDA

### DIFF
--- a/.chloggen/profiles-cuda.yaml
+++ b/.chloggen/profiles-cuda.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: profile
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Extend the list of known frame types with a value for CUDA
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: [4079]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/profiles-cuda.yaml
+++ b/.chloggen/profiles-cuda.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: profile
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Extend the list of known frame types with a value for CUDA
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/general/profiles.md
+++ b/docs/general/profiles.md
@@ -42,6 +42,7 @@ They may be used in any Profiles record they apply to.
 | --- | --- | --- |
 | `beam` | [Erlang](https://en.wikipedia.org/wiki/BEAM_(Erlang_virtual_machine)) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cpython` | [Python](https://wikipedia.org/wiki/Python_(programming_language)) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `cuda` | [CUDA](https://de.wikipedia.org/wiki/CUDA) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `dotnet` | [.NET](https://wikipedia.org/wiki/.NET) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `go` | [Go](https://wikipedia.org/wiki/Go_(programming_language)), | ![Development](https://img.shields.io/badge/-development-blue) |
 | `jvm` | [JVM](https://wikipedia.org/wiki/Java_virtual_machine) | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/general/profiles.md
+++ b/docs/general/profiles.md
@@ -42,6 +42,7 @@ They may be used in any Profiles record they apply to.
 | --- | --- | --- |
 | `beam` | [Erlang](https://en.wikipedia.org/wiki/BEAM_(Erlang_virtual_machine)) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cpython` | [Python](https://wikipedia.org/wiki/Python_(programming_language)) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `cuda` | [CUDA](https://wikipedia.org/wiki/CUDA) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `dotnet` | [.NET](https://wikipedia.org/wiki/.NET) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `go` | [Go](https://wikipedia.org/wiki/Go_(programming_language)), | ![Development](https://img.shields.io/badge/-development-blue) |
 | `jvm` | [JVM](https://wikipedia.org/wiki/Java_virtual_machine) | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/registry/attributes/profile.md
+++ b/docs/registry/attributes/profile.md
@@ -21,6 +21,7 @@ Describes the origin of a single frame in a Profile.
 | --- | --- | --- |
 | `beam` | [Erlang](https://en.wikipedia.org/wiki/BEAM_(Erlang_virtual_machine)) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cpython` | [Python](https://wikipedia.org/wiki/Python_(programming_language)) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `cuda` | [CUDA](https://wikipedia.org/wiki/CUDA) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `dotnet` | [.NET](https://wikipedia.org/wiki/.NET) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `go` | [Go](https://wikipedia.org/wiki/Go_(programming_language)), | ![Development](https://img.shields.io/badge/-development-blue) |
 | `jvm` | [JVM](https://wikipedia.org/wiki/Java_virtual_machine) | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/docs/registry/attributes/profile.md
+++ b/docs/registry/attributes/profile.md
@@ -21,6 +21,7 @@ Describes the origin of a single frame in a Profile.
 | --- | --- | --- |
 | `beam` | [Erlang](https://en.wikipedia.org/wiki/BEAM_(Erlang_virtual_machine)) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `cpython` | [Python](https://wikipedia.org/wiki/Python_(programming_language)) | ![Development](https://img.shields.io/badge/-development-blue) |
+| `cuda` | [CUDA](https://de.wikipedia.org/wiki/CUDA) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `dotnet` | [.NET](https://wikipedia.org/wiki/.NET) | ![Development](https://img.shields.io/badge/-development-blue) |
 | `go` | [Go](https://wikipedia.org/wiki/Go_(programming_language)), | ![Development](https://img.shields.io/badge/-development-blue) |
 | `jvm` | [JVM](https://wikipedia.org/wiki/Java_virtual_machine) | ![Development](https://img.shields.io/badge/-development-blue) |

--- a/model/profile/registry.yaml
+++ b/model/profile/registry.yaml
@@ -83,3 +83,8 @@ groups:
                 [LuaJIT](https://en.wikipedia.org/wiki/LuaJIT)
               value: "luajit"
               stability: development
+            - id: cuda
+              brief: >
+                [CUDA](https://de.wikipedia.org/wiki/CUDA)
+              value: "cuda"
+              stability: development

--- a/model/profile/registry.yaml
+++ b/model/profile/registry.yaml
@@ -83,3 +83,8 @@ groups:
                 [LuaJIT](https://en.wikipedia.org/wiki/LuaJIT)
               value: "luajit"
               stability: development
+            - id: cuda
+              brief: >
+                [CUDA](https://wikipedia.org/wiki/CUDA)
+              value: "cuda"
+              stability: development


### PR DESCRIPTION
## Changes

OTel eBPF profiler is about to start unwinding GPU stack. To report these GPU stackframes add this new frame.type.

FYI: @gnurizen @open-telemetry/profiling-approvers

> [!IMPORTANT]
> Pull request acceptance is subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Links to prototypes or existing instrumentations (when adding or changing conventions)
    * https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/1813#issuecomment-5531826592
* [ ] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [x] no AI used
  * [ ] AI-assisted
  * [ ] bulk AI-generated
* [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
