### PR TITLE
Warn that the span status description may contain sensitive information

### DIFF
--- a/.chloggen/span-status-description-sensitive.yaml
+++ b/.chloggen/span-status-description-sensitive.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: exceptions
+note: Indicate that span status description may contain sensitive information when it is set to the exception message.
+issues: [2967]

--- a/docs/general/recording-errors.md
+++ b/docs/general/recording-errors.md
@@ -59,10 +59,11 @@ When the operation ends with an error, instrumentation:
 
 > [!WARNING]
 >
-> Like [`exception.message`](/docs/registry/attributes/exception.md#exception-message),
-> the span status description may contain sensitive information. Exception messages
-> frequently include the input value that caused the failure. Additional processing
-> in the telemetry pipeline may be necessary to remove sensitive information.
+> The span status description may contain sensitive information, in particular when it is
+> set to the exception message as described above. Like
+> [`exception.message`](/docs/registry/attributes/exception.md#exception-message), it
+> frequently includes the input value that caused the failure. Additional processing in the
+> telemetry pipeline may be necessary to remove sensitive information.
 
 Refer to the [recording exceptions](#recording-exceptions) on capturing exception
 details.

--- a/docs/general/recording-errors.md
+++ b/docs/general/recording-errors.md
@@ -57,6 +57,13 @@ When the operation ends with an error, instrumentation:
   When the operation fails with an exception, the span status description SHOULD be set to
   the exception message.
 
+> [!WARNING]
+>
+> Like [`exception.message`](/docs/registry/attributes/exception.md#exception-message),
+> the span status description may contain sensitive information. Exception messages
+> frequently include the input value that caused the failure. Additional processing
+> in the telemetry pipeline may be necessary to remove sensitive information.
+
 Refer to the [recording exceptions](#recording-exceptions) on capturing exception
 details.
 


### PR DESCRIPTION
Refs #2967

## Changes

`docs/general/recording-errors.md` currently asks for two things that cannot both hold.

Lines 51-53:

> SHOULD set the span status description when it has additional information
> about the error which is not expected to contain sensitive details [...]

Lines 57-58:

> When the operation fails with an exception, the span status description SHOULD be set to
> the exception message.

And `model/exceptions/registry.yaml:32` says of `exception.message`:

> This attribute may contain sensitive information.

This adds the warning to lines 60-65, in the "Recording errors on spans" section. The wording and the
callout style copy `model/exceptions/registry.yaml:30-32`. #3310 warned about `exception.message`
alone and left the span status description out, which is why #2967 is still open.

No requirement level moves. Nothing new becomes normative.

`.chloggen/span-status-description-sensitive.yaml` uses `component: exceptions`, the folder name
under `model/`, per CONTRIBUTING step 3.

`Refs`, not `Fixes`: #2967 covers three subjects and this is one.

The commit carries an `Assisted-by: Claude Opus 5` trailer.

> [!IMPORTANT]
> Pull request acceptance is subject to the triage process as described in [Issue and PR Triage Management](https://github.com/open-telemetry/semantic-conventions/blob/main/issue-management.md).
> PRs that do not follow the guidance above may be automatically rejected and closed.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Links to prototypes or existing instrumentations (when adding or changing conventions)
  Not applicable: no convention is added or changed. The change adds a non-normative warning
  to guidance, and no requirement level moves.
* [x] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [ ] no AI used
  * [x] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]
[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.

