### PR TITLE
Log a warning when OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN is ignored

### DIFF
--- a/.chloggen/exception-signal-opt-in-warning.yaml
+++ b/.chloggen/exception-signal-opt-in-warning.yaml
@@ -1,0 +1,13 @@
+change_type: enhancement
+
+component: exceptions
+
+note: >
+  Instrumentations should log a warning through the SDK logging facilities when the
+  `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN` environment variable is ignored.
+
+issues: [4095]
+
+subtext: |
+  Without the warning, an instrumentation that falls back to emitting exceptions as span
+  events gives users no indication that their opt-in did not take effect.

--- a/docs/exceptions/exceptions-logs.md
+++ b/docs/exceptions/exceptions-logs.md
@@ -39,7 +39,7 @@ emitted through the [Logger API](https://opentelemetry.io/docs/specs/otel/logs/a
 >     emitting exceptions as span events (existing behavior) and the SDK MUST log
 >     a warning using the SDK internal logger with the message that "The
 >     `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN` environment variable is ignored
->     because no logging provider is configured."
+>     because no logger provider is configured."
 > * SHOULD maintain (security patching at a minimum) their existing major version
 >   for at least six months after it starts emitting both sets of conventions.
 > * MAY drop the environment variable in their next major version and emit exceptions

--- a/docs/exceptions/exceptions-logs.md
+++ b/docs/exceptions/exceptions-logs.md
@@ -36,7 +36,10 @@ emitted through the [Logger API](https://opentelemetry.io/docs/specs/otel/logs/a
 >   * `logs` - emit exceptions as logs only.
 >   * `logs/dup` - emit both span events and logs, allowing for a phased rollout.
 >   * The default behavior (in the absence of one of these values) is to continue
->     emitting exceptions as span events (existing behavior).
+>     emitting exceptions as span events (existing behavior) and the SDK MUST log
+>     a warning using the SDK internal logger with the message that "The
+>     `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN` environment variable is ignored
+>     because no logging provider is configured."
 > * SHOULD maintain (security patching at a minimum) their existing major version
 >   for at least six months after it starts emitting both sets of conventions.
 > * MAY drop the environment variable in their next major version and emit exceptions


### PR DESCRIPTION
Fixes #4095

## Changes

Follow-up the maintainer call on Sept 8th, 2026, regarding the discussion around `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN`.

As written, an instrumentation that falls back to the default behavior of emitting span events for exceptions rather than log records, gives the user no feedback about it: exceptions keep being emitted as span events.

This PR adds a requirement that instrumentations log a warning through the SDK logging
facilities in that case, with the message:

> The `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN` environment variable is ignored because no
> logging provider is configured.

Prototype for the Java agent [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/20171).

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Links to prototypes or existing instrumentations (when adding or changing conventions): https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/20171
* [x] Disclose AI usage, see [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md):
  * [X] no AI used
  * [ ] AI-assisted
  * [ ] bulk AI-generated
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.
