### PR TITLE
Recommend default SDK component name format

### DIFF
--- a/.chloggen/component-name-fallback.yaml
+++ b/.chloggen/component-name-fallback.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: otel
+note: >
+  Recommend `<otel.component.type>/<instance-counter>` as the format for
+  automatically assigned `otel.component.name` values.
+issues: [4077]

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -145,13 +145,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[2] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -211,13 +211,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[2] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -313,13 +313,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[3] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -390,13 +390,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[2] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -494,13 +494,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[3] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -597,13 +597,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[2] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -663,13 +663,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[2] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -765,13 +765,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[3] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -842,13 +842,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[2] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -946,13 +946,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[3] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -1029,13 +1029,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[2] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -1133,13 +1133,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[3] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -1243,13 +1243,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[3] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.
@@ -1355,13 +1355,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[3] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.

--- a/docs/otel/sdk-metrics.md
+++ b/docs/otel/sdk-metrics.md
@@ -142,7 +142,7 @@ This metric is [recommended][MetricRecommended].
 **[1] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -208,7 +208,7 @@ This metric is [recommended][MetricRecommended].
 **[1] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -310,7 +310,7 @@ it's RECOMMENDED to:
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -387,7 +387,7 @@ If the exporter retries failed export attempts, spans remain inflight across all
 **[1] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -491,7 +491,7 @@ it's RECOMMENDED to:
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -594,7 +594,7 @@ This metric is [recommended][MetricRecommended].
 **[1] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -660,7 +660,7 @@ This metric is [recommended][MetricRecommended].
 **[1] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -762,7 +762,7 @@ it's RECOMMENDED to:
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -839,7 +839,7 @@ If the exporter retries failed export attempts, log records remain inflight acro
 **[1] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -943,7 +943,7 @@ it's RECOMMENDED to:
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -1026,7 +1026,7 @@ If the exporter retries failed export attempts, metric data points remain inflig
 **[1] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -1130,7 +1130,7 @@ it's RECOMMENDED to:
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -1240,7 +1240,7 @@ it's RECOMMENDED to:
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
@@ -1352,7 +1352,7 @@ it's RECOMMENDED to:
 **[2] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.

--- a/docs/registry/attributes/otel.md
+++ b/docs/registry/attributes/otel.md
@@ -68,13 +68,13 @@ E.g. implementations MUST NOT use UUIDs as values for this attribute.
 When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
 instance of the given component type is started.
 
 With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
 as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-These values will therefore be reused in the case of an application restart.
+These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
 
 **[2] `otel.component.type`:** If none of the standardized values apply, implementations SHOULD use the language-defined name of the type.
 E.g. for Java the fully qualified classname SHOULD be used in this case.

--- a/docs/registry/attributes/otel.md
+++ b/docs/registry/attributes/otel.md
@@ -65,7 +65,7 @@ Attributes used for OpenTelemetry component self-monitoring
 **[1] `otel.component.name`:** Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
 E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
 Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
 The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.

--- a/model/otel/registry.yaml
+++ b/model/otel/registry.yaml
@@ -200,11 +200,11 @@ groups:
           When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
           Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
-          The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.
-          For example, `<instance-counter>` MAY be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+          The value of `instance-counter` is implementation-defined. Implementations MUST ensure that the resulting `otel.component.name` is unique within the enclosing SDK instance.
+          For example, implementations MAY use a monotonically increasing counter (starting with `0`), which is incremented every time an
           instance of the given component type is started.
 
           With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
           as `otel.component.name`, the second one `batching_span_processor/1` and so on.
-          These values will therefore be reused in the case of an application restart.
+          These values will therefore be reused in the case of an application restart, but a particular value is not required to identify the same logical component after restart.
         examples: ["otlp_grpc_span_exporter/0", "custom-name"]

--- a/model/otel/registry.yaml
+++ b/model/otel/registry.yaml
@@ -197,7 +197,7 @@ groups:
           Implementations SHOULD ensure a low cardinality for this attribute, even across application or SDK restarts.
           E.g. implementations MUST NOT use UUIDs as values for this attribute.
 
-          Implementations MAY achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+          When no application-provided name is configured, implementations SHOULD follow a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
           Hereby `otel.component.type` refers to the corresponding attribute value of the component.
 
           The value of `instance-counter` MAY be automatically assigned by the component and uniqueness within the enclosing SDK instance MUST be guaranteed.


### PR DESCRIPTION
Fixes #4077

Related to open-telemetry/opentelemetry-specification#5298.

## Related changes

Together, these changes define configurable SDK component names, their fallback naming convention, and declarative configuration support.

- open-telemetry/opentelemetry-specification#5300
- open-telemetry/opentelemetry-configuration#737

## Changes

When no application-provided component name is configured, recommend `<otel.component.type>/<instance-counter>` as the default format for `otel.component.name`.

This strengthens the existing fallback guidance from `MAY` to `SHOULD`. Assignment of the instance counter remains implementation-defined, and the existing uniqueness and cardinality requirements are unchanged.

The recommended format reflects existing counter-based implementations in [.NET](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Logs/Processor/BatchLogRecordExportProcessor.cs), [Go](https://github.com/open-telemetry/opentelemetry-go/blob/main/sdk/log/internal/observ/batch_log_processor.go), [Java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/ComponentId.java), and [Python](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/_processor_metrics.py). Automatically assigned values are not required to identify the same logical component across restarts.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Links to prototypes or existing instrumentations (when adding or changing conventions)
* [x] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [ ] no AI used
  * [x] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.
